### PR TITLE
support FillArrays in convolutions

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -6,6 +6,12 @@ git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
 
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "85c6b57e2680fa28d5c8adc798967377646fbf66"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.8.5"
+
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -17,6 +18,7 @@ julia = "1"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 
 [targets]
-test = ["Test", "Zygote"]
+test = ["Test", "Zygote", "FillArrays"]

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -1,5 +1,12 @@
 module NNlib
 using Requires
+import FillArrays
+
+# Temporary fix for https://github.com/FluxML/Flux.jl/issues/1055
+# remove this (and FillArrays dependency) once defined in FillArrays.jl
+Base.pointer(x::FillArrays.AbstractFill) = pointer(Array(x))
+Base.pointer(x::FillArrays.AbstractFill, i::Integer) = pointer(Array(x), i)
+
 
 # Include APIs
 include("dim_helpers.jl")

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -684,3 +684,13 @@ end
     @test size(NNlib.∇conv_data_direct!(x, y, w, cdims)) == x_size
     @test size(NNlib.∇conv_filter_direct!(w, x, y, cdims)) == w_size
 end
+
+@testset "conv FillArrays support" begin 
+    x = Ones(2,2,2,2)
+    w = Ones(2,2,2,2)
+    dy = Fill(8, (1,1,2,2))
+    cdims = DenseConvDims(x, w)
+    @test NNlib.conv(x, w) == fill(8, (1,1,2,2))
+    @test ∇conv_data(dy, w, cdims) == fill(16, (2,2,2,2))
+    @test ∇conv_filter(x, dy, cdims) == fill(16, (2,2,2,2))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using NNlib, Test
+using FillArrays: Ones, Fill
 
 include("activation.jl")
 include("conv.jl")


### PR DESCRIPTION
Hotfix for https://github.com/FluxML/Flux.jl/issues/1055.
Those methods should go into FillArrays really, will open an issue there, but in the meanwhile let's fix this issue here since it can come up easily while doing simple tests on Flux conv layers 