### PR TITLE
Add `pad` and `stride` passthroughs for conv gradients

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -26,10 +26,10 @@ conv(x::A, w::A; pad = 0, stride = 1) where A<:AbstractArray =
   conv!(similar(x, cdims(w, x, padding = pad, stride = stride)), x, w, pad = pad, stride = stride)
 
 ∇conv_data(dy::A, x::A, w::A; pad = 0, stride = 1) where A<:AbstractArray =
-  ∇conv_data!(zeros(x), dy, x, w)
+  ∇conv_data!(zeros(x), dy, x, w; pad = pad, stride = stride)
 
 ∇conv_filter(dy::A, x::A, w::A; pad = 0, stride = 1) where A<:AbstractArray =
-  ∇conv_filter!(zeros(w), dy, x, w)
+  ∇conv_filter!(zeros(w), dy, x, w; pad = pad, stride = stride)
 
 # N-D dispatch
 

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -1,7 +1,6 @@
 using NNlib: conv, ∇conv_filter, ∇conv_data, ∇maxpool, maxpool
 
 @testset "conv2d" begin
-
     x = reshape(Float64[1:20;], 5, 4, 1, 1)
     w = reshape(Float64[1:4;], 2, 2, 1, 1)
 
@@ -32,6 +31,11 @@ using NNlib: conv, ∇conv_filter, ∇conv_data, ∇maxpool, maxpool
     @test size(∇conv_filter(reshape(rand(4,3), 4, 3, 1, 1), x, w)) == size(w)
     @test size(∇conv_data(reshape(rand(4,3), 4, 3, 1, 1), x, w)) == size(x)
 
+    # Test that stride/pad work backward as well
+    y = conv(x, w; stride=2, pad=1)
+    @test size(y) == (3, 3, 1, 1)
+    @test size(∇conv_filter(y, x, w; stride=2, pad=1)) == size(w)
+    @test size(∇conv_data(y, x, w; stride=2, pad=1)) == size(x)
 end
 
 


### PR DESCRIPTION
This closes https://github.com/FluxML/Flux.jl/issues/188