### PR TITLE
Improvements to batched_mul, including PermutedDimsArray

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,10 +1,22 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArrayLayouts]]
+deps = ["FillArrays", "LinearAlgebra"]
+git-tree-sha1 = "5a57a6158c1d340635a89d19beb34b0f325a4431"
+uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+version = "0.2.5"
+
 [[BinaryProvider]]
 deps = ["Libdl", "SHA"]
 git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "51cc2f9bc4eb9c6c0e81ec2f779d1085583cc956"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.8.7"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 version = "0.6.6"
 
 [deps]
+ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,6 +11,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+ArrayLayouts = "0.2.2"
 BinaryProvider = "0.5"
 Requires = "0.5, 1.0"
 julia = "1"

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -42,8 +42,8 @@ batched_adjoint(A::BatchedAdjoint) = A.parent
 
 batched_adjoint(A::BatchedTranspose{<:Real}) = A.parent
 batched_transpose(A::BatchedAdjoint{<:Real}) = A.parent
-# batched_adjoint(A::PermutedDimsArray{<:Real,3,(2,1,3)}) = A.parent
-# batched_transpose(A::PermutedDimsArray{<:Number,3,(2,1,3)}) = A.parent
+batched_adjoint(A::PermutedDimsArray{<:Real,3,(2,1,3)}) = A.parent
+batched_transpose(A::PermutedDimsArray{<:Number,3,(2,1,3)}) = A.parent
 
 BatchedAdjoint(A) = BatchedAdjoint{Base.promote_op(adjoint,eltype(A)),typeof(A)}(A)
 BatchedTranspose(A) = BatchedTranspose{Base.promote_op(transpose,eltype(A)),typeof(A)}(A)

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -13,10 +13,10 @@ as it operated on such matrix slices of an array with `ndims(A)==3`.
 For arrays of real numbers, `batched_transpose(A) == PermutedDimsArray(A, (2,1,3))`,
 which is a more widely-supported wrapper, and also understood by `batched_mul`.
 
-    BatchedTranspose{T, N, S} <: AbstractBatchedMatrix{T, N}
-    BatchedAdjoint{T, N, S}
+    BatchedTranspose{T, S} <: AbstractBatchedMatrix{T, 3}
+    BatchedAdjoint{T, S}
 
-Lazy wrappers analogous to `Transpose` and `Adjoint`, returned by `batched_transpose`.
+Lazy wrappers analogous to `Transpose` and `Adjoint`, returned by `batched_transpose` etc.
 """
 
 @doc _batched_doc

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -74,11 +74,15 @@ function Base.strides(A::BatchedAdjOrTrans)
     sp = strides(A.parent)
     (sp[2], sp[1], sp[3])
 end
+
 function Base.stride(A::BatchedAdjOrTrans, d::Integer)
     d == 1 && return Base.stride(A.parent, 2)
     d == 2 && return Base.stride(A.parent, 1)
     Base.stride(A.parent, d)
 end
+
+Base.unsafe_convert(::Type{Ptr{T}}, A::BatchedAdjOrTrans{T}) where {T} =
+    Base.unsafe_convert(Ptr{T}, parent(A))
 
 (-)(A::BatchedAdjoint)   = BatchedAdjoint(  -A.parent)
 (-)(A::BatchedTranspose) = BatchedTranspose(-A.parent)

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -41,8 +41,8 @@ batched_adjoint(A::BatchedAdjoint) = A.parent
 
 batched_adjoint(A::BatchedTranspose{<:Real}) = A.parent
 batched_transpose(A::BatchedAdjoint{<:Real}) = A.parent
-batched_adjoint(A::PermutedDimsArray{<:Real,3,(2,1,3)}) = A.parent
-batched_transpose(A::PermutedDimsArray{<:Number,3,(2,1,3)}) = A.parent
+# batched_adjoint(A::PermutedDimsArray{<:Real,3,(2,1,3)}) = A.parent
+# batched_transpose(A::PermutedDimsArray{<:Number,3,(2,1,3)}) = A.parent
 
 BatchedAdjoint(A) = BatchedAdjoint{Base.promote_op(adjoint,eltype(A)),typeof(A)}(A)
 BatchedTranspose(A) = BatchedTranspose{Base.promote_op(transpose,eltype(A)),typeof(A)}(A)
@@ -73,6 +73,11 @@ Base.parent(A::BatchedAdjOrTrans) = A.parent
 function Base.strides(A::BatchedAdjOrTrans)
     sp = strides(A.parent)
     (sp[2], sp[1], sp[3])
+end
+function Base.stride(A::BatchedAdjOrTrans, d::Integer)
+    d == 1 && return Base.stride(A.parent, 2)
+    d == 2 && return Base.stride(A.parent, 1)
+    Base.stride(A.parent, d)
 end
 
 (-)(A::BatchedAdjoint)   = BatchedAdjoint(  -A.parent)

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -44,6 +44,8 @@ batched_adjoint(A::BatchedTranspose{<:Real}) = A.parent
 batched_transpose(A::BatchedAdjoint{<:Real}) = A.parent
 batched_adjoint(A::PermutedDimsArray{<:Real,3,(2,1,3)}) = A.parent
 batched_transpose(A::PermutedDimsArray{<:Number,3,(2,1,3)}) = A.parent
+# if you can't unwrap, put BatchedAdjoint outside (for dispatch):
+batched_transpose(A::BatchedAdjoint{<:Complex}) = BatchedAdjoint(BatchedTranspose(A.parent))
 
 BatchedAdjoint(A) = BatchedAdjoint{Base.promote_op(adjoint,eltype(A)),typeof(A)}(A)
 BatchedTranspose(A) = BatchedTranspose{Base.promote_op(transpose,eltype(A)),typeof(A)}(A)

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -33,12 +33,12 @@ const _GemmFloat = Union{Float64, Float32, ComplexF64, ComplexF32}
 
 _BATCHED_GEMM_LIST = [
     (:(StridedArray{T, 3}), 'N'),
-    (:(BatchedTranspose{T, <:StridedArray{T, 3}}), 'T'),
-    (:(BatchedAdjoint{T, <:StridedArray{T, 3}}), 'C')
+    (:(BatchedTranspose{T, <:Array{T, 3}}), 'T'),
+    (:(BatchedAdjoint{T, <:Array{T, 3}}), 'C')
 ]
 
 for (TA, transA) in _BATCHED_GEMM_LIST, (TB, transB) in _BATCHED_GEMM_LIST
-    @eval function batched_mul!(C::StridedArray{T, 3}, A::$TA, B::$TB) where {T<:_GemmFloat}
+    @eval function batched_mul!(C::Array{T, 3}, A::$TA, B::$TB) where {T<:_GemmFloat}
         batched_gemm!($transA, $transB, one(T), _unbatch(A), _unbatch(B), zero(T), C)
         C
     end

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -35,12 +35,29 @@ julia> B = PermutedDimsArray(rand(5,10,6), (1,3,2)); size(B)
 julia> strides(B)
 (1, 50, 5)
 
-julia> ENV["JULIA_DEBUG"] = NNlib;
+julia> ENV["JULIA_DEBUG"] = NNlib; # nothing logged means we got batched_gemm!
 
 julia> C = batched_mul(A, B); size(C)
 (4, 6, 10)
+
+julia> A2 = PermutedDimsArray(rand(10,5,4), (3,2,1)); size(A2)
+(4, 5, 10)
+
+julia> C2 = batched_mul(A2, B); size(C2)
+┌ Debug: couldn't re-arrange strides for batched_gemm!
+│   strides(A) = (50, 10, 1)
+│   strides(B) = (1, 50, 5)
+│   strides(C) = (1, 4, 24)
+└ @ NNlib ~/.julia/dev/NNlib/src/batched/batchedmul.jl:112
+┌ Debug: calling fallback method for batched_mul!
+│   typeof(A) = PermutedDimsArray{Float64,3,(3, 2, 1),(3, 2, 1),Array{Float64,3}}
+│   typeof(B) = PermutedDimsArray{Float64,3,(1, 3, 2),(1, 3, 2),Array{Float64,3}}
+│   typeof(C) = Array{Float64,3}
+└ @ NNlib ~/.julia/dev/NNlib/src/batched/batchedmul.jl:133
+(4, 6, 10)
 ```
-On the GPU, all permutations of dimensions are handled by `gemm_batched_strided` I think.
+On the GPU, perhaps more permutations of dimensions can be handled by `gemm_strided_batched!`,
+which is what gets called.
 """
 function batched_mul(A::AbstractArray{T1, 3}, B::AbstractArray{T2, 3}) where {T1, T2}
     axes(A, 3) == axes(B, 3) || throw(DimensionMismatch("batch size mismatch"))
