### PR TITLE
Fix debug string

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -94,8 +94,8 @@ for front_name in (:conv, :∇conv_data, :∇conv_filter,
                         y::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
                         in2::AbstractArray{T2,N}, cdims::ConvDims;
                         kwargs...) where {yT, T1, T2, N}
-            @debug string("Slow fallback implementation invoked for ", $front_name, "!  ",
-                          "You probably don't want this; check your datatypes.")
+            @debug string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
+                          "You probably don't want this; check your datatypes.") yT T1 T2
             $(Symbol("$(front_name)_direct!"))(y, in1, in2, cdims; kwargs...)
         end
     end


### PR DESCRIPTION
With `ENV["JULIA_DEBUG"] = "all"`, the string for this `@debug` fails like this:
```
┌ Error: Exception while generating log record in module NNlib at /Users/me/.julia/packages/NNlib/3krvM/src/conv.jl:97
│   exception =
│    UndefVarError: front_name not defined
│    Stacktrace:
│     [1] macro expansion at ./logging.jl:319 [inlined]
│     [2] #∇conv_data!#84(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(∇conv_data!), ::Array{AbstractFloat,5}, ::Array{AbstractFloat,5}, ::Array{Float32,5}, ::DenseConvDims{3,(5, 1, 1),16,24,(1, 1, 1),(0, 0, 0, 0, 0, 0),(1, 1, 1),false}) at /Users/me/.julia/packages/NNlib/3krvM/src/conv.jl:97
```
After:
```
julia> main()
Float32[2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32 2.9545236e32]
┌ Debug: Slow fallback implementation invoked for ∇conv_data!  You probably don't want this; check your datatypes.
│   yT = AbstractFloat
│   T1 = AbstractFloat
│   T2 = Float32
└ @ NNlib ~/.julia/dev/NNlib/src/conv.jl:97
```

Edit: recently changed in #155