### PR TITLE
Make softmax! dimension-agnostic

### DIFF
--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -20,7 +20,7 @@ independent.
 softmax(xs; dims=1) = softmax!(similar(xs), xs, dims)
 
 function softmax!(out::AbstractArray{T}, xs::AbstractArray{T}, dims) where {T}
-    max = maximum(xs, dims)
+    max = maximum(xs, dims=dims)
     out .= exp.(xs.-max)
     out ./= sum(out, dims=dims)
     return out

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -3,23 +3,23 @@ export softmax, softmax!, ∇softmax, ∇softmax!,
 
 """
     softmax(xs) = exp.(xs) ./ sum(exp.(xs))
+
 [Softmax](https://en.wikipedia.org/wiki/Softmax_function) takes
 log-probabilities (any real vector) and returns a probability distribution that
 sums to 1.
+
 If given a matrix it will treat it as a batch of vectors, with each column
 independent.
+
     julia> softmax([1,2,3.])
     3-element Array{Float64,1}:
       0.0900306
       0.244728
       0.665241
 """
-softmax(xs) = softmax!(similar(xs), xs)
-
 function softmax(xs::AbstractArray{T}; dims=1) where {T}
     max = maximum(xs, dims=dims)
-    out = exp.(xs .- max)
-    out = out ./ sum(out, dims=dims)
+    out = exp.(xs .- max) ./ sum(exp.(xs .- max), dims=dims)
 end
 
 function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}) where {T}
@@ -60,6 +60,7 @@ end
 
 """
     logsoftmax(xs) = log.(exp.(xs) ./ sum(exp.(xs)))
+
 `logsoftmax(xs)` computes the log of `softmax(xs)`, but in a more numerically stable
 way than directly taking the log of the softmax function, which is commonly used in
 computing cross entropy loss.

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -17,7 +17,7 @@ independent.
       0.244728
       0.665241
 """
-softmax(xs; dims=2) = softmax!(similar(xs), xs, dims)
+softmax(xs; dims=1) = softmax!(similar(xs), xs, dims)
 
 function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}, dims) where {T}
     # First, store column-wise maximum in the last element of `out`

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -19,15 +19,9 @@ independent.
 """
 softmax(xs; dims=1) = softmax!(similar(xs), xs, dims)
 
-function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}, dims) where {T}
-    # First, store column-wise maximum in the last element of `out`
-    maxdims = ntuple(d -> (d in dims) ? (1:1) : (:), ndims(xs))
-    out[maxdims...] = maximum!(out[maxdims...], xs)
-
-    # Subtract the column-wise maximums to normalize, take exp()
-    out .= exp.(xs.-out[maxdims...])
-
-    # Normalize by sum of the entire thing
+function softmax!(out::AbstractArray{T}, xs::AbstractArray{T}, dims) where {T}
+    max = maximum(xs, dims)
+    out .= exp.(xs.-max)
     out ./= sum(out, dims=dims)
     return out
 end

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -53,8 +53,10 @@ function ∇softmax!(out::AbstractVecOrMat, Δ::AbstractVecOrMat, xs::AbstractVe
     sf = softmax(xs)
     out .= sf .* (Δ .- sum(Δ .*sf, dims = 1))
 end
-
-∇softmax(Δ, xs) = ∇softmax!(similar(Δ), Δ, xs)
+function ∇softmax(Δ, xs; dims=1) 
+    sf = softmax(xs, dims=dims)
+    out = sf .* (Δ .- sum(Δ .* sf, dims=dims))
+end
 ∇softmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)
 
 

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -3,29 +3,63 @@ export softmax, softmax!, ∇softmax, ∇softmax!,
 
 """
     softmax(xs) = exp.(xs) ./ sum(exp.(xs))
-
 [Softmax](https://en.wikipedia.org/wiki/Softmax_function) takes
 log-probabilities (any real vector) and returns a probability distribution that
 sums to 1.
-
 If given a matrix it will treat it as a batch of vectors, with each column
 independent.
-
     julia> softmax([1,2,3.])
     3-element Array{Float64,1}:
       0.0900306
       0.244728
       0.665241
 """
+softmax(xs) = softmax!(similar(xs), xs)
+
 function softmax(xs::AbstractArray{T}; dims=1) where {T}
     max = maximum(xs, dims=dims)
     out = exp.(xs .- max)
     out = out ./ sum(out, dims=dims)
 end
 
+function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}) where {T}
+    @inbounds for j = 1:size(xs, 2)
+        # First, store column-wise maximum in the last element of `out`
+        out[end, j] = xs[end, j]
+        @inbounds for i = 1:(size(xs, 1) - 1)
+            out[end, j] = max(out[end, j], xs[i, j])
+        end
+
+        # Subtract the column-wise maximums to normalize, take exp()
+        # out .= exp(xs .- out[end, :])
+        @inbounds for i = 1:size(out, 1)
+            out[i, j] = exp(xs[i, j] - out[end, j])
+        end
+
+        # Normalize by sum of the entire thing
+        # out ./= sum(out, 1)
+        s = T(0)
+        @inbounds for i = 1:size(out, 1)
+            s += out[i, j]
+        end
+        @inbounds for i = 1:size(out, 1)
+            out[i, j] /= s
+        end
+    end
+    return out
+end
+
+function ∇softmax!(out::AbstractVecOrMat, Δ::AbstractVecOrMat, xs::AbstractVecOrMat)
+    sf = softmax(xs)
+    out .= sf .* (Δ .- sum(Δ .*sf, dims = 1))
+end
+
+∇softmax(Δ, xs) = ∇softmax!(similar(Δ), Δ, xs)
+∇softmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)
+
+
 """
     logsoftmax(xs) = log.(exp.(xs) ./ sum(exp.(xs)))
-
 `logsoftmax(xs)` computes the log of `softmax(xs)`, but in a more numerically stable
 way than directly taking the log of the softmax function, which is commonly used in
 computing cross entropy loss.

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -17,9 +17,9 @@ independent.
       0.244728
       0.665241
 """
-softmax(xs) = softmax!(similar(xs), xs)
+softmax(xs; dims=2) = softmax!(similar(xs), xs, dims)
 
-function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}) where {T}
+function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}, dims) where {T}
     # First, store column-wise maximum in the last element of `out`
     maxdims = ntuple(d -> (d in dims) ? (1:1) : (:), ndims(xs))
     out[maxdims...] = maximum!(out[maxdims...], xs)


### PR DESCRIPTION
I tried reducing the allocations for a dimension-agnostic softmax implementation but there is still a few allocations. On my pc benchmarking this against the original implementation gives very similar results however.
As for `logsoftmax`, I'm not quite sure what's happening in the original implementation so I've not yet tried to generalize that.
EDIT:
Of course, I should note I also haven't changed the derivatives yet since I'm not sure what they should be.