### PR TITLE
logsoftmax with dims

### DIFF
--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -68,7 +68,7 @@ end
 way than directly taking the log of the softmax function, which is commonly used in
 computing cross entropy loss.
 """
-function logsoftmax(xs::AbstractArray{T}; dims=1) where {T}
+function logsoftmax(xs::AbstractArray; dims=1)
     max_ = maximum(xs, dims=dims)
     out = exp.(xs .- max_)
     log_ = log.(sum(out, dims=dims))

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -21,8 +21,8 @@ julia> softmax([1,2,3.])
 """
 function softmax(xs::AbstractArray; dims=1)
     max_ = maximum(xs, dims=dims)
-    out = exp.(xs .- max_)
-    out .= out ./ sum!(max_, out)
+    exp_ = exp.(xs .- max_)
+    exp_ ./ sum(exp_, dims=dims)
 end
 
 function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}) where {T}
@@ -58,7 +58,7 @@ function ∇softmax!(out::AbstractVecOrMat, Δ::AbstractVecOrMat, xs::AbstractVe
 end
 function ∇softmax(Δ, xs; dims=1)
     sf = softmax(xs, dims=dims)
-    out = sf .* (Δ .- sum(Δ .* sf, dims=dims))
+    sf .* (Δ .- sum(Δ .* sf, dims=dims))
 end
 ∇softmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)
 
@@ -72,9 +72,9 @@ computing cross entropy loss.
 """
 function logsoftmax(xs::AbstractArray; dims=1)
     max_ = maximum(xs, dims=dims)
-    out = exp.(xs .- max_)
-    log_ = log.(sum(out, dims=dims))
-    out .= (xs .- max_) .- log_
+    exp_ = exp.(xs .- max_)
+    log_ = log.(sum(exp_, dims=dims))
+    (xs .- max_) .- log_
 end
 
 function logsoftmax!(out::AbstractVecOrMat, xs::AbstractVecOrMat)

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -8,19 +8,21 @@ export softmax, softmax!, ∇softmax, ∇softmax!,
 log-probabilities (any real vector) and returns a probability distribution that
 sums to 1.
 
-If given a matrix it will treat it as a batch of vectors, with each column
-independent.
+If given a matrix it will by default (`dims=1`) treat it as a batch of vectors,
+with each column independent. Keyword `dims=2` will instead treat rows independently, etc.
 
-    julia> softmax([1,2,3.])
-    3-element Array{Float64,1}:
-      0.0900306
-      0.244728
-      0.665241
+```
+julia> softmax([1,2,3.])
+3-element Array{Float64,1}:
+  0.0900306
+  0.244728
+  0.665241
+```
 """
-function softmax(xs::AbstractArray{T}; dims=1) where {T}
-    temp = maximum(xs, dims=dims)
-    out = exp.(xs .- temp)
-    out .= out ./ sum!(temp, out)
+function softmax(xs::AbstractArray; dims=1)
+    max_ = maximum(xs, dims=dims)
+    out = exp.(xs .- max_)
+    out .= out ./ sum!(max_, out)
 end
 
 function softmax!(out::AbstractVecOrMat{T}, xs::AbstractVecOrMat{T}) where {T}
@@ -64,8 +66,8 @@ end
 """
     logsoftmax(xs) = log.(exp.(xs) ./ sum(exp.(xs)))
 
-`logsoftmax(xs)` computes the log of `softmax(xs)`, but in a more numerically stable
-way than directly taking the log of the softmax function, which is commonly used in
+Computes the log of softmax in a more numerically stable
+way than directly taking `log.(softmax(xs))`. Commonly used in
 computing cross entropy loss.
 """
 function logsoftmax(xs::AbstractArray; dims=1)
@@ -93,5 +95,6 @@ function logsoftmax!(out::AbstractVecOrMat, xs::AbstractVecOrMat)
     end
     return out
 end
+
 ∇logsoftmax(Δ, xs; dims=1) = Δ .- sum(Δ, dims=dims) .* softmax(xs)
 ∇logsoftmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -84,7 +84,9 @@ end
     @testset "softmax" begin
         xs = rand(5,5)
         @test all(sum(softmax(xs), dims = 1) .≈ 1)
+        @test all(sum(softmax(xs; dims=2), dims = 2) .≈ 1)
         @test sum(softmax(vec(xs))) ≈ 1
+        @test log.(softmax(xs; dims=2)) ≈ logsoftmax(xs; dims=2)
 
         xs = [-100_000, -100_000.]
         @test softmax(xs) ≈ [0.5, 0.5]
@@ -100,7 +102,7 @@ end
         xs = Float32[1 2 3; 1000 2000 3000]
         @test logsoftmax(xs) ≈ [-999 -1998 -2997; 0 0 0.]
 
-        @test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ Float32[1 1 1; -1 -1 -1] 
+        @test NNlib.∇logsoftmax(ones(size(xs)), xs) ≈ Float32[1 1 1; -1 -1 -1]
         @test NNlib.∇softmax(ones(size(xs)), xs) ≈ zeros(Float32, size(xs))
 
         # These values precalculated using PyTorch's nn.LogSoftmax


### PR DESCRIPTION
For #77, this adds a version of `logsoftmax` which takes `dims` keyword, and `∇logsoftmax` too.  

It also adjusts the implementation for `softmax` from #130 so as not to exponentiate twice; this is about twice as fast, see https://github.com/FluxML/NNlib.jl/issues/77#issuecomment-527090413 .

Both of these mutate their `out` array, which could easily be avoided if desired, at the cost of twice the memory. 