### PR TITLE
Added some Activation functions

### DIFF
--- a/src/activation.jl
+++ b/src/activation.jl
@@ -160,9 +160,7 @@ end
 Continuously Differentiable Exponential Linear Units
 See [Continuously Differentiable Exponential Linear Units](https://arxiv.org/pdf/1704.07483.pdf).
 """
-function celu(x::Real, α::Real = one(x))
-    return ifelse(x ≥ 0, x / one(x), α * (exp(x/α) - one(x)))
-end 
+celu(x::Real, α::Real = one(x)) = ifelse(x ≥ 0, x / one(x), α * (exp(x/α) - one(x))) 
 
 
 """
@@ -171,9 +169,7 @@ end
 Threshold Gated Rectified Linear   
 See [ThresholdRelu](https://arxiv.org/pdf/1402.3337.pdf)
 """
-function trelu(x::Real,theta = one(x)) 
-    return ifelse(x> theta, x/ one(x), zero(x))
-end 
+trelu(x::Real,theta = one(x)) = ifelse(x> theta, x/ one(x), zero(x))
 const thresholdrelu = trelu
 
 

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -22,8 +22,6 @@ end
 
 Segment-wise linear approximation of sigmoid
 See: [BinaryConnect: Training Deep Neural Networks withbinary weights during propagations](https://arxiv.org/pdf/1511.00363.pdf)
-
-Note: It should not be used with Regression tasks.
 """
 hardσ(x::Real, a=0.2) = oftype(x/1, max(zero(x/1), min(one(x/1), oftype(x/1,a) * x + oftype(x/1,0.5))))
 const hardsigmoid = hardσ

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -169,7 +169,7 @@ celu(x::Real, α::Real = one(x)) = ifelse(x ≥ 0, x / one(x), α * (exp(x/α) -
 Threshold Gated Rectified Linear   
 See [ThresholdRelu](https://arxiv.org/pdf/1402.3337.pdf)
 """
-trelu(x::Real,theta = one(x)) = ifelse(x> theta, x/ one(x), zero(x))
+trelu(x::Real,theta = one(x)) = ifelse(x> theta, x, zero(x))
 const thresholdrelu = trelu
 
 

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -1,5 +1,5 @@
 export σ, sigmoid, relu, leakyrelu, relu6, rrelu, elu, gelu, swish, selu, celu, softplus, softsign, logσ,
-       logsigmoid, logcosh, mish, tanhshrink, softshrink
+       logsigmoid, logcosh, mish, tanhshrink, softshrink, thresholdrelu, trelu, lisht, hardσ, hardsigmoid
 
 """
     σ(x) = 1 / (1 + exp(-x))
@@ -17,6 +17,14 @@ const sigmoid = σ
   σ(x::ForwardDiff.Dual{T,Float32}) where T = σ_stable(x)
 end
 
+"""
+   hardσ(x) = x > 2.5 ? 1.0 : x < -2.5 ? 0 : 0.2 * x + 0.5
+Segment-wise linear approximation of sigmoid[HardSigmoid]()
+
+Note: It should not be use with Regression tasks.
+"""
+hardσ(x::Real) = oftype(x,x>2.5 ? 1.0 : x<-2.5 ? 0 : 0.2*x + 0.5)
+const hardsigmoid = hardσ
 
 """
     logσ(x)
@@ -110,6 +118,16 @@ See [Swish: a Self-Gated Activation Function](https://arxiv.org/pdf/1710.05941.p
 """
 swish(x::Real) = x * σ(x)
 
+
+"""
+    lisht(x) = x * tanh(x)
+
+Non-Parametric Linearly Scaled Hyperbolic Tangent Activation Function
+See [LiSHT](https://arxiv.org/abs/1901.05894)
+"""
+lisht(x::Real) = x * tanh(x)
+
+
 """
     selu(x) = λ * (x ≥ 0 ? x : α * (exp(x) - 1))
 
@@ -135,6 +153,15 @@ See [Continuously Differentiable Exponential Linear Units](https://arxiv.org/pdf
 function celu(x::Real, α::Real = one(x))
     return ifelse(x ≥ 0, x / one(x), α * (exp(x/α) - one(x)))
 end 
+
+"""
+    trelu(x, theta = 1.0) = x > theta ? x : 0 
+
+Threshold Gated Rectified Linear   
+See [ThresholdRelu](https://arxiv.org/pdf/1402.3337.pdf)
+"""
+trelu(x::Real,theta = one(x)) = x > theta ? x : zero(x) 
+const thresholdrelu = trelu
 
 """
     softsign(x) = x / (1 + |x|)
@@ -184,7 +211,7 @@ See [Softshrink Activation Function](https://www.gabormelli.com/RKB/Softshrink_A
 softshrink(x::Real, λ = oftype(x/1, 0.5)) = min(max(zero(x), x - λ), x + λ)
 
 # Provide an informative error message if activation functions are called with an array
-for f in (:σ, :σ_stable, :logσ, :relu, :leakyrelu, :relu6, :rrelu, :elu, :gelu, :swish, :selu, :celu, :softsign, :softplus, :logcosh, :mish, :tanhshrink, :softshrink)
+for f in (:σ, :σ_stable, :hardσ, :logσ, :relu, :leakyrelu, :relu6, :rrelu, :elu, :gelu, :swish, :lisht, :selu, :celu, :trelu, :softsign, :softplus, :logcosh, :mish, :tanhshrink, :softshrink)
     @eval $(f)(x::AbstractArray, args...) =
       error("Use broadcasting (`", $(string(f)), ".(x)`) to apply activation functions to arrays.")
 end

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -18,12 +18,14 @@ const sigmoid = σ
 end
 
 """
-   hardσ(x) = max(0, min(1.0, 0.2 * x + 0.5))
+   hardσ(x, a=0.2) = max(0, min(1.0, a * x + 0.5))
 
 Segment-wise linear approximation of sigmoid
+See: [BinaryConnect: Training Deep Neural Networks withbinary weights during propagations](https://arxiv.org/pdf/1511.00363.pdf)
+
 Note: It should not be used with Regression tasks.
 """
-hardσ(x::Real) = oftype(x/1, max(zero(x/1), min(one(x/1), oftype(x/1,0.2) * x + oftype(x/1,0.5))))
+hardσ(x::Real, a=0.2) = oftype(x/1, max(zero(x/1), min(one(x/1), oftype(x/1,a) * x + oftype(x/1,0.5))))
 const hardsigmoid = hardσ
 
 
@@ -48,8 +50,9 @@ const logsigmoid = logσ
     hardtanh(x) = max(-1, min(1, x))
 
 Segment-wise linear approximation of tanh. Cheaper  and  more  computational  efficient version of tanh.
+See: (http://ronan.collobert.org/pub/matos/2004_phdthesis_lip6.pdf)
 """
-hardtanh(x::Real) = oftype(x / 1,max(-1, min( 1, x)))
+hardtanh(x::Real) = max(-one(x), min( one(x), x))
 
 
 """
@@ -170,8 +173,8 @@ end
 Threshold Gated Rectified Linear   
 See [ThresholdRelu](https://arxiv.org/pdf/1402.3337.pdf)
 """
-function trelu(x::Real,theta = one(x/1)) 
-    return ifelse(x> theta, x/ one(x), zero(x/1))
+function trelu(x::Real,theta = one(x)) 
+    return ifelse(x> theta, x/ one(x), zero(x))
 end 
 const thresholdrelu = trelu
 

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -23,7 +23,7 @@ end
 Segment-wise linear approximation of sigmoid
 Note: It should not be used with Regression tasks.
 """
-hardσ(x::Real) = oftype(x, max(0, min(1.0, 0.2 * x + 0.5)))
+hardσ(x::Real) = oftype(x/1, max(zero(x/1), min(one(x/1), oftype(x/1,0.2) * x + oftype(x/1,0.5))))
 const hardsigmoid = hardσ
 
 
@@ -43,12 +43,14 @@ Return `log(σ(x))` which is computed in a numerically stable way.
 logσ(x::Real) = -softplus(-x)
 const logsigmoid = logσ
 
+
 """
     hardtanh(x) = max(-1, min(1, x))
 
 Segment-wise linear approximation of tanh. Cheaper  and  more  computational  efficient version of tanh.
 """
-hardtanh(x::Real) = oftype(x,max(-1, min( 1, x)))
+hardtanh(x::Real) = oftype(x / 1,max(-1, min( 1, x)))
+
 
 """
     relu(x) = max(0, x)
@@ -168,7 +170,9 @@ end
 Threshold Gated Rectified Linear   
 See [ThresholdRelu](https://arxiv.org/pdf/1402.3337.pdf)
 """
-trelu(x::Real,theta = one(x)) = x > theta ? x : zero(x) 
+function trelu(x::Real,theta = one(x/1)) 
+    return ifelse(x> theta, x/ one(x), zero(x/1))
+end 
 const thresholdrelu = trelu
 
 

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -1,6 +1,6 @@
 using NNlib, Test, Zygote
 
-ACTIVATION_FUNCTIONS = [σ,hardσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
+ACTIVATION_FUNCTIONS = [σ, hardσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
 
 function test_value_float_precision_preserving(a)
     @testset "$(a): " begin
@@ -113,7 +113,7 @@ end
     end
 
     @testset "Test Integer64 and Integer32 inputs will force Float64 outputs" begin
-        test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6), ACTIVATION_FUNCTIONS))
+        test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6 && x != hardtanh && x != trelu), ACTIVATION_FUNCTIONS))
 
         @testset "relu: " begin
             # relu doesn't have to force floating point outputs
@@ -126,7 +126,18 @@ end
             @test typeof(relu6(Int64(1))) == Int64
             @test typeof(relu6(Int32(1))) == Int32
         end
-
+        
+        @testset "hardtanh: " begin
+            # relu6 doesn't have to force floating point outputs
+            @test typeof(hardtanh(Int64(1))) == Int64
+            @test typeof(hardtanh(Int32(1))) == Int32
+        end
+        
+        @testset "trelu: " begin
+            # relu6 doesn't have to force floating point outputs
+            @test typeof(trelu(Int64(1))) == Int64
+            @test typeof(trelu(Int32(1))) == Int32
+        end
     end
     
     @testset "Float gradient inference" begin
@@ -218,6 +229,7 @@ end
     @testset "hardsigmoid" begin
         @test hardsigmoid(0.3) == 0.56
         @test hardsigmoid(-0.3) == 0.44
+        @test hardsigmoid(0.1,0.5) == 0.55
         for T in [:Float32, :Float64]
             @eval @test hardsigmoid.($T[-100_000, 100_000.]) ≈ $T[0., 1.]
         end

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -128,13 +128,13 @@ end
         end
         
         @testset "hardtanh: " begin
-            # relu6 doesn't have to force floating point outputs
+            # hardtanh doesn't have to force floating point outputs
             @test typeof(hardtanh(Int64(1))) == Int64
             @test typeof(hardtanh(Int32(1))) == Int32
         end
         
         @testset "trelu: " begin
-            # relu6 doesn't have to force floating point outputs
+            # trelu doesn't have to force floating point outputs
             @test typeof(trelu(Int64(1))) == Int64
             @test typeof(trelu(Int32(1))) == Int32
         end

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -113,7 +113,7 @@ end
     end
 
     @testset "Test Integer64 and Integer32 inputs will force Float64 outputs" begin
-        test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6 ), ACTIVATION_FUNCTIONS))
+        test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6), ACTIVATION_FUNCTIONS))
 
         @testset "relu: " begin
             # relu doesn't have to force floating point outputs

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -1,6 +1,6 @@
 using NNlib, Test, Zygote
 
