### PR TITLE
RFC: Loosen the signature for conv

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -24,7 +24,8 @@ padtuple(x::Tuple,p::Integer) = map(_->p, head(head(x)))
 padtuple(x::Tuple,p::Tuple) = p
 padtuple(x::AbstractArray,p) = padtuple(size(x),p)
 
-function conv(x::A, w::A; pad = 0, stride = 1, dilation = 1) where A<:AbstractArray
+function conv(x::AbstractArray{T,N}, w::AbstractArray{T,N};
+              pad = 0, stride = 1, dilation = 1) where {T, N}
   pad_, stride_ = padtuple(x, pad), padtuple(x, stride)
   conv!(similar(x, cdims(size(x), dilation_dims(w, dilation), pad_, stride_)),
         x, w, pad = pad_, stride = stride_, dilation = dilation)


### PR DESCRIPTION
So it accepts AbstractArrays of the same eltype, ndims, but possibly different AbstractArray types