### PR TITLE
Fixed softmax for large negative numbers

### DIFF
--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -4,7 +4,7 @@ function softmax!(out::AbstractVecOrMat, xs::AbstractVecOrMat)
   @threads for j = 1:size(xs, 2)
     @inbounds begin
       # out[end, :] .= maximum(xs, 1)
-      out[end, j] = 0
+      out[end, j] = xs[end, j]
       for i = 1:size(xs, 1)
         out[end, j] = max(out[end, j], xs[i, j])
       end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ if Base.find_in_path("CuArrays") ≠ nothing
   include("cubroadcast.jl")
 end
 
+xs = [-100_000, -100_000.]
+@test softmax(xs) ≈ [0.5, 0.5]
+@test logsoftmax(xs) ≈ log.([0.5, 0.5])
+
 xs = rand(5)
 @test softmax(xs) ≈ exp.(xs) ./ sum(exp.(xs))
 @test logsoftmax(xs) ≈ log.(softmax(xs))


### PR DESCRIPTION
In softmax, we first subtract element-wise maximum from the input vector to achieve better numerical stability. However, in the previous implementation it wasn't the maximum but max(0, element-wise-max).

It used to fail for `softmax([-10000, -10000.])` which should be trivial and after subtracting the max recomputed as `softmax([0, 0.])`.

P.s.: Credit should be given to Tomas Pevny for finding the precise line of the bug.