-ACTIVATION_FUNCTIONS = [σ, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, selu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
+ACTIVATION_FUNCTIONS = [σ,hardσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
 
 function test_value_float_precision_preserving(a)
     @testset "$(a): " begin
@@ -37,6 +37,8 @@ end
 
 @testset "Activation Functions" begin
     @test σ(0.0) == 0.5
+    @test hardσ(0.0) == 0.5
+    @test hardtanh(0.0) == 0.0
     @test relu(0.0) == 0.0
     @test leakyrelu(0.0) == 0.0
     @test relu6(0.0) == 0.0
@@ -44,18 +46,22 @@ end
     @test elu(0.0) == 0.0
     @test gelu(0.0) == 0.0
     @test swish(0.0) == 0.0
+    @test lisht(0.0) == 0.0
     @test softplus(0.0) ≈ log(2.0)
     @test softplus(1e8) ≈ 1e8
     @test softplus(-1e8) ≈ 0.0
     @test softsign(0.0) == 0.0
     @test selu(0.0) == 0.0
     @test celu(0.0) == 0.0
+    @test trelu(0.0) == 0.0
     @test logcosh(0.0) == log(cosh(0.0))
     @test mish(0.0) == 0.0
     @test tanhshrink(0.0) == 0.0
     @test softshrink(0.0) == 0.0
 
     @test σ(1.0) == 1.0 / (1.0 + exp(-1.0))
+    @test hardσ(1.0) == max(0,min(1,0.2*1.0 + 0.5))
+    @test hardtanh(1.0) == 1.0
     @test relu(1.0) == 1.0
     @test leakyrelu(1.0) == 1.0
     @test relu6(1.0) == 1.0
@@ -63,16 +69,20 @@ end
     @test elu(1.0) == 1.0
     @test gelu(1.0) == 0.8411919906082768
     @test swish(1.0) == 1.0 / (1.0 + exp(-1.0))
+    @test lisht(1.0) ≈ 1.0 * tanh(1.0) 
     @test softplus(1.0) ≈ log(exp(1.0) + 1.0)
     @test softsign(1.0) == 0.5
     @test selu(1.0) == 1.0507009873554804934193349852946
     @test celu(1.0) == 1.0
+    @test trelu(1.0) == 0.0
     @test logcosh(1.0) ≈ log(cosh(1.0))
     @test mish(1.0) ≈ tanh(log(1.0 + exp(1.0)))
     @test tanhshrink(1.0) ≈ 0.23840584404423515
     @test softshrink(1.0) == 0.5
 
     @test σ(-1.0) == 1.0 / (1.0 + exp(1.0))
+    @test hardσ(-1.0) == max(0,min(1,0.2*-1.0 + 0.5))
+    @test hardtanh(-1.0) == -1.0
     @test relu(-1.0) == 0.0
     @test leakyrelu(-1.0) == -0.01
     @test relu6(-1.0) == 0.0
@@ -80,10 +90,12 @@ end
     @test elu(-1.0) == exp(-1.0) - 1.0
     @test gelu(-1.0) == -0.15880800939172324
     @test swish(-1.0) == -1.0 / (1.0 + exp(1.0))
+    @test lisht(-1.0) ≈ -1.0 * tanh(-1.0)
     @test softplus(-1.0) ≈ log(exp(-1.0) + 1.0)
     @test softsign(-1.0) == -0.5
     @test selu(-1.0) == 1.0507009873554804934193349852946 * 1.6732632423543772848170429916717 * (exp(-1.0) - 1.0)
     @test celu(-1.0) == exp(-1.0) - 1
+    @test trelu(-1.0) == 0.0
     @test log(cosh(-1.0)) ≈ log(cosh(-1.0))
     @test mish(-1.0) ≈ -tanh(log(1.0 + exp(-1.0)))
     @test tanhshrink(-1.0) ≈ -0.23840584404423515
@@ -101,7 +113,7 @@ end
     end
 
     @testset "Test Integer64 and Integer32 inputs will force Float64 outputs" begin
-        test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6), ACTIVATION_FUNCTIONS))
+        test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6 ), ACTIVATION_FUNCTIONS))
 
         @testset "relu: " begin
             # relu doesn't have to force floating point outputs