@@ -55,36 +72,42 @@ end
 In-place batched matrix multiplication,
 equivalent to `mul!(C[:,:,k], A[:,:,k], B[:,:,k])` for all `k`.
 """
-function batched_mul! end
+batched_mul!(C::AbstractArray{<:Any,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3}) =
+    batched_mul_cpu!(C, A, B)
+# CuArrays can have a more specific method for batched_mul!, which looks innside for storage.
+# If rejected, it can call batched_mul_cpu! to continue:
+
+function batched_mul_cpu!(C::AbstractArray{<:Any,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3})
+    if eltype(A) <: BlasFloat &&
+        eltype(A) == eltype(B) == eltype(C) &&
+        is_strided(A) && is_strided(B) && is_strided(C)
+        # Now it's safe to call strides(A), and there's a chance batched_gemm! may be legal.
+        batched_try_gemm!(C, A, B)
+    else
+        batched_mul_generic!(C, A, B)
+    end
+end
 
 _unbatch(A) = A
 _unbatch(A::BatchedAdjOrTrans) = A.parent
+
+_perm12(A::AbstractArray) = PermutedDimsArray(A, (2,1,3))
+_perm12(A::PermutedDimsArray{<:Any,3,(2,1,3)}) = parent(A)
+_perm12(A::PermutedDimsArray{T,3,P}) where {T,P} = PermutedDimsArray(parent(A), (P[2], P[1], P[3]))
+
+_BATCHED_GEMM_LIST = [
+    (:(AbstractArray{T, 3}), 'N', :identity),
+    (:(BatchedTranspose{T}), 'T', :batched_transpose),
+    (:(BatchedAdjoint{T}),   'C', :batched_adjoint)
+]
 
 # batched_gemm! is happy with PermutedDimsArray, which is not StridedArray, but needs:
 # (1) all same eltype <: BlasFloat, and
 # (2) all with Base.stride(X,1) == 1 where A,B might be batched_adjoint(X) etc.
 
-# const SuperStrided2 = Union{StridedArray, BatchedAdjOrTrans, PermutedDimsArray{T,N,P,Q,<:StridedArray} where {T,N,P,Q}}
-#
-# function batched_mul!(C::AbstractArray{<:Any,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3})
-#     if A isa SuperStrided2 && B isa SuperStrided2 && C isa StridedArray
-#         batched_try_gemm!(C, A, B)
-#     else
-#         batched_mul_generic!(C, A, B)
-#     end
-# end
-# This "batched_try_gemm!" thing attempts to be careful about e.g. some views for strides(A) is an error. But I'm not sure it's worth bothering.
-
-_BATCHED_GEMM_LIST = [
-    (:(AbstractArray{T, 3}), 'N', :identity),
-    (:(BatchedTranspose{T, <:AbstractArray{T, 3}}), 'T', :batched_transpose),
-    (:(BatchedAdjoint{T, <:AbstractArray{T, 3}}), 'C', :batched_adjoint)
-]
-
 for (TA, transA, fA) in _BATCHED_GEMM_LIST, (TB, transB, fB) in _BATCHED_GEMM_LIST
 
-    # @eval function batched_try_gemm!(C::AbstractArray{T, 3}, A::$TA, B::$TB) where {T<:BlasFloat}
-    @eval function batched_mul!(C::AbstractArray{T, 3}, A::$TA, B::$TB) where {T<:BlasFloat}
+    @eval function batched_try_gemm!(C::AbstractArray{T, 3}, A::$TA, B::$TB) where {T<:BlasFloat}
         Abase, Bbase = _unbatch(A), _unbatch(B)
 
         # Best case, we can call batched_gemm! immediately:
@@ -94,16 +117,16 @@ for (TA, transA, fA) in _BATCHED_GEMM_LIST, (TB, transB, fB) in _BATCHED_GEMM_LI
         # Second-best, can we fix it by Perm.ing the base, and adjusing 'T' label?
         # But only if we won't produce BatchedTranspose(BatchedAdjoint(complex array)).
         elseif Base.stride(Abase,2) == 1 && !(T<:Complex && $TA<:BatchedAdjoint)
-            newAbase = batched_transpose(PermutedDimsArray(Abase, (2,1,3)))
-            # return batched_try_gemm!(C, $fA(newAbase), B)
-            return batched_mul!(C, $fA(newAbase), B)
+            newAbase = batched_transpose(_perm12(Abase))
+            return batched_try_gemm!(C, $fA(newAbase), B)
+
         elseif Base.stride(Bbase,2) == 1 && !(T<:Complex && $TB<:BatchedAdjoint)
-            newBbase = batched_transpose(PermutedDimsArray(Bbase, (2,1,3)))
-            # return batched_try_gemm!(C, A, $fB(newBbase))
-            return batched_mul!(C, A, $fB(newBbase))
+            newBbase = batched_transpose(_perm12(Bbase))
+            return batched_try_gemm!(C, A, $fB(newBbase))
 
         # Fallback, e.g when Base.stride(A,3)==1
         else
+            @debug "couldn't re-arrange strides for batched_gemm!" strides(A) strides(B) strides(C)
             batched_mul_generic!(C, A, B)
         end
         C
@@ -113,12 +136,10 @@ end
 
 # fallback
 
-batched_mul!(C::AbstractArray{<:Any,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3}) = batched_mul_generic!(C, A, B)
-
 _BATCHED_LIST = [
     (:(AbstractArray{<:Any, 3}), :identity),
-    (:BatchedTranspose, :transpose),
-    (:BatchedAdjoint, :adjoint),
+    (:BatchedTranspose,          :transpose),
+    (:BatchedAdjoint,            :adjoint),
 ]
 for (TA, fA) in _BATCHED_LIST, (TB, fB) in _BATCHED_LIST
 
@@ -133,3 +154,105 @@ for (TA, fA) in _BATCHED_LIST, (TB, fB) in _BATCHED_LIST
     end
 
 end
+
+
+"""
+    is_strided(A::AbstractArray)
+
+This generalises `A isa StridedArray` to treat wrappers like `A::PermutedDimsArray`,
+for which it returns `is_strided(parent(A))`.
+
+Other wrappers (defined outside Base, LinearAlgebra) are assumed not to break
+strided-ness, and hence also return `is_strided(parent(A))`.
+This correctly handles things like `NamedDimsArray` wihch don't alter indexing.
+However, it's a little pessimistic in that e.g. a `view` of such a container will return
+`false`, even in cases where the same `view` of `parent(A)` would be a `StridedArray`.
+
+`A::Transpose` doesn't currently define `strides`, so for now returns `false`.
+(I guess `Adjoint(A)` should only unwrapped when its elements are real numbers.)
+
+"""
+is_strided(A::StridedArray) = true
+is_strided(A) = false
+function is_strided(A::AbstractArray)
+    M = parentmodule(typeof(A))
+    if parent(A) === A # SparseMatrix, StaticArray, etc
+        false
+    elseif M === Base || M === Core || M ===LinearAlgebra
+        # bad reshapes, etc, plus Diagonal, UpperTriangular, etc.
+        false
+    else
+        is_strided(parent(A)) # PermutedDimsArray, NamedDimsArray
+    end
+end
+
+if hasmethod(Base.strides, Tuple{LinearAlgebra.Transpose})
+    # https://github.com/JuliaLang/julia/pull/29135
+    is_strided(A::LinearAlgebra.Transpose) = is_strided(parent(A))
+    is_strided(A::LinearAlgebra.Adjoint) = eltype(A) <: Real && is_strided(parent(A))
+else
+    is_strided(A::LinearAlgebra.Transpose) = false
+    is_strided(A::LinearAlgebra.Adjoint) = false
+end
+
+#=
+"""
+    is_strided_cu(A)
+
+This should return `true` for `A::CuArray`, and also for:
+* Any `view(::CuArray)` or `reshape(::CuArray)` etc. which remains a `StridedArray`
+* Any other wrapper for which `is_strided_cu(parent(A))`
+* Except that `Adjoint(A)` is only unwrapped for real numbers.
+
+Such wrappers include `PermutedDimsArray(::CuArray, ...)`,
+but also those defined elsewhere (such as `NamedDimsArray`s)
+which are assumed not to break strided-ness.
+
+`Transpose` and `Adjoint` don't currently define `strides`, so for now they return `false`.
+"""
+is_strided_cu(A::CuArray) = true
+is_strided_cu(A) = false
+function is_strided(A::AbstractArray)
+    M = parentmodule(typeof(A))
+    if parent(A) === A # Array, SparseMatrix, StaticArray
+        false
+    elseif M === Base || M === Core || M ===LinearAlgebra
+        A isa StridedArray && is_strided_cu(parent(A))
+    else
+        is_strided(parent(A)) # PermutedDimsArray, NamedDimsArray
+    end
+end
+
+# is_strided_cu(A::AbstractArray) = parent(A) === A ? false : is_strided_cu(parent(A))
+# is_strided_cu(A::Union{SubArray, Base.ReshapedArray, Base.ReinterpretArray}) =
+#     A isa StridedArray && is_strided_cu(parent(A))
+
+if hasmethod(Base.strides, Tuple{LinearAlgebra.Transpose})
+    is_strided_cu(A::LinearAlgebra.Transpose) = is_strided(parent(A))
+    is_strided_cu(A::LinearAlgebra.Adjoint) = eltype(A) <: Real && is_strided(parent(A))
+else
+    is_strided_cu(A::LinearAlgebra.Transpose) = false
+    is_strided_cu(A::LinearAlgebra.Adjoint) = false
+end
+
+using CuArrays: is_strided_cu
+@testset "is_strided_cu" begin
+
+    M = cu(ones(10,10))
+
+    @test is_strided_cu(M)
+    @test is_strided_cu(view(M, 1:2:5,:))
+    @test is_strided_cu(PermutedDimsArray(M, (2,1)))
+
+    @test !is_strided_cu(reshape(view(M, 1:2:10,:), 10,:))
+    @test !is_strided_cu((M.+im)')
+    @test !is_strided_cu(ones(10,10))
+    @test !is_strided_cu(Diagonal(ones(3)))
+
+    #=
+    using NamedDims
+    @test is_strided(NamedDimsArray(M,(:a, :b))) # and 0.029 ns, 0 allocations
+    =#
+
+end
+=#

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -12,8 +12,35 @@ include("./batchedadjtrans.jl")
 
 Batched matrix multiplication. Result has `C[:,:,k] == A[:,:,k] * B[:,:,k]` for all `k`.
 
-Using `batched_transpose(A)` or `PermutedDimsArray(A, (2,1,3))` will transpose each `A[:,:,k]`,
+Using `batched_transpose(A)` will transpose each `A[:,:,k]`,
 and similarly `batched_adjoint(B)` will use `adjoint(B[:,:,k])`.
+
+It will also accept `A` or `B` which are `PermutedDimsArray{T,3}`.
+On the CPU, these will still be handled by `BLAS.gemm!` provided `T <: LinearAlgebra.BlasFloat`
+and the can be permuted to be column-major. For `T <: Real` this allows any permutations
+so long as `Base.stride(A,3) != 1` and `Base.stride(B,3) != 1`.
+For `T <: Complex` instead you must have `Base.stride(A,1) == 1 == Base.stride(B,1)`.
+
+Other cases will fall back to `batched_mul_generic!`, which logs a message via `@debug`.
+```
+julia> A = PermutedDimsArray(rand(5,4,10), (2,1,3)); size(A)
+(4, 5, 10)
+
+julia> strides(A)
+(5, 1, 20)
+
+julia> B = PermutedDimsArray(rand(5,10,6), (1,3,2)); size(B)
+(5, 6, 10)
+
+julia> strides(B)
+(1, 50, 5)
+
+julia> ENV["JULIA_DEBUG"] = NNlib;
+
+julia> C = batched_mul(A, B); size(C)
+(4, 6, 10)
+```
+On the GPU, all permutations of dimensions are handled by `gemm_batched_strided` I think.
 """
 function batched_mul(A::AbstractArray{T1, 3}, B::AbstractArray{T2, 3}) where {T1, T2}
     axes(A, 3) == axes(B, 3) || throw(DimensionMismatch("batch size mismatch"))
