### PR TITLE
Preserve the type in differentiation

### DIFF
--- a/src/activation.jl
+++ b/src/activation.jl
@@ -51,7 +51,7 @@ Leaky [Rectified Linear Unit](https://en.wikipedia.org/wiki/Rectifier_(neural_ne
 activation function.
 You can also specify the coefficient explicitly, e.g. `leakyrelu(x, 0.01)`.
 """
-leakyrelu(x::Real, a = oftype(x/1, 0.01)) = max(a*x, x/1)
+leakyrelu(x::Real, a = oftype(x/1, 0.01)) = max(a*x, x/one(x))
 
 
 """
@@ -62,7 +62,7 @@ Exponential Linear Unit activation function.
 See [Fast and Accurate Deep Network Learning by Exponential Linear Units](https://arxiv.org/abs/1511.07289).
 You can also specify the coefficient explicitly, e.g. `elu(x, 1)`.
 """
-elu(x, α = one(x)) = ifelse(x ≥ 0, x/1, α * (exp(x) - one(x)))
+elu(x, α = one(x)) = ifelse(x ≥ 0, x/one(x), α * (exp(x) - one(x)))
 
 
 """
@@ -99,7 +99,7 @@ See [Self-Normalizing Neural Networks](https://arxiv.org/pdf/1706.02515.pdf).
 function selu(x::Real)
   λ = oftype(x/1, 1.0507009873554804934193349852946)
   α = oftype(x/1, 1.6732632423543772848170429916717)
-  λ * ifelse(x > 0, x/1, α * (exp(x) - 1))
+  λ * ifelse(x > 0, x/one(x), α * (exp(x) - one(x)))
 end
 
 


### PR DESCRIPTION
The current implementations of `leakyrelu`, `elu` and `selu` return `Float64` gradients for `Float32` inputs. 

```julia
julia> using NNlib, Zygote

julia> leakyrelu'(1f0)
1.0

julia> leakyrelu'(-1f0)
0.009999999776482582

julia> elu'(1f0)
1.0

julia> elu'(-1f0)
0.3678794503211975

julia> selu'(1f0)
1.0507010221481323

julia> selu'(-1f0)
0.6467686295509338
```

cf. https://github.com/FluxML/Flux.jl/issues/963. This PR is intended to preserve float precision for differentiation.

```julia
using NNlib, Zygote, Test

ACTIVATION_FUNCTIONS = [σ, relu, leakyrelu, elu, gelu, swish, selu, softplus, softsign, logcosh];
function test_deliv_float_precision_preserving(a)
    @testset "$(a): " begin
        for T in [Float32, Float64]
            for val in [-10, -1, 0, 1, 10]
                val = @inferred a'(T(val))
                @test typeof(val) == T
            end
        end
    end
end

@testset "Float derivative inference" begin
    test_deliv_float_precision_preserving.(ACTIVATION_FUNCTIONS)
end
```

Before
```shell
Test Summary:              | Pass  Fail  Total
Float derivative inference |   85    15    100
  σ:                       |   10           10
  relu:                    |   10           10
  leakyrelu:               |    5     5     10
  elu:                     |    5     5     10
  gelu:                    |   10           10
  swish:                   |   10           10
  selu:                    |    5     5     10
  softplus:                |   10           10
  softsign:                |   10           10
  logcosh:                 |   10           10
ERROR: Some tests did not pass: 85 passed, 15 failed, 0 errored, 0 broken.
```

After
```shell
Test Summary:              | Pass  Total
Float derivative inference |  100    100
```