### PR TITLE
Fix output shape of ∇conv_data_direct!

### DIFF
--- a/src/impl/conv_direct.jl
+++ b/src/impl/conv_direct.jl
@@ -161,7 +161,7 @@ function ∇conv_data_direct!(dx::AbstractArray{xT,5}, dy::AbstractArray{yT,5},
                                   dilation=dilation(cdims),
                                   flipkernel=flipkernel(cdims))
     dx = conv_direct!(dx, dy, w, ctdims; alpha=alpha, beta=beta)
-    return transpose_swapbatch(dx)
+    return dx
 end
 
 """

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -670,3 +670,17 @@ end
     @test size(depthwiseconv(x, w1; stride = (1, 2), pad = (2, 3), dilation = (2, 2))) == (10, 5, 9, 10)
     @test size(depthwiseconv(x, w1; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true)) == (10, 5, 9, 10)
 end
+
+# https://github.com/FluxML/NNlib.jl/pull/171
+@testset "conv_direct! - Check Sizes" begin 
+    x_size = (6, 7, 8, 5, 3)
+    y_size = (5, 6, 7, 4, 3)
+    w_size = (2, 2, 2, 5, 4)
+    x = randn(Float32, x_size);
+    y = randn(Float32, y_size);
+    w = randn(Float32, w_size);
+    cdims = DenseConvDims(x_size, w_size)
+    @test size(NNlib.conv_direct!(y, x, w, cdims)) == y_size
+    @test size(NNlib.∇conv_data_direct!(x, y, w, cdims)) == x_size
+    @test size(NNlib.∇conv_filter_direct!(w, x, y, cdims)) == w_size
+end


### PR DESCRIPTION
Fixes #156, https://github.com/FluxML/Flux.jl/issues/978

```julia
julia> using Flux

julia> using Flux: ConvTranspose, conv_transpose_dims

julia> using NNlib: ∇conv_data_im2col, ∇conv_data_direct

julia> ct = ConvTranspose((2, 2, 2), 4=>5, stride=2)
ConvTranspose((2, 2, 2), 4=>5)

julia> mat = Float32.(rand(16, 16, 16, 4, 3));

julia> ∇conv_data_im2col(mat, ct.weight, conv_transpose_dims(ct, mat)) |> size
(32, 32, 32, 5, 3)

julia> ∇conv_data_direct(mat, ct.weight, conv_transpose_dims(ct, mat)) |> size
(32, 32, 32, 5, 3)
```