@@ -33,22 +60,60 @@ function batched_mul! end
 _unbatch(A) = A
 _unbatch(A::BatchedAdjOrTrans) = A.parent
 
-# batched_gemm!
+# batched_gemm! is happy with PermutedDimsArray, which is not StridedArray, but needs:
+# (1) all same eltype <: BlasFloat, and
+# (2) all with Base.stride(X,1) == 1 where A,B might be batched_adjoint(X) etc.
+
+# const SuperStrided2 = Union{StridedArray, BatchedAdjOrTrans, PermutedDimsArray{T,N,P,Q,<:StridedArray} where {T,N,P,Q}}
+#
+# function batched_mul!(C::AbstractArray{<:Any,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3})
+#     if A isa SuperStrided2 && B isa SuperStrided2 && C isa StridedArray
+#         batched_try_gemm!(C, A, B)
+#     else
+#         batched_mul_generic!(C, A, B)
+#     end
+# end
+# This "batched_try_gemm!" thing attempts to be careful about e.g. some views for strides(A) is an error. But I'm not sure it's worth bothering.
 
 _BATCHED_GEMM_LIST = [
-    (:(StridedArray{T, 3}), 'N'),
-    (:(BatchedTranspose{T, <:StridedArray{T, 3}}), 'T'),
-    (:(BatchedAdjoint{T, <:StridedArray{T, 3}}), 'C')
+    (:(AbstractArray{T, 3}), 'N', :identity),
+    (:(BatchedTranspose{T, <:AbstractArray{T, 3}}), 'T', :batched_transpose),
+    (:(BatchedAdjoint{T, <:AbstractArray{T, 3}}), 'C', :batched_adjoint)
 ]
 