@@ -202,4 +214,22 @@ end
     end
 
     @test logcosh(1_000.0) + log(2) == 1_000.0
+    
+    @testset "hardsigmoid" begin
+        @test hardsigmoid(0.3) == 0.56
+        @test hardsigmoid(-0.3) == 0.44
+        for T in [:Float32, :Float64]
+            @eval @test hardsigmoid.($T[-100_000, 100_000.]) ≈ $T[0., 1.]
+        end
+    end
+    
+    @test hardtanh(10.0) == 1.0
+    @test lisht(2.5) == 2.5*tanh(2.5)
+    
+    @testset "trelu" begin
+        @test trelu(0.5) == 0.0
+        @test trelu(1.0) == 0.0
+        @test trelu(1.1) == 1.1
+        @test trelu(0.9,0.5) == 0.9
+    end
 end


### PR DESCRIPTION
Added the following activation functions along with tests

- [x] hardsigmoid
- [x] hardtanh 
- [x] thresholdrelu or trelu
- [x]  lisht 

- hardsigmoid and hardtanh are piecewise linear approximations and computationally effiecient than their counterparts, sigmoid and tanh respectively
- Threshold relu is used in Autoencoders as Threshold gated RELU
- LiSHT: Non-Parametric Linearly Scaled Hyperbolic Tangent Activation Function
  Ref: https://arxiv.org/pdf/1901.05894.pdf
