### PR TITLE
Softmax

### DIFF
--- a/src/logsoftmax.jl
+++ b/src/logsoftmax.jl
@@ -23,7 +23,7 @@ end
 logsoftmax!(xs) = logsoftmax!(xs, xs)
 logsoftmax(xs) = logsoftmax!(similar(xs), xs)
 
-∇logsoftmax(Δ, xs) = ∇softmax(Δ ./ softmax(xs), xs)
+∇logsoftmax(Δ, xs) = ∇softmax(Δ ./ max.(eps(eltype(xs)),softmax(xs)), xs)
 
 """
     logsoftmax(xs) = log.(exp.(xs) ./ sum(exp.(xs)))

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -29,8 +29,8 @@ softmax!(xs) = softmax!(xs, xs)
 softmax(xs) = softmax!(similar(xs), xs)
 
 function ∇softmax!(out::AbstractVecOrMat, Δ::AbstractVecOrMat, xs::AbstractVecOrMat)
-  s = sum(exp, xs, dims=1)
-  out .= exp.(xs)./s.*(Δ .- sum(Δ .* exp.(xs), dims=1)./s)
+  sf = softmax(xs)
+  out .= sf .* (Δ .- sum(Δ .*sf, dims = 1))
 end
 
 ∇softmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,4 +29,6 @@ xs = Float32[1, 2, 3000.]
 
 xs = Float32[1 2 3; 1000 2000 3000]
 @test logsoftmax(xs) ≈ [-999 -1998 -2997; 0 0 0.]
+@test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
+@test NNlib.∇softmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using NNlib, Test, Flux
+using NNlib, Test
 
 @testset "NNlib" begin
 
@@ -32,11 +32,8 @@ xs = Float32[1 2 3; 1000 2000 3000]
 
 @test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
 @test NNlib.∇softmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
-gradtest(f, xs::AbstractArray...) = Flux.Tracker.gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
-@test gradtest(logsoftmax, xs)
-@test gradtest(softmax, xs)
 
-xs = randn(5, 10)
-@test gradtest(logsoftmax, xs)
-@test gradtest(softmax, xs)
+xs = [-0.238639 0.748142 -0.283194 -0.525461 -1.5348 -0.797842; 0.690384 0.211427 0.254794 -0.213572 -0.314174 -0.372663; -1.14637 -0.577988 0.718952 0.91972 -0.620773 0.929977]
+@test isapprox(NNlib.∇logsoftmax(ones(size(xs)), xs), [0.237703 -0.621474 0.448193 0.546047 0.564185 0.632273; -0.930163 0.0519798 0.0549979 0.3799 -0.477112 0.437428; 0.69246 0.569494 -0.503191 -0.925947 -0.0870738 -1.0697]; rtol = 1e-6)
+@test isapprox(NNlib.∇softmax(ones(size(xs)), xs), zeros(size(xs)); atol = 1e-6)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using NNlib, Test
+using NNlib, Test, Flux
 
 @testset "NNlib" begin
 
@@ -29,6 +29,14 @@ xs = Float32[1, 2, 3000.]
 
 xs = Float32[1 2 3; 1000 2000 3000]
 @test logsoftmax(xs) ≈ [-999 -1998 -2997; 0 0 0.]
+
 @test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
 @test NNlib.∇softmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
+gradtest(f, xs::AbstractArray...) = Flux.Tracker.gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
+@test gradtest(logsoftmax, xs)
+@test gradtest(softmax, xs)
+
+xs = randn(5, 10)
+@test gradtest(logsoftmax, xs)
+@test gradtest(softmax, xs)
 end


### PR DESCRIPTION
This is a fix to an issue #68 (Softmax and crossentropy are prone to produce NaNs). I have added tests that the gradient does not produce any NaNs). I have also add more test of gradients of these functions to `runtests.jl` and also a check that gradients of these function do not overflows.