-for (TA, transA) in _BATCHED_GEMM_LIST, (TB, transB) in _BATCHED_GEMM_LIST
-    @eval function batched_mul!(C::Array{T, 3}, A::$TA, B::$TB) where {T<:BlasFloat}
-        batched_gemm!($transA, $transB, one(T), _unbatch(A), _unbatch(B), zero(T), C)
+for (TA, transA, fA) in _BATCHED_GEMM_LIST, (TB, transB, fB) in _BATCHED_GEMM_LIST
+
+    # @eval function batched_try_gemm!(C::AbstractArray{T, 3}, A::$TA, B::$TB) where {T<:BlasFloat}
+    @eval function batched_mul!(C::AbstractArray{T, 3}, A::$TA, B::$TB) where {T<:BlasFloat}
+        Abase, Bbase = _unbatch(A), _unbatch(B)
+
+        # Best case, we can call batched_gemm! immediately:
+        if Base.stride(Abase,1) == Base.stride(Bbase,1) == Base.stride(C,1) == 1
+            batched_gemm!($transA, $transB, one(T), _unbatch(A), _unbatch(B), zero(T), C)
+
+        # Second-best, can we fix it by Perm.ing the base, and adjusing 'T' label?
+        # But only if we won't produce BatchedTranspose(BatchedAdjoint(complex array)).
+        elseif Base.stride(Abase,2) == 1 && !(T<:Complex && $TA<:BatchedAdjoint)
+            newAbase = batched_transpose(PermutedDimsArray(Abase, (2,1,3)))
+            # return batched_try_gemm!(C, $fA(newAbase), B)
+            return batched_mul!(C, $fA(newAbase), B)
+        elseif Base.stride(Bbase,2) == 1 && !(T<:Complex && $TB<:BatchedAdjoint)
+            newBbase = batched_transpose(PermutedDimsArray(Bbase, (2,1,3)))
+            # return batched_try_gemm!(C, A, $fB(newBbase))
+            return batched_mul!(C, A, $fB(newBbase))
+
+        # Fallback, e.g when Base.stride(A,3)==1
+        else
+            batched_mul_generic!(C, A, B)
+        end
         C
     end
+
 end
 
 # fallback
+
+batched_mul!(C::AbstractArray{<:Any,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3}) = batched_mul_generic!(C, A, B)
 
 _BATCHED_LIST = [
     (:(AbstractArray{<:Any, 3}), :identity),
@@ -56,18 +121,15 @@ _BATCHED_LIST = [
     (:BatchedAdjoint, :adjoint),
 ]
 for (TA, fA) in _BATCHED_LIST, (TB, fB) in _BATCHED_LIST
-    @eval function batched_mul!(C::AbstractArray{<:Any, 3}, A::$TA, B::$TB)
+
+    @eval function batched_mul_generic!(C::AbstractArray{<:Any, 3}, A::$TA, B::$TB)
         axes(A, 3) == axes(B, 3) == axes(C, 3) || throw(DimensionMismatch("batch size mismatch"))
-        if A isa PermutedDimsArray{<:BlasFloat,3,(2,1,3)}
-            return batched_mul!(C, batched_transpose(parent(A)), B)
-        elseif B isa PermutedDimsArray{<:BlasFloat,3,(2,1,3)}
-            return batched_mul!(C, A, batched_transpose(parent(B)))
-        end
         @debug "calling fallback method for batched_mul!" typeof(A) typeof(B) typeof(C)
-        A′, B′ = _unbatch(A), _unbatch(B)
+        Abase, Bbase = _unbatch(A), _unbatch(B)
         @inbounds for k in axes(C, 3)
-            @views mul!(C[:,:,k], $fA(A′[:,:,k]), $fB(B′[:,:,k]))
+            @views mul!(C[:,:,k], $fA(Abase[:,:,k]), $fB(Bbase[:,:,k]))
         end
         C
     end
+
 end

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -94,9 +94,9 @@ for (gemm, elt) in gemm_datatype_mappings
                       ptrB, max(1,Base.stride(B,2)), beta, ptrC,
                       max(1,Base.stride(C,2)))
 
