### PR TITLE
Adding ForwardDiff fix for sigmoid.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [targets]
-test = ["Test"]
+test = ["Test", "ForwardDiff"]

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -127,7 +127,7 @@ Return `log(cosh(x))` which is computed in a numerically stable way.
 logcosh(x::T) where T = x + softplus(-2x) - log(convert(T, 2))
 
 # Provide an informative error message if activation functions are called with an array
-for f in (:σ, :σ_stable, :logσ, :relu, :leakyrelu, :elu, :gelu, :swish, :selu, :softsign, :softplus, :logcosh)
+for f in (:σ, :logσ, :relu, :leakyrelu, :elu, :gelu, :swish, :selu, :softsign, :softplus, :logcosh)
   @eval $(f)(x::AbstractArray, args...) =
     error("Use broadcasting (`", $(string(f)), ".(x)`) to apply activation functions to arrays.")
 end

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -10,13 +10,13 @@ function.
 σ(x::Real) = one(x) / (one(x) + exp(-x))
 const sigmoid = σ
 
-# ForwardDiff numerical stability hack
-σ_stable(x::Real) = ifelse(x < -80, zero(x), one(x) / (one(x) + exp(-x)))
-σ(x::Float32) = σ_stable(x)
+# ForwardDiff numerical stability
 @init @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
-  σ(x::ForwardDiff.Dual{T,Float32}) where T = σ_stable(x)
+    function σ(x::ForwardDiff.Dual)
+        sx = σ(x.value)
+        return ForwardDiff.Dual(sx, sx*(one(sx)-sx)*x.partials)
+    end
 end
-
 
 """
     logσ(x)

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -1,4 +1,4 @@
-using NNlib, Test
+using NNlib, Test, ForwardDiff
 
 ACTIVATION_FUNCTIONS = [σ, relu, leakyrelu, elu, gelu, swish, selu, softplus, softsign, logcosh];
 
@@ -25,6 +25,9 @@ function test_value_int_input_forces_float64(a)
 end
 
 @testset "Activation Functions" begin
+    dual = σ(ForwardDiff.Dual(-708.0, 1.0))
+    @test -1e-8 < dual.value < 1e-8
+    @test all(map(x->-1e-8< x <1e-8, dual.partials.values))
     @test σ(0.0) == 0.5
     @test relu(0.0) == 0.0
     @test leakyrelu(0.0) == 0.0


### PR DESCRIPTION
This is a sample PR for changes needed for ForwardDiff.Duals. The derivatives can be computed as simple operations on orginal functions than resorting to situations where `Inf`/`Inf` or `Inf`*0  can arise leading to potential NaNs. 