### PR TITLE
Faster ReLU support using NNPACK

### DIFF
--- a/src/activation.jl
+++ b/src/activation.jl
@@ -45,26 +45,21 @@ const logsigmoid = logσ
 [Rectified Linear Unit](https://en.wikipedia.org/wiki/Rectifier_(neural_networks))
 activation function.
 """
-relu_(x) = max(zero(x), x)
-
-function relu_(x, out)
+function relu_(x)
          ptp = ccall((:pthreadpool_create, :libnnpack), Ptr{Void}, (Csize_t,), 1)
          input = Cfloat.(x)
-       
+         out = zeros(Cfloat, size(x))
          ccall((:nnp_initialize,"libnnpack"),Void,(),)
          ccall((:nnp_relu_output,"libnnpack"),Void,(Csize_t, Csize_t, Ptr{Cfloat}, Ptr{Cfloat}, Cfloat, Ptr{Void}), Csize_t(size(input, 2)), Csize_t(size(input, 1)), input, out, Cfloat(0), ptp)
        
-         return convert(typeof(x), out)
+         return out
 end
 
 function relu(x)
-  @show length(size(x))
   if (is_linux() || is_mac()) && length(size(x)) > 0
-    out = zeros(Cfloat, size(x))
-    return relu_(x, out)
-  else
     return relu_(x)
   end
+  return max(zero(x), x)
 end
 
 """


### PR DESCRIPTION
Facilitates faster ReLU using [NNPACK](https://github.com/Maratyszcza/NNPACK). This requires the presence of `libnnpack.so`, a shared object file of NNPACK. The shared object file is to be placed manually, but work is in progress to automatically take care of that using [BinaryBuilder](https://github.com/JuliaPackaging/BinaryBuilder.jl).

Currently, two tests are failing when tested locally.
```
return type ForwardDiff.Dual{Void,Float32,1} does not match inferred return type Union{Array{Float32,0}, ForwardDiff.Dual{Void,Float32,1}}
```
at https://github.com/FluxML/NNlib.jl/blob/julia-0.6/test/activation.jl#L30 (which has been removed in the latest `master`)  and 
```
return type Float32 does not match inferred return type Union{Array{Float32,0}, Float32}
```
 at https://github.com/FluxML/NNlib.jl/blob/julia-0.6/test/activation.jl#L7.