-                ptrA += size(A, 1) * size(A, 2) * sizeof($elt)
-                ptrB += size(B, 1) * size(B, 2) * sizeof($elt)
-                ptrC += size(C, 1) * size(C, 2) * sizeof($elt)
+                ptrA += Base.stride(A, 3) * sizeof($elt)
+                ptrB += Base.stride(B, 3) * sizeof($elt)
+                ptrC += Base.stride(C, 3) * sizeof($elt)
             end
 
             C

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -25,82 +25,93 @@ end
 using Base.CoreLogging: Debug
 
 @testset "batched_mul: Float64 * $TB" for TB in [Float64, Float32]
+    @testset "real" begin
 
-    A = randn(7,5,3)
-    B = randn(TB, 5,7,3)
-    C = randn(7,6,3)
-    A_, C_ = TB.(A), TB.(C)
+        A = randn(7,5,3)
+        B = randn(TB, 5,7,3)
+        C = randn(7,6,3)
+        A_, C_ = TB.(A), TB.(C)
 
-    @test batched_mul(A, B) ≈ bmm_test(A, B)
-    @test batched_mul(batched_transpose(A), batched_transpose(B)) ≈ bmm_test(A, B; transA = true, transB = true)
-    @test batched_mul(batched_transpose(A), C_) ≈ bmm_test(A, C_; transA = true)
-    @test batched_mul(PermutedDimsArray(A, (2,1,3)), C_) ≈ bmm_test(A, C_; transA = true)
-    @test batched_mul(A, batched_transpose(A_)) ≈ bmm_test(A, A_; transB = true)
-    @test batched_mul(A, PermutedDimsArray(A_, (2,1,3))) ≈ bmm_test(A, A_; transB = true)
+        @test batched_mul(A, B) ≈ bmm_test(A, B)
+        @test batched_mul(batched_transpose(A), batched_transpose(B)) ≈ bmm_test(A, B; transA = true, transB = true)
+        @test batched_mul(batched_transpose(A), C_) ≈ bmm_test(A, C_; transA = true)
+        @test batched_mul(PermutedDimsArray(A, (2,1,3)), C_) ≈ bmm_test(A, C_; transA = true)
+        @test batched_mul(A, batched_transpose(A_)) ≈ bmm_test(A, A_; transB = true)
+        @test batched_mul(A, PermutedDimsArray(A_, (2,1,3))) ≈ bmm_test(A, A_; transB = true)
 
-    @test batched_transpose(batched_transpose(A)) === A
-    @test batched_adjoint(batched_adjoint(A)) === A
-    # mixed wrappers
-    @test batched_transpose(batched_adjoint(A)) === A
-    @test batched_adjoint(batched_transpose(A)) === A
-    @test batched_transpose(PermutedDimsArray(A, (2,1,3))) === A
-    @test batched_adjoint(PermutedDimsArray(A, (2,1,3))) === A
+        if TB == Float64
+            # check that these go to gemm!, not fallback:
+            @test_logs min_level=Debug batched_mul(A, B)
+            @test_logs min_level=Debug batched_mul(A, PermutedDimsArray(A_, (2,1,3)))
+            @test_logs min_level=Debug batched_mul(PermutedDimsArray(A_, (2,1,3)), C)
+        else
+            # check that these write logging message:
+            @test_logs min_level=Debug (:debug,
+                "calling fallback method for batched_mul!") batched_mul(A, B)
+            @test_logs min_level=Debug (:debug,
+                "calling fallback method for batched_mul!") batched_mul(A, PermutedDimsArray(A_, (2,1,3)))
+        end
 
-    if TB == Float64
-        # check that these go to gemm!, not fallback:
-        @test_logs min_level=Debug batched_mul(A, B)
-        @test_logs min_level=Debug batched_mul(A, PermutedDimsArray(A_, (2,1,3)))
-        @test_logs min_level=Debug batched_mul(PermutedDimsArray(A_, (2,1,3)), C)
-    else
-        # check that these write logging message:
-        @test_logs min_level=Debug (:debug,
-            "calling fallback method for batched_mul!") batched_mul(A, B)
-        @test_logs min_level=Debug (:debug,
-            "calling fallback method for batched_mul!") batched_mul(A, PermutedDimsArray(A_, (2,1,3)))
+        @test batched_transpose(batched_transpose(A)) === A
+        @test batched_adjoint(batched_adjoint(A)) === A
+        # mixed wrappers
+        @test batched_transpose(batched_adjoint(A)) === A
+        @test batched_adjoint(batched_transpose(A)) === A
+        @test batched_transpose(PermutedDimsArray(A, (2,1,3))) === A
+        @test batched_adjoint(PermutedDimsArray(A, (2,1,3))) === A
+
     end
+    @testset "complex" begin
 
+        cA = randn(Complex{Float64}, 7,5,3)
+        cB = randn(Complex{TB}, 5,7,3)
+        cC = randn(Complex{Float64}, 7,6,3)
+        cA_, cC_ = complex(TB).(cA), complex(TB).(cC)
 
-    cA = randn(Complex{Float64}, 7,5,3)
-    cB = randn(Complex{TB}, 5,7,3)
-    cC = randn(Complex{Float64}, 7,6,3)
-    cA_, cC_ = complex(TB).(cA), complex(TB).(cC)
+        @test batched_mul(cA, cB) ≈ bmm_adjtest(cA, cB)
+        @test batched_mul(batched_adjoint(cA), batched_adjoint(cB)) ≈
+            bmm_adjtest(cA, cB; adjA = true, adjB = true)
+        @test batched_mul(batched_adjoint(cA), cC_) ≈ bmm_adjtest(cA, cC_; adjA = true)
+        @test batched_mul(cA, batched_adjoint(cA_)) ≈ bmm_adjtest(cA, cA_; adjB = true)
 
-    @test batched_mul(cA, cB) ≈ bmm_adjtest(cA, cB)
-    @test batched_mul(batched_adjoint(cA), batched_adjoint(cB)) ≈
-        bmm_adjtest(cA, cB; adjA = true, adjB = true)
-    @test batched_mul(batched_adjoint(cA), cC_) ≈ bmm_adjtest(cA, cC_; adjA = true)
-    @test batched_mul(cA, batched_adjoint(cA_)) ≈ bmm_adjtest(cA, cA_; adjB = true)
+        if TB == Float64
+            @test_logs min_level=Debug batched_mul(cA, cB)
+            @test_logs min_level=Debug batched_mul(cA, PermutedDimsArray(cA_, (2,1,3)))
+        end
 
