### PR TITLE
Reflect mode parameter from NNlib

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -91,14 +91,14 @@ function dcdims(x::NTuple{4,Int}, w::NTuple{4,Int}, pad, stride)
   ((x[1] + 2 * pad[1] - w[1])÷stride[1] + 1,(x[2] + 2 * pad[2] - w[2])÷stride[2] + 1,w[3]*w[4],x[4])
 end
 
-function depthwiseconv(x::A, w::A; pad = 0, stride = 1) where A<:AbstractArray
+function depthwiseconv(x::A, w::A; pad = 0, stride = 1, flipkernel = true) where A<:AbstractArray
   pad_, stride_ = padtuple(x, pad), padtuple(x, stride)
-  depthwiseconv!(similar(x, dcdims(size(x), size(w), pad_, stride_)), x, w, pad = pad_, stride = stride_)
+  depthwiseconv!(similar(x, dcdims(size(x), size(w), pad_, stride_)), x, w, pad = pad_, stride = stride_, flipkernel = flipkernel)
 end
 
 depthwiseconv!(y::AbstractArray{T,4}, x::AbstractArray{T,4}, w::AbstractArray{T,4};
-      pad = 0, stride = 1) where T =
-  depthwiseconv2d!(y, x, w, padding = pad, stride = stride)
+      pad = 0, stride = 1, flipkernel = true) where T =
+  depthwiseconv2d!(y, x, w, padding = pad, stride = stride, flipkernel = flipkernel)
 
 ∇depthwiseconv_data(dy::A, x::A, w::A; pad = 0, stride = 1) where A<:AbstractArray =
   ∇depthwiseconv_data!(zeros(x), dy, x, w; pad = pad, stride = stride)

--- a/src/impl/conv.jl
+++ b/src/impl/conv.jl
@@ -182,7 +182,7 @@ function im2col_dims(w::NTuple{4, Int}, y)
 end
 
 function depthwiseconv2d!(y::AbstractArray{T,4}, x::AbstractArray{T,4}, w::AbstractArray{T,4};
-                  padding = 0, stride = 1, mode = 1, alpha = T(1)) where T
+                  padding = 0, stride = 1, flipkernel = true, alpha = T(1)) where T
     Wx,Hx,Cx,Nx = size(x)
     Ww,Hw,Cm,Cw = size(w) # Cm = Channel Multiplier
     @assert Cx == Cw DimensionMismatch()
@@ -195,7 +195,7 @@ function depthwiseconv2d!(y::AbstractArray{T,4}, x::AbstractArray{T,4}, w::Abstr
     M,N,K,Y = Wy*Hy,Cm,Ww*Hw,Wy*Hy*Cm
     yidx = 1
     @inbounds for i in 1:Nx
-        im2col2d!(dims_w, x, x2, i, p1, p2, s1, s2, mode)
+        im2col2d!(dims_w, x, x2, i, p1, p2, s1, s2, flipkernel)
         @inbounds for j in 1:Cx
             gemm!('N','N',M,N,K,alpha,pointer(x2,(j-1)*M*K+1),pointer(w,(j-1)*K*N+1),T(0),pointer(y,yidx))
             yidx += Y
@@ -205,7 +205,7 @@ function depthwiseconv2d!(y::AbstractArray{T,4}, x::AbstractArray{T,4}, w::Abstr
 end
 
 function depthwiseconv2d_grad_w!(dw::AbstractArray{T,4}, x::AbstractArray{T,4}, w::AbstractArray{T,4}, dy::AbstractArray{T,4};
-        padding=0, stride=1, mode=0, alpha=1) where T
+        padding=0, stride=1, flipkernel = true, alpha=1) where T
     Wx,Hx,Cx,Nx = size(x)
     Ww,Hw,Cm,Cw = size(w) # Cm = Channel Multiplier
     @assert Cx == Cw DimensionMismatch()
@@ -220,7 +220,7 @@ function depthwiseconv2d_grad_w!(dw::AbstractArray{T,4}, x::AbstractArray{T,4}, 
     alpha,beta = T(alpha),T(1)
     dyidx = 1
     @inbounds for i in 1:Nx
-        im2col2d!(dims_w, x, x2, i, p1, p2, s1, s2, mode)
+        im2col2d!(dims_w, x, x2, i, p1, p2, s1, s2, flipkernel)
         dwidx = 1
         @inbounds for j in 1:Cx
             gemm!('T','T',M,N,K,alpha,pointer(x2,(j-1)*M*K+1),pointer(dy,dyidx+(j-1)*K*N),beta,pointer(dw,dwidx))
@@ -232,7 +232,7 @@ function depthwiseconv2d_grad_w!(dw::AbstractArray{T,4}, x::AbstractArray{T,4}, 
 end
 
 function depthwiseconv2d_grad_x!(dx::AbstractArray{T,4}, x::AbstractArray{T,4}, w::AbstractArray{T,4}, dy::AbstractArray{T,4};
-                   padding=0, stride=1, mode=0, alpha=1) where T
+                   padding=0, stride=1, flipkernel = true, alpha=1) where T
     Wx,Hx,Cx,Nx = size(x)
     Ww,Hw,Cm,Cw = size(w) # Cm = Channel Multiplier
     @assert Cx == Cw DimensionMismatch()
@@ -250,7 +250,7 @@ function depthwiseconv2d_grad_x!(dx::AbstractArray{T,4}, x::AbstractArray{T,4}, 
         @inbounds for j in 1:Cx
             gemm!('N','T',M,N,K,alpha,pointer(dy,dyidx+(j-1)*K*M),pointer(w,(j-1)*K*N+1),beta,pointer(x2,(j-1)*M*N+1))        
         end
-        col2im2d!(dims_w,dx,x2,i,p1,p2,s1,s2,mode)
+        col2im2d!(dims_w,dx,x2,i,p1,p2,s1,s2,flipkernel)
         dyidx += Y
     end
     return dx

--- a/src/impl/conv.jl
+++ b/src/impl/conv.jl
@@ -12,7 +12,7 @@ end
 
 function im2col_2d!(img::AbstractArray{T,3}, col::AbstractArray{T,2}, width::Int, height::Int, channels::Int,
   kernel_w::Int, kernel_h::Int, pad_w::Int, pad_h::Int, stride_w::Int, stride_h::Int,
-  dil_w::Int, dil_h::Int, mode::Int) where T
+  dil_w::Int, dil_h::Int, flipkernel::Bool) where T
 
   height_col = div(height + 2pad_h - (kernel_h - 1) * dil_h - 1, stride_h) + 1
   width_col = div(width + 2pad_w - (kernel_w - 1) * dil_w - 1, stride_w) + 1


### PR DESCRIPTION
Added `mode` parameter in the external functions (src/conv.jl), (option to choose cross-correlation or convolution), which were using `mode = 0` by default.
I will create a corresponding PR in Flux too, to adapt to the changes made in this PR.

