### PR TITLE
handle dims properly in gradient of logsoftmax

### DIFF
--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -96,5 +96,5 @@ function logsoftmax!(out::AbstractVecOrMat, xs::AbstractVecOrMat)
     return out
 end
 
-∇logsoftmax(Δ, xs; dims=1) = Δ .- sum(Δ, dims=dims) .* softmax(xs)
+∇logsoftmax(Δ, xs; dims=1) = Δ .- sum(Δ, dims=dims) .* softmax(xs, dims=dims)
 ∇logsoftmax!(Δ, xs) = ∇softmax!(Δ, Δ, xs)


### PR DESCRIPTION
Original implementation was not passing `dims` to `softmax`

I picked this up when testing gradients for FluxML/Zygote.jl#425