### PR TITLE
Replace old binary artifact with the new one during Pkg.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.dll
 *~
 \#*
+.juliahistory

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,6 +12,6 @@ elseif is_unix()
     run(`c++ -c -fPIC -std=c++11 conv.cpp`)
     run(`c++ -shared -o nnlib.so conv.o`)
     rm("conv.o")
-    mv("nnlib.so", "../deps/nnlib.so")
+    mv("nnlib.so", "../deps/nnlib.so"; remove_destination=true)
   end
 end


### PR DESCRIPTION
Otherwise build fails on Linux when run more than once. 