### PR TITLE
Improve numerical stability of logsoftmax gradient

### DIFF
--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -81,5 +81,5 @@ function logsoftmax!(out::AbstractVecOrMat, xs::AbstractVecOrMat)
     end
     return out
 end
-∇logsoftmax(Δ, xs) = ∇softmax(Δ ./ max.(eps(eltype(xs)),softmax(xs)), xs)
+∇logsoftmax(Δ, xs) = Δ - sum(Δ, dims=1) .* softmax(xs)
 ∇logsoftmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -100,7 +100,7 @@ end
         xs = Float32[1 2 3; 1000 2000 3000]
         @test logsoftmax(xs) ≈ [-999 -1998 -2997; 0 0 0.]
 
-        @test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
+        @test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ Float32[1 1 1; -1 -1 -1] 
         @test NNlib.∇softmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
 
         # These values precalculated using PyTorch's nn.LogSoftmax


### PR DESCRIPTION
Fixes Flux.jl issue [#744](https://github.com/FluxML/Flux.jl/issues/744#issue-435126750). `Logitcrossentropy` uses `logsoftmax` which appears to underflow for large inputs.

This issue may have been caught earlier but for what looks like an incorrect [test](https://github.com/FluxML/NNlib.jl/blob/f5fce7a9ce336e9322d98701b256e23bbb801586/test/activation.jl#L103), where the gradient of `sum(logsoftmax(xs))` where `xs` =
```julia
    1.0     2.0     3.0
 1000.0  2000.0  3000.0
```
is suggested to be approx. 0 for all entries. While the numerical gradient does give this for `Float32`s, I believe this is an artefact of low numerical precision. For instance, in python:
```python
import torch
xs = torch.Tensor([[1.0,2.0,3.0], [1000.0, 2000.0, 3000.0]]).requires_grad_(True)
out = sum(sum(torch.log_softmax(xs, 0)))
out.backward()
xs.grad
```
or in julia (note `Float64` here):
```julia
xs = Float64[1 2 3; 1000 2000 3000]
Tracker.ngradient(x->sum(logsoftmax(x)), xs)[1]
```
both give
```
  1.0   1.0   1.0
 -1.0  -1.0  -1.0
```
as does the amended gradient in this PR. With regard to the math, this [blog post](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) by Eli Bendersky gives a proof for something similar to this, modulo reshaping / reordering for matrix calculations. Nevertheless, it is easier to write logsoftmax out as `x - log(sum(exp(x)))` and recall that softmax is the gradient of logsumexp. As an added bonus, this implementation is also faster; removing the need for `∇softmax` in the calculation.

One can check this plays nicely with Flux using the following tests, taken from [Tracker.jl](https://github.com/FluxML/Tracker.jl/blob/master/test/tracker.jl) :
```julia
using Flux
using Flux: gradtest
using Flux.Tracker: gradcheck
@test gradtest(f, xs::AbstractArray...) = gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
@test gradtest(f, dims...) = gradtest(f, rand.(Float64, dims)...)
@test gradtest(x -> logsoftmax(x).*(1:3), 3)
@test gradtest(x -> logsoftmax(x).*(1:3), (3,5))
```
Furthermore, one might want to add some tests in Tracker.jl for numerical stability, such as:
```julia
gradtest(x -> logsoftmax(x).*(1:3), randn(Float64, 3,5)*100)
```
which currently fails, but passes with the implementation in this PR.