### PR TITLE
Scalar pad and stride for maxpool and meanpool

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -97,30 +97,37 @@ function pdims(dims::Dims{N}, window, padding, stride) where N
   end
 end
 
+expand(::Type{Val{N}}, i::Integer) where N = ntuple(_ -> i, Val{N})
+expand(::Type{Val{N}}, i::NTuple{N, Integer}) where N = i
+
 # Interface
 
 maxpool(x::AbstractArray, k; pad = map(_->0,k), stride = k) =
-  maxpool!(similar(x, pdims(size(x), k, pad, stride)),
-           x, k, pad = pad, stride = stride)
+  maxpool!(similar(x, pdims(size(x), k, expand(Val{length(k)}, pad),
+            expand(Val{length(k)}, stride))), x, k, pad = expand(Val{length(k)}, pad),
+            stride = expand(Val{length(k)}, stride))
 
 maxpool!(y::A, x::A, k; kw...) where A<:AbstractArray =
   maxpool_cpu!(y, x, k; kw...)
 
 ∇maxpool(dy::A, y::A, x::A, k; pad = map(_->0,k), stride = k) where A<:AbstractArray =
-  ∇maxpool!(similar(x), dy, y, x, k, pad = pad, stride = stride)
+  ∇maxpool!(similar(x), dy, y, x, k, pad = expand(Val{length(k)}, pad),
+            stride = expand(Val{length(k)}, stride))
 
 ∇maxpool!(dx::A, dy::A, y::A, x::A, k; kw...) where A<:AbstractArray =
   ∇maxpool_cpu!(dx, dy, y, x, k; kw...)
 
 meanpool(x::AbstractArray, k; pad = map(_->0,k), stride = k) =
-  meanpool!(similar(x, pdims(size(x), k, pad, stride)),
-           x, k, pad = pad, stride = stride)
+  meanpool!(similar(x, pdims(size(x), k, expand(Val{length(k)}, pad),
+            expand(Val{length(k)}, stride))), x, k, pad = expand(Val{length(k)}, pad),
+            stride = expand(Val{length(k)}, stride))
 
 meanpool!(y::A, x::A, k; kw...) where A<:AbstractArray =
   meanpool_cpu!(y, x, k; kw...)
 
 ∇meanpool(dy::A, y::A, x::A, k; pad = map(_->0,k), stride = k) where A<:AbstractArray =
-  ∇meanpool!(similar(x), dy, y, x, k, pad = pad, stride = stride)
+  ∇meanpool!(similar(x), dy, y, x, k, pad = expand(Val{length(k)}, pad),
+            stride = expand(Val{length(k)}, stride))
 
 ∇meanpool!(dx::A, dy::A, y::A, x::A, k; kw...) where A<:AbstractArray =
   ∇meanpool_cpu!(dx, dy, y, x, k; kw...)


### PR DESCRIPTION
Scalar pad and stride as suggested in issue [#235](https://github.com/FluxML/Flux.jl/issues/235) for pooling