### PR TITLE
Bump version.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+version = "0.6"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
Since we'll be switching to Project.toml-based versioning soon, which I'm currently experimenting with for CI reasons, let's bump the version here to communicate the API breakage caused by https://github.com/FluxML/NNlib.jl/pull/94.