-    @test batched_adjoint(batched_adjoint(cA)) === cA
-    @test batched_transpose(batched_transpose(cA)) === cA
-    @test batched_transpose(PermutedDimsArray(cA, (2,1,3))) === cA
-    @test batched_adjoint(batched_transpose(cA)) != cA
+        @test batched_adjoint(batched_adjoint(cA)) === cA
+        @test batched_transpose(batched_transpose(cA)) === cA
+        @test batched_transpose(PermutedDimsArray(cA, (2,1,3))) === cA
+        @test batched_adjoint(batched_transpose(cA)) != cA
 
-    if TB == Float64
-        @test_logs min_level=Debug batched_mul(cA, cB)
-        @test_logs min_level=Debug batched_mul(cA, PermutedDimsArray(cA_, (2,1,3)))
     end
+    @testset "integer" begin
 
-    @test copy(cA[:,:,1]') isa Array
-    @test copy(transpose(cA[:,:,1])) isa Array
-    @test copy(batched_adjoint(cA)) isa Array
-    @test copy(batched_transpose(cA)) isa Array
+        cA = randn(Complex{Float64}, 7,5,3)
+        TBi = TB==Float64 ? Int64 : Int32
+        iA = rand(1:99, 7,5,3)
+        iB = TBi.(rand(1:99, 5,7,3))
+        iC = zeros(Int, 7,6,3)
 
-    @test strides(batched_transpose(cA)) == strides(PermutedDimsArray(cA, (2,1,3)))
-    @test strides(batched_adjoint(cA)) == (7, 1, 35)
+        @test batched_mul(iA, iB) == bmm_adjtest(iA, iB)
+        @test batched_mul(cA, iB) ≈ bmm_adjtest(cA, iB)
 
+    end
+    @testset "misc" begin
 
-    cA = randn(Complex{Float64}, 7,5,3)
-    TBi = TB==Float64 ? Int64 : Int32
-    iA = rand(1:99, 7,5,3)
-    iB = TB.(rand(1:99, 5,7,3))
-    iC = zeros(Int, 7,6,3)
-    @test batched_mul(iA, iB) == bmm_adjtest(iA, iB)
-    @test batched_mul(cA, iB) ≈ bmm_adjtest(cA, iB)
+        cA = randn(Complex{Float64}, 7,5,3)
 
+        @test copy(cA[:,:,1]') isa Array
+        @test copy(transpose(cA[:,:,1])) isa Array
+        @test copy(batched_adjoint(cA)) isa Array
+        @test copy(batched_transpose(cA)) isa Array
 
-    @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 2,2,10))
-    @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 10,2,2))
-    @test_throws Exception batched_mul!(zeros(2,2,10), rand(2,2,2), rand(TB, 2,2,2))
+        @test strides(batched_transpose(cA)) == strides(PermutedDimsArray(cA, (2,1,3)))
+        @test strides(batched_adjoint(cA)) == (7, 1, 35)
 
+        @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 2,2,10))
+        @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 10,2,2))
+        @test_throws Exception batched_mul!(zeros(2,2,10), rand(2,2,2), rand(TB, 2,2,2))
+
+    end
 end

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -117,7 +117,7 @@ using Base.CoreLogging: Debug
     end
 end
 
-using NNlin: _perm12
+using NNlib: _perm12
 @testset "_perm12" begin
 
     A = rand(Int8, 3,3,3)

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -6,7 +6,7 @@ using NNlib
 using NNlib: memory_layout, storage_type, batched_mul!
 
 using ArrayLayouts
-using ArrayLayouts: DenseColumnMajor, FirstMajor, SecondMajor, FirstUnion, StridedLayout
+using ArrayLayouts: DenseColumnMajor, UnitStride, StridedLayout, ConjLayout
 
 # Minimal wrapper which ArrayLayouts knows nothing about
 struct TestWrap{T,AT} <: AbstractArray{T,3}
@@ -25,12 +25,12 @@ Base.unsafe_convert(::Type{Ptr{T}}, A::TestWrap{T}) where {T} =
     A = randn(ComplexF64, 7,5,3)
     @test memory_layout(A) == DenseColumnMajor()
 
-    @test memory_layout(batched_transpose(A)) == SecondMajor()
-    @test memory_layout(batched_adjoint(A)) == ConjLayout{SecondMajor}()
+    @test memory_layout(batched_transpose(A)) == UnitStride{2}()
+    @test memory_layout(batched_adjoint(A)) == ConjLayout{UnitStride{2}}()
 
-    @test memory_layout(PermutedDimsArray(A, (1,3,2))) == FirstMajor()
-    @test memory_layout(PermutedDimsArray(A, (2,1,3))) == SecondMajor()
-    @test memory_layout(PermutedDimsArray(A, (2,3,1))) == StridedLayout()
+    @test memory_layout(PermutedDimsArray(A, (1,3,2))) == UnitStride{1}()
+    @test memory_layout(PermutedDimsArray(A, (2,1,3))) == UnitStride{2}()
+    @test memory_layout(PermutedDimsArray(A, (2,3,1))) == UnitStride{3}()
 
     @test memory_layout(TestWrap(A)) == StridedLayout()
     @test memory_layout(TestWrap(batched_transpose(A))) == StridedLayout()

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -86,6 +86,9 @@ using Base.CoreLogging: Debug
     @test copy(batched_adjoint(cA)) isa Array
     @test copy(batched_transpose(cA)) isa Array
 
+    @test strides(batched_transpose(cA)) == strides(PermutedDimsArray(cA, (2,1,3)))
+    @test strides(batched_adjoint(cA)) == (7, 1, 35)
+
 
     cA = randn(Complex{Float64}, 7,5,3)
     TBi = TB==Float64 ? Int64 : Int32

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -116,3 +116,41 @@ using Base.CoreLogging: Debug
 
     end
 end
