### PR TITLE
Fix typo: actvation -> activation

### DIFF
--- a/src/activation.jl
+++ b/src/activation.jl
@@ -82,7 +82,7 @@ end
 """
     swish(x) = x * σ(x)
 
-Self-gated actvation function.
+Self-gated activation function.
 See [Swish: a Self-Gated Activation Function](https://arxiv.org/pdf/1710.05941.pdf).
 """
 swish(x::Real) = x * σ(x)


### PR DESCRIPTION
## Summary

Fix a typo in the documentation of the `swish` activation layer.