### PR TITLE
Fix typo in plane size calculation

### DIFF
--- a/src/impl/conv.jl
+++ b/src/impl/conv.jl
@@ -342,7 +342,7 @@ function conv2d!(y::AbstractArray{T,4}, x::AbstractArray{T,4}, w::AbstractArray{
     Ww, Hw = kernel_size(cdims)
     Wy, Hy = output_size(cdims)
     Cx = img_channels(cdims)
-    M, N, K, Y = Wy*Hy, size(y,4), Ww*Hw*Cx, Wy*Hy*size(y, 4)
+    M, N, K, Y = Wy*Hy, size(y,3), prod(size(w)[1:3]), prod(size(y)[1:3])
 
     x2 = similar(x, im2col_dims(w, y))
     @inbounds for n in 1:size(x,4)


### PR DESCRIPTION
This should fix https://github.com/FluxML/NNlib.jl/pull/92#issuecomment-461834322

I have a much more thorough testing suite I'm working on that should help with this (and give us much more confidence when adding new accelerations such as NNPACK) that is based upon just writing the simple, slow, direct convolution in Julia, and then essentially fuzzing every parameter combination and comparing the outputs.