### PR TITLE
Update deps for CI

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -19,9 +19,9 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "999513b7dea8ac17359ed50ae8ea089e4464e35e"
+git-tree-sha1 = "d37400976e98018ee840e0ca4f9d20baa231dc6b"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.0.0"
+version = "1.0.1"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"


### PR DESCRIPTION
CI cuilds for julia:nightly are falling because of https://github.com/JuliaLang/julia/pull/34611 (Requires.jl uses the deprecated function `@get!`). Requires.jl need to be updated to 1.0.1 to pass CI tests.

It would fix the build errors of https://github.com/FluxML/NNlib.jl/pull/165 https://github.com/FluxML/NNlib.jl/pull/162.