+
+using NNlin: _perm12
+@testset "_perm12" begin
+
+    A = rand(Int8, 3,3,3)
+
+    for a in 1:3, b in 1:3, c in 1:3
+        perm = (a,b,c)
+        isperm(perm) || continue
+
+        B = permutedims(A, perm)
+        C = PermutedDimsArray(A, perm)
+        @test _perm12(B) == _perm12(C)
+    end
+
+end
+
+
+using NNlib: is_strided
+@testset "is_strided" begin
+
+    M = ones(10,10)
+
+    @test is_strided(M)
+    @test is_strided(view(M, 1:2:5,:))
+    @test is_strided(PermutedDimsArray(M, (2,1)))
+
+    @test !is_strided(reshape(view(M, 1:2:10,:), 10,:))
+    @test !is_strided((M.+im)')
+    @test !is_strided(Diagonal(ones(3)))
+    #=
+    using SparseArrays
+    @test !is_strided(sparse(M))
+    using NamedDims
+    @test is_strided(NamedDimsArray(M,(:a, :b))) # and 0.029 ns, 0 allocations
+    =#
+
+end

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -42,6 +42,29 @@ Base.unsafe_convert(::Type{Ptr{T}}, A::TestWrap{T}) where {T} =
 
 end
 
+#=
+for n in [2,10,50]
+    @show n
+    A = rand(n,n,n); B = PermutedDimsArray(rand(n,n,n), (2,1,3)); C = similar(A);
+    @btime batched_mul!($C, $A, $B);
+    A_ = TestWrap(A); B_ = TestWrap(B); C_ = TestWrap(C);
+    @btime batched_mul!($C, $A_, $B); # runtime strides for 1
+    @btime batched_mul!($C_, $A_, $B_); # or for all
+end
+# n = 2
+#   266.969 ns (0 allocations: 0 bytes)
+#   420.025 ns (1 allocation: 32 bytes)
+#   846.074 ns (5 allocations: 128 bytes)
+# n = 10
+#   2.943 μs (0 allocations: 0 bytes)
+#   3.117 μs (1 allocation: 32 bytes)
+#   3.594 μs (5 allocations: 128 bytes)
+# n = 50
+#   421.166 μs (0 allocations: 0 bytes)
+#   421.283 μs (1 allocation: 32 bytes)
+#   421.789 μs (5 allocations: 128 bytes)
+=#
+
 function bmm_test(a,b; transA = false, transB = false)
     bs = size(a,3)
     transA && (a = permutedims(a, [2,1,3]))

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -182,17 +182,17 @@ end
             end
 
         end
-        @testset "batched_mul! with permuted output" begin # this is broken!
+        # @testset "batched_mul! with permuted output" begin # this is broken!
 
-            A = rand(3,3,3)
-            B = rand(3,3,3)
-            C = PermutedDimsArray(zeros(3,3,3), (2,1,3))
-            @test_broken batched_mul(A, B) ≈ batched_mul!(C, B, A)
+        #     A = rand(3,3,3)
+        #     B = rand(3,3,3)
+        #     C = PermutedDimsArray(zeros(3,3,3), (2,1,3))
+        #     @test_broken batched_mul(A, B) ≈ batched_mul!(C, B, A)
 
-            B = batched_adjoint(rand(3,3,3))
-            C = PermutedDimsArray(zeros(3,3,3), (3,1,2))
-            @test_broken batched_mul(A, B) ≈ batched_mul!(C, B, A)
+        #     B = batched_adjoint(rand(3,3,3))
+        #     C = PermutedDimsArray(zeros(3,3,3), (3,1,2))
+        #     @test_broken batched_mul(A, B) ≈ batched_mul!(C, B, A)
 
-        end
+        # end
     end
 end

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -22,37 +22,79 @@ function bmm_adjtest(a,b; adjA = false, adjB = false)
     cat(c...; dims = 3)
 end
 
+using Base.CoreLogging: Debug
 
 @testset "batched_mul: Float64 * $TB" for TB in [Float64, Float32]
 
     A = randn(7,5,3)
     B = randn(TB, 5,7,3)
     C = randn(7,6,3)
+    A_, C_ = TB.(A), TB.(C)
 
     @test batched_mul(A, B) ≈ bmm_test(A, B)
     @test batched_mul(batched_transpose(A), batched_transpose(B)) ≈ bmm_test(A, B; transA = true, transB = true)
-    @test batched_mul(batched_transpose(A), C) ≈ bmm_test(A, C; transA = true)
-    @test batched_mul(A, batched_transpose(A)) ≈ bmm_test(A, A; transB = true)
+    @test batched_mul(batched_transpose(A), C_) ≈ bmm_test(A, C_; transA = true)
+    @test batched_mul(PermutedDimsArray(A, (2,1,3)), C_) ≈ bmm_test(A, C_; transA = true)
+    @test batched_mul(A, batched_transpose(A_)) ≈ bmm_test(A, A_; transB = true)
+    @test batched_mul(A, PermutedDimsArray(A_, (2,1,3))) ≈ bmm_test(A, A_; transB = true)
+
+    @test batched_transpose(batched_transpose(A)) === A
+    @test batched_adjoint(batched_adjoint(A)) === A
+    # mixed wrappers
+    @test batched_transpose(batched_adjoint(A)) === A
+    @test batched_adjoint(batched_transpose(A)) === A
+    @test batched_transpose(PermutedDimsArray(A, (2,1,3))) === A
+    @test batched_adjoint(PermutedDimsArray(A, (2,1,3))) === A
+
+    if TB == Float64
+        # check that these go to gemm!, not fallback:
+        @test_logs min_level=Debug batched_mul(A, B)
+        @test_logs min_level=Debug batched_mul(A, PermutedDimsArray(A_, (2,1,3)))
+        @test_logs min_level=Debug batched_mul(PermutedDimsArray(A_, (2,1,3)), C)
+    else
+        # check that these write logging message:
+        @test_logs min_level=Debug (:debug,
+            "calling fallback method for batched_mul!") batched_mul(A, B)
+        @test_logs min_level=Debug (:debug,
+            "calling fallback method for batched_mul!") batched_mul(A, PermutedDimsArray(A_, (2,1,3)))
+    end
 
 
     cA = randn(Complex{Float64}, 7,5,3)
     cB = randn(Complex{TB}, 5,7,3)
     cC = randn(Complex{Float64}, 7,6,3)
+    cA_, cC_ = complex(TB).(cA), complex(TB).(cC)
 
     @test batched_mul(cA, cB) ≈ bmm_adjtest(cA, cB)
-    @test batched_mul(batched_adjoint(cA), batched_adjoint(cB)) ≈ bmm_adjtest(cA, cB; adjA = true, adjB = true)
-    @test batched_mul(batched_adjoint(cA), cC) ≈ bmm_adjtest(cA, cC; adjA = true)
-    @test batched_mul(cA, batched_adjoint(cA)) ≈ bmm_adjtest(cA, cA; adjB = true)
+    @test batched_mul(batched_adjoint(cA), batched_adjoint(cB)) ≈
+        bmm_adjtest(cA, cB; adjA = true, adjB = true)
+    @test batched_mul(batched_adjoint(cA), cC_) ≈ bmm_adjtest(cA, cC_; adjA = true)
+    @test batched_mul(cA, batched_adjoint(cA_)) ≈ bmm_adjtest(cA, cA_; adjB = true)
 
-    @test batched_transpose(batched_transpose(A)) === A
     @test batched_adjoint(batched_adjoint(cA)) === cA
+    @test batched_transpose(batched_transpose(cA)) === cA
+    @test batched_transpose(PermutedDimsArray(cA, (2,1,3))) === cA
+    @test batched_adjoint(batched_transpose(cA)) != cA
 
+    if TB == Float64
+        @test_logs min_level=Debug batched_mul(cA, cB)
+        @test_logs min_level=Debug batched_mul(cA, PermutedDimsArray(cA_, (2,1,3)))
+    end
+
+    @test copy(cA[:,:,1]') isa Array
+    @test copy(transpose(cA[:,:,1])) isa Array
+    @test copy(batched_adjoint(cA)) isa Array
+    @test copy(batched_transpose(cA)) isa Array
+
+
+    cA = randn(Complex{Float64}, 7,5,3)
     TBi = TB==Float64 ? Int64 : Int32
     iA = rand(1:99, 7,5,3)
     iB = TB.(rand(1:99, 5,7,3))
     iC = zeros(Int, 7,6,3)
     @test batched_mul(iA, iB) == bmm_adjtest(iA, iB)
     @test batched_mul(cA, iB) ≈ bmm_adjtest(cA, iB)
+
 
     @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 2,2,10))
     @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 10,2,2))

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -32,9 +32,9 @@ Base.unsafe_convert(::Type{Ptr{T}}, A::TestWrap{T}) where {T} =
     @test memory_layout(PermutedDimsArray(A, (2,1,3))) == UnitStride{2}()
     @test memory_layout(PermutedDimsArray(A, (2,3,1))) == UnitStride{3}()
 
