### PR TITLE
Add maxout

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -3,7 +3,7 @@ module NNlib
 using Requires
 
 export σ, sigmoid, relu, leakyrelu, elu, swish, selu, softplus, softsign, logσ, logsigmoid,
-  softmax, logsoftmax, maxpool, meanpool
+  softmax, logsoftmax, maxpool, meanpool, Maxout
 
 include("numeric.jl")
 include("activation.jl")


### PR DESCRIPTION
Adds a generic form of `maxout`.  ([Link to paper](https://arxiv.org/pdf/1302.4389.pdf)).

It decreases the number of elements in a particular axis of a matrix, by dividing the axis into `n` chunks and comparing the corresponding elements. The maxima are retained. This implementation behaves merely like an activation layer, decreasing the number of elements in an axis by one of its proper divisors.

An alternate implementation of `maxout` may be found at https://github.com/FluxML/Flux.jl/pull/209.