### PR TITLE
Add hard-saturating (clipped) sigmoid and tanh activations

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -2,8 +2,9 @@ module NNlib
 
 using Requires
 
-export σ, sigmoid, relu, leakyrelu, elu, swish, selu, softplus, softsign, logσ, logsigmoid,
-  softmax, logsoftmax, maxpool, meanpool
+export σ, sigmoid, hardσ, hard_sigmoid, hardσ_keras, hard_sigmoid_keras,
+  relu, leakyrelu, elu, swish, selu, softplus, softsign, logσ, logsigmoid,
+  softmax, logsoftmax, maxpool, meanpool, hard_tanh
 
 include("numeric.jl")
 include("activation.jl")

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -39,6 +39,34 @@ end
 
 const logsigmoid = logσ
 
+macro hard_sigmoid(cutoff)
+    local c = eval(cutoff)
+    local m = eval(1/(2*c))
+    return quote
+        x -> ifelse(x ≤ -$c, zero(x/1),
+                    ifelse(x ≥ $c, one(x/1),
+                           x*oftype(x/1, $m) + oftype(x/1, 0.5)))
+    end
+end
+
+"""
+    hardσ(x) = max(min(0.25x + 0.5, 1), 0)
+
+Hard sigmoid activation function the first-order Maclaurin expansion of `σ(x)`,
+clipped at `±2.0`; it hard-saturates its domain.
+"""
+hard_sigmoid = @hard_sigmoid(2.0)
+const hardσ = hard_sigmoid
+
+"""
+    hardσ_keras(x) = max(min(0.2x + 0.5, 1), 0)
+
+Like `hardσ(x)`, but using a different slope and clipped at `±2.5`.
+"""
+hard_sigmoid_keras = @hard_sigmoid(2.5)
+const hardσ_keras = hard_sigmoid_keras
+
+
 """
     relu(x) = max(0, x)
 
@@ -104,3 +132,10 @@ softsign(x) = x / (one(x) + abs(x))
 See [Deep Sparse Rectifier Neural Networks](http://proceedings.mlr.press/v15/glorot11a/glorot11a.pdf).
 """
 softplus(x) = log1p(exp(x))
+
+"""
+    hard_tanh(x) = max(min(x, 1), -1)
+
+First-order Maclaurin expansion of `tanh`, clipped at `±1`.
+"""
+hard_tanh(x) = ifelse(x ≥ 1, one(x/1), ifelse(x ≤ -1, -one(x/1), x/1))

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -39,6 +39,8 @@ end
 @testset "Activation Functions" begin
 
   @test σ(0.0) == 0.5
+  @test hardσ(0.0) == 0.5
+  @test hardσ_keras(0.0) == 0.5
   @test relu(0.0) == 0.0
   @test leakyrelu(0.0) == 0.0
   @test elu(0.0) == 0.0
@@ -46,8 +48,11 @@ end
   @test softplus(0.0) ≈ log(2.0)
   @test softsign(0.0) == 0.0
   @test selu(0.0) == 0.0
+  @test hard_tanh(0.0) == 0.0
 
   @test σ(1.0) == 1.0 / (1.0 + exp(-1.0))
+  @test hardσ(1.0) == 0.75
+  @test hardσ_keras(1.0) == 0.7
   @test relu(1.0) == 1.0
   @test leakyrelu(1.0) == 1.0
   @test elu(1.0) == 1.0
@@ -55,8 +60,11 @@ end
   @test softplus(1.0) ≈ log(exp(1.0) + 1.0)
   @test softsign(1.0) == 0.5
   @test selu(1.0) == 1.0507009873554804934193349852946
+  @test hard_tanh(1.0) == 1.0
 
   @test σ(-1.0) == 1.0 / (1.0 + exp(1.0))
+  @test hardσ(-1.0) == 0.25
+  @test hardσ_keras(-1.0) == 0.3
   @test relu(-1.0) == 0.0
   @test leakyrelu(-1.0) == -0.01
   @test elu(-1.0) == exp(-1.0) - 1.0
@@ -64,6 +72,15 @@ end
   @test softplus(-1.0) ≈ log(exp(-1.0) + 1.0)
   @test softsign(-1.0) == -0.5
   @test selu(-1.0) == 1.0507009873554804934193349852946 * 1.6732632423543772848170429916717 * (exp(-1.0) - 1.0)
+  @test hard_tanh(-1.0) == -1.0
+
+  # clipping
+  @test hardσ(3.0) == 1.0
+  @test hardσ_keras(3.0) == 1.0
+  @test hard_tanh(3.0) == 1.0
+  @test hardσ(-3.0) == 0.0
+  @test hardσ_keras(-3.0) == 0.0
+  @test hard_tanh(-3.0) == -1.0
 
   @testset "Float inference" begin
     test_value_float_precision_preserving.(ACTIVATION_FUNCTIONS)


### PR DESCRIPTION
Added `hard_tanh`, `hardσ = hard_sigmoid`, and `hardσ_keras = hardσ_keras`. These are linearized versions of those functions. The Keras variant of `hardσ`, `hardσ_keras` is just to match `keras.activations.hard_sigmoid`.