-    @test memory_layout(TestWrap(A)) == StridedLayout()
-    @test memory_layout(TestWrap(batched_transpose(A))) == StridedLayout()
-    @test memory_layout(TestWrap(batched_adjoint(A))) == ConjLayout{StridedLayout}()
+    @test memory_layout(TestWrap(A)) == UnitStride{1}()
+    @test memory_layout(TestWrap(batched_transpose(A))) == UnitStride{2}()
+    @test memory_layout(TestWrap(batched_adjoint(A))) == ConjLayout{UnitStride{2}}()
     @test stride(TestWrap(A),3) == stride(A,3)
 
     @test storage_type(TestWrap(A)) == typeof(A)
@@ -182,17 +182,6 @@ end
             end
 
         end
-        # @testset "batched_mul! with permuted output" begin # this is broken!
 
-        #     A = rand(3,3,3)
-        #     B = rand(3,3,3)
-        #     C = PermutedDimsArray(zeros(3,3,3), (2,1,3))
-        #     @test_broken batched_mul(A, B) ≈ batched_mul!(C, B, A)
-
-        #     B = batched_adjoint(rand(3,3,3))
-        #     C = PermutedDimsArray(zeros(3,3,3), (3,1,2))
-        #     @test_broken batched_mul(A, B) ≈ batched_mul!(C, B, A)
-
-        # end
     end
 end

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -3,7 +3,7 @@ using Test
 using Base.CoreLogging: Debug
 
 using NNlib
-using NNlib: memory_layout, storage_type, batched_mul!
+using NNlib: memory_layout, storage_type, batched_mul!, BatchedAdjoint
 
 using ArrayLayouts
 using ArrayLayouts: DenseColumnMajor, UnitStride, StridedLayout, ConjLayout
@@ -130,7 +130,8 @@ end
         @test batched_adjoint(batched_adjoint(cA)) === cA
         @test batched_transpose(batched_transpose(cA)) === cA
         @test batched_transpose(PermutedDimsArray(cA, (2,1,3))) === cA
-        @test batched_adjoint(batched_transpose(cA)) != cA
+        @test batched_adjoint(batched_transpose(cA)) == conj.(cA)
+        @test batched_transpose(batched_adjoint(cA)) isa BatchedAdjoint
 
     end
     @testset "integer" begin

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -133,7 +133,7 @@ using NNlib: _perm12
 
 end
 
-
+using LinearAlgebra
 using NNlib: is_strided
 @testset "is_strided" begin
 

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -57,8 +57,9 @@ using Base.CoreLogging: Debug
         # mixed wrappers
         @test batched_transpose(batched_adjoint(A)) === A
         @test batched_adjoint(batched_transpose(A)) === A
-        @test batched_transpose(PermutedDimsArray(A, (2,1,3))) === A
-        @test batched_adjoint(PermutedDimsArray(A, (2,1,3))) === A
+        # this should NOT unwrap:
+        @test batched_transpose(PermutedDimsArray(A, (2,1,3))) !== A
+        @test batched_adjoint(PermutedDimsArray(A, (2,1,3))) !== A
 
     end
     @testset "complex" begin
@@ -81,7 +82,7 @@ using Base.CoreLogging: Debug
 
         @test batched_adjoint(batched_adjoint(cA)) === cA
         @test batched_transpose(batched_transpose(cA)) === cA
-        @test batched_transpose(PermutedDimsArray(cA, (2,1,3))) === cA
+        @test batched_transpose(PermutedDimsArray(cA, (2,1,3))) !== cA
         @test batched_adjoint(batched_transpose(cA)) != cA
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using NNlib, Test
 
-# include("activation.jl")
-# include("conv.jl")
+include("activation.jl")
+include("conv.jl")
 include("batchedmul.jl")
-# include("pooling.jl")
+include("pooling.jl")
 include("inference.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using NNlib, Test
 
-include("activation.jl")
-include("conv.jl")
+# include("activation.jl")
+# include("conv.jl")
 include("batchedmul.jl")
-include("pooling.jl")
+# include("pooling.jl")
 include("inference.jl")


### PR DESCRIPTION
I think that we can allow `batched_gemm!` to be called on many (but not all) `PermutedDimsArray`s, and this is generally much faster than first calling `permutedims`. This PR is an attempt to implement this. It also extends `batched_mul!` to take `α, β` scales like `mul!`.

EARLIER:
* It adds methods to treat `PermutedDimsArray{<:Number,3,(2,1,3)}` as equivalent to `BatchedTranspose` (see https://github.com/FluxML/Zygote.jl/issues/552) and to allow `batched_adjoint ∘ batched_transpose` to be trivial on real-valued arrays.
* It deletes the method for `copy(::BatchedAdjoint)` etc, from #100, to return an `Array` like `copy(::Adjoint)`.