### PR TITLE
Pure-Julia convolutions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+ImageFiltering

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -4,6 +4,7 @@ export σ, relu, leakyrelu, elu, swish, softmax
 
 include("activation.jl")
 include("softmax.jl")
+include("convolution.jl")
 include("adapt.jl")
 
 end # module

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -1,0 +1,11 @@
+using ImageFiltering
+
+function conv(x, w)
+  @assert(size(x, ndims(w)-1) == size(w, ndims(w)-1))
+  filters = size(w, ndims(w))
+  cs = map(1:filters) do f
+    w′ = reflect(centered(slicedim(w, ndims(w), f)))
+    imfilter(x, w′, Inner()).parent
+  end
+  cat(ndims(w)-1, cs...)
+end


### PR DESCRIPTION
Accepts an input `W+ C N` and a kernel `W+ Cin Cout` (similar to Knet, although we don't flip the channel dimension of the kernel).

This is fairly naive – it's very fast for basic convolutions but struggles a bit more when you have multiple channels.