### PR TITLE
Add comment for wrapper functions in CuArrays.jl 

### DIFF
--- a/src/activation.jl
+++ b/src/activation.jl
@@ -1,6 +1,11 @@
 export σ, sigmoid, hardσ, hardsigmoid, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, swish, selu, celu, softplus, softsign, logσ,
        logsigmoid, logcosh, mish, tanhshrink, softshrink, thresholdrelu, trelu, lisht
 
+## Activation functions
+# 
+# Some of activation functions have its wrapper function for GPU in CuArrays.jl.
+# https://github.com/JuliaGPU/CuArrays.jl/issues/614
+
 """
     σ(x) = 1 / (1 + exp(-x))
 

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -1,6 +1,6 @@
 using NNlib, Test, Zygote
 
-ACTIVATION_FUNCTIONS = [σ, hardσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
+ACTIVATION_FUNCTIONS = [σ, hardσ, logσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
 
 function test_value_float_precision_preserving(a)
     @testset "$(a): " begin


### PR DESCRIPTION
Some of activation functions defined in NNlib are incomplatible with GPU and they need `@cufunc` wrappers, which are defined in CuArrays.jl. https://github.com/JuliaGPU/CuArrays.jl/issues/614 

I found some activation function we added recently (e.g. `celu`) are GPU-unfriendly. I already submitted a PR https://github.com/JuliaGPU/CuArrays.jl/pull/615 to fix this issue, but I think it is better for us to consider GPU compatibility when we add a new function or update its definition  in future.
