### PR TITLE
Allow batched_mul to work through PermutedDimsArray, II

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Compat = "3.13"
+Compat = "3.14"
 Requires = "0.5, 1.0"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 version = "0.7.5"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -10,6 +11,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Compat = "3.13"
 Requires = "0.5, 1.0"
 julia = "1.3"
 

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -9,10 +9,10 @@ _batched_doc = """
 Equivalent to applying `transpose` or `adjoint` to each matrix `A[:,:,k]`.
 
 These exist to control how `batched_mul` behaves,
-as it operated on such matrix slices of an array with `ndims(A)==3`.
+as it operates on such matrix slices of an array with `ndims(A)==3`.
 
-For arrays of real numbers, `batched_transpose(A) == PermutedDimsArray(A, (2,1,3))`,
-which is a more widely-supported wrapper, and also understood by `batched_mul`.
+`PermutedDimsArray(A, (2,1,3))` is equivalent to `batched_transpose(A)`,
+and is also understood by `batched_mul` (and more widely supported elsewhere).
 
     BatchedTranspose{T, S} <: AbstractBatchedMatrix{T, 3}
     BatchedAdjoint{T, S}

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -85,12 +85,12 @@ end
 
 _batched_mul!(::Type, C, A, B, α::Number, β::Number) = batched_mul_generic!(C, A, B, α, β)
 
-_batched_mul!(DT::Type{<:DenseArray{T}}, C, A, B, α::Number, β::Number) where {T<:BlasFloat} =
+_batched_mul!(::Type{DT}, C, A, B, α::Number, β::Number) where {DT<:DenseArray{T}} where {T<:BlasFloat} =
     _batched_try_gemm!(DT, C, A, B, α, β)
 
-function _batched_try_gemm!(DT::Type{<:DenseArray{T}}, C, A, B, α::Number, β::Number) where {T<:BlasFloat}
+function _batched_try_gemm!(::Type{DT}, C, A, B, α::Number, β::Number) where {DT<:DenseArray{T}} where {T<:BlasFloat}
 
-    alpha, beta = promote(α, β, zero(T)) # trick from https://github.com/JuliaLang/julia/pull/33229
+    alpha, beta = promote(α, β, zero(T))
     alpha isa T && beta isa T || return batched_mul_generic!(C, A, B, α, β)
 
     are_strided(C, _unbatch(A), _unbatch(B)) || return batched_mul_generic!(C, A, B, α, β)

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -1,13 +1,23 @@
-# batch-wise matrix multiplication
-# wrapper for batched_gemm!
+
 export batched_mul, batched_transpose, batched_adjoint
 
 include("./batchedadjtrans.jl")
+
+using LinearAlgebra: BlasFloat, Transpose, Adjoint
+
+_unbatch(A) = A
+_unbatch(A::BatchedAdjOrTrans) = parent(A)
 
 """
     batched_mul(A, B) -> C
 
 Batched matrix multiplication. Result has `C[:,:,k] == A[:,:,k] * B[:,:,k]` for all `k`.
+
+To transpose each matrix apply `batched_transpose` to the array,
+and similarly `batched_adjoint`. Other permutations are also handled efficiently,
+provided that the batch index `k` is not the first dimension of the underlying array.
+Thus `PermutedDimsArray(::Array, (1,3,2))` and `PermutedDimsArray(::Array, (3,1,2))` are fine,
+but `PermutedDimsArray(::Array, (3,2,1))` must use the fallback `batched_mul_generic!`.
 """
 function batched_mul(A::AbstractArray{T1, 3}, B::AbstractArray{T2, 3}) where {T1, T2}
     axes(A, 3) == axes(B, 3) || throw(DimensionMismatch("batch size mismatch"))
@@ -18,47 +28,173 @@ end
 
 """
     batched_mul!(C, A, B) -> C
+    batched_mul!(C, A, B, α=1, β=0)
 
-In-place batched matrix multiplication,
-equivalent to `mul!(C[:,:,k], A[:,:,k], B[:,:,k])` for all `k`.
+In-place batched matrix multiplication, equivalent to
+`mul!(C[:,:,k], A[:,:,k], B[:,:,k], α, β)` for all `k`.
+
+This will call `batched_gemm!` whenever possible. For real arrays this means that,
+for `X ∈ [A,B,C]`, either `strides(X,1)==1` or `strides(X,2)==1`, the latter may
+be caused by `batched_transpose` or by for instance `PermutedDimsArray(::Array, (3,1,2))`.
+
+For complex arrays, the wrapper made by `batched_adjoint` must be outermost to be seen,
+and in this case `stride(A::BatchedAdjoint,2) == 1` is not optional.
+
+The fallback method calls 5-argument `mul!` on Julia 1.3 and later,
+on earlier verions it will thrown an error if `α!=1` or `β!=0`.
 """
-function batched_mul! end
-
-_unbatch(A) = A
-_unbatch(A::BatchedAdjOrTrans) = A.parent
-
-# batched_gemm!
-
-const _GemmFloat = Union{Float64, Float32, ComplexF64, ComplexF32}
-
-_BATCHED_GEMM_LIST = [
-    (:(StridedArray{T, 3}), 'N'),
-    (:(BatchedTranspose{T, <:StridedArray{T, 3}}), 'T'),
-    (:(BatchedAdjoint{T, <:StridedArray{T, 3}}), 'C')
-]
-
-for (TA, transA) in _BATCHED_GEMM_LIST, (TB, transB) in _BATCHED_GEMM_LIST
-    @eval function batched_mul!(C::StridedArray{T, 3}, A::$TA, B::$TB) where {T<:_GemmFloat}
-        batched_gemm!($transA, $transB, one(T), _unbatch(A), _unbatch(B), zero(T), C)
-        C
-    end
+function batched_mul!(C::AbstractArray{T,3}, A::AbstractArray{<:Any,3}, B::AbstractArray{<:Any,3},
+        α::Number=one(T), β::Number=zero(T)) where {T}
+    _batched_mul!(storage_type(C,A,B), C, A, B, α, β)
+    C
 end
 
-# fallback
+_batched_mul!(::Type, C, A, B, α::Number, β::Number) = batched_mul_generic!(C, A, B, α, β)
+
+function _batched_mul!(::Array{T}, C, A, B, α::Number, β::Number) where {T<:BlasFloat}
+
+    is_strided(C) && is_strided(_unbatch(A)) && is_strided(_unbatch(B)) ||
+        return batched_mul_generic!(C, A, B, α, β)
+
+    if Base.stride(C,1) == 1
+    elseif Base.stride(C,2) == 1
+        return batched_mul!(batched_transpose(C), batched_transpose(B), batched_transpose(A), α, β)
+    else
+        return batched_mul_generic!(C, A, B, α, β)
+    end
+
+    blasA, transA = if A isa BatchedAdjoint
+        Base.stride(parent(A),1) == 1 || return batched_mul_generic!(C, A, B, α, β)
+        parent(A), 'C'
+    elseif Base.stride(A,1) == 1
+        A, 'N'
+    elseif Base.stride(A,2) == 1
+        batched_transpose(A), 'T'
+    else
+        return batched_mul_generic!(C, A, B, α, β)
+    end
+
+    blasB, transB = if B isa BatchedAdjoint
+        Base.stride(parent(B),1) == 1 || return batched_mul_generic!(C, A, B, α, β)
+        parent(B), 'C'
+    elseif Base.stride(B,1) == 1
+        B, 'N'
+    elseif Base.stride(B,2) == 1
+        batched_transpose(B), 'T'
+    else
+        return batched_mul_generic!(C, A, B, α, β)
+    end
+
+    _batched_gemm!(transA, transB, convert(T,α), blasA, blasB, convert(T,β), C)
+    C
+end
+
+_batched_gemm!(::Type{<:Array}, transA::Char, transB::Char, α::Number, A, B, β::Number, C) =
+    batched_gemm!(transA, transB, α, A, B, β, C)
 
 _BATCHED_LIST = [
     (:(AbstractArray{<:Any, 3}), :identity),
-    (:(BatchedTranspose{<:Any, <:AbstractArray{<:Any, 3}}), :transpose),
-    (:(BatchedAdjoint{<:Any, <:AbstractArray{<:Any, 3}}), :adjoint)
+    (:BatchedTranspose,          :transpose),
+    (:BatchedAdjoint,            :adjoint),
 ]
 for (TA, fA) in _BATCHED_LIST, (TB, fB) in _BATCHED_LIST
-    @eval function batched_mul!(C::AbstractArray{<:Any, 3}, A::$TA, B::$TB)
+
+    @eval function batched_mul_generic!(C::AbstractArray{T, 3}, A::$TA, B::$TB,
+            α::Number=one(T), β::Number=zero(T)) where {T}
         axes(A, 3) == axes(B, 3) == axes(C, 3) || throw(DimensionMismatch("batch size mismatch"))
         @debug "calling fallback method for batched_mul!" typeof(A) typeof(B) typeof(C)
-        A′, B′ = _unbatch(A), _unbatch(B)
-        @inbounds for k in axes(C, 3)
-            @views mul!(C[:,:,k], $fA(A′[:,:,k]), $fB(B′[:,:,k]))
+        Abase, Bbase = _unbatch(A), _unbatch(B)
+
+        if VERSION >= v"1.3"
+            @inbounds for k in axes(C, 3)
+                @views mul!(C[:,:,k], $fA(Abase[:,:,k]), $fB(Bbase[:,:,k]), convert(T,α), convert(T,β))
+            end
+        else
+            α==1 && β==0 || throw(ArgumentError("5-arg batched_mul_generic! does not work on Julia < 1.3"))
+            @inbounds for k in axes(C, 3)
+                @views mul!(C[:,:,k], $fA(Abase[:,:,k]), $fB(Bbase[:,:,k]))
+            end
         end
+
         C
     end
+
+end
+
+"""
+    storage_type(A) -> Type
+
+Removes all wrappers to return the `Array` or `CuArray` (or whatever) type within.
+```
+julia> view(reshape(ones(10)',2,5),:, 3:4) |> storage_type
+Array{Float64,1}
+
+julia> reshape(sparse(rand(10)), 5,2) |> storage_type
+SparseVector{Float64,Int64}
+```
+"""
+function storage_type(A::AbstractArray)
+    P = parent(A)
+    typeof(A) === typeof(P) ? typeof(A) : storage_type(P)
+end
+storage_type(A) = typeof(A)
+
+"""
+    storage_type(A, B, C, ...) -> Type
+
+Reduces with `Base.promote_typejoin`, in order that this conveys useful information
+for dispatching to BLAS, rather than information about the storage to allocate:
+```
+julia> storage_type(rand(2), rand(Float32, 2))
+Array{T,1} where T
+
+julia> eltype(ans) <: LinearAlgebra.BlasFloat
+false
+
+julia> storage_type(rand(2), rand(2,3), rand(2,3,4))
+Array{Float64,N} where N
+```
+"""
+storage_type(A, Bs...) = Base.promote_typejoin(storage_type(A), storage_type(Bs...))
+
+
+"""
+    is_strided(A::AbstractArray) -> Bool
+
+This generalises `A isa StridedArray` to treat wrappers like `A::PermutedDimsArray`,
+for which it returns `is_strided(parent(A))`.
+
+Other wrappers (defined outside Base, LinearAlgebra) are assumed not to break
+strided-ness, and hence also return `is_strided(parent(A))`.
+This correctly handles things like `NamedDimsArray` wihch don't alter indexing.
+However, it's a little pessimistic in that e.g. a `view` of such a container will return
+`false`, even in cases where the same `view` of `parent(A)` would be a `StridedArray`.
+
+`A::Transpose` doesn't currently define `strides`, until that's fixed this returns `false`.
+The PR to fix that only defines `strides(::Adjoint{T})` for `T<:Real`, so this will follow.
+"""
+is_strided(A::StridedArray) = true
+is_strided(A) = false
+function is_strided(A::AbstractArray)
+    M = parentmodule(typeof(A))
+    if parent(A) === A # SparseMatrix, StaticArray, etc
+        false
+    elseif M === Base || M === Core || M ===LinearAlgebra
+        # bad reshapes, etc, plus Diagonal, UpperTriangular, etc.
+        false
+    else
+        is_strided(parent(A)) # PermutedDimsArray, NamedDimsArray
+    end
+end
+
+is_strided(A::BatchedAdjoint) = eltype(A) <: Real && is_strided(parent(A))
+is_strided(A::BatchedTranspose) = is_strided(parent(A))
+
+if hasmethod(Base.strides, Tuple{LinearAlgebra.Transpose})
+    # https://github.com/JuliaLang/julia/pull/29135
+    is_strided(A::LinearAlgebra.Transpose) = is_strided(parent(A))
+    is_strided(A::LinearAlgebra.Adjoint) = eltype(A) <: Real && is_strided(parent(A))
+else
+    is_strided(A::LinearAlgebra.Transpose) = false
+    is_strided(A::LinearAlgebra.Adjoint) = false
 end

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -54,7 +54,7 @@ end
 
 _batched_mul!(::Type, C, A, B, α::Number, β::Number) = batched_mul_generic!(C, A, B, α, β)
 
-function _batched_mul!(CT::Type{<:Array{T}}, C, A, B, α::Number, β::Number) where {T<:BlasFloat}
+function _batched_mul!(CT::Type{<:DenseArray{T}}, C, A, B, α::Number, β::Number) where {T<:BlasFloat}
 
     are_strided(C, _unbatch(A), _unbatch(B)) || return batched_mul_generic!(C, A, B, α, β)
 

--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -192,13 +192,13 @@ storage_type(A) = typeof(A)
 Reduces with `Base.promote_typejoin`, in order that this conveys useful information
 for dispatching to BLAS. It does not tell you what container to allocate:
 ```
-julia> storage_type(rand(2), rand(Float32, 2))
+julia> storage_typejoin(rand(2), rand(Float32, 2))
 Array{T,1} where T
 
 julia> eltype(ans) <: LinearAlgebra.BlasFloat
 false
 
-julia> storage_type(rand(2), rand(2,3), rand(2,3,4))
+julia> storage_typejoin(rand(2), rand(2,3), rand(2,3,4))
 Array{Float64,N} where N
 ```
 """

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -94,9 +94,9 @@ for (gemm, elt) in gemm_datatype_mappings
                       ptrB, max(1,Base.stride(B,2)), beta, ptrC,
                       max(1,Base.stride(C,2)))
 
-                ptrA += size(A, 1) * size(A, 2) * sizeof($elt)
-                ptrB += size(B, 1) * size(B, 2) * sizeof($elt)
-                ptrC += size(C, 1) * size(C, 2) * sizeof($elt)
+                ptrA += Base.stride(A, 3) * sizeof($elt)
+                ptrB += Base.stride(B, 3) * sizeof($elt)
+                ptrC += Base.stride(C, 3) * sizeof($elt)
             end
 
             C

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -25,9 +25,18 @@ function bmm_adjtest(a,b; adjA = false, adjB = false)
     cat(c...; dims = 3)
 end
 
+function half_batched_mul(x,y)
+    @assert size(y,3) == 1
+    d = size(x,2)
+    x_mat = reshape(permutedims(x, (1,3,2)),:,d)
+    y_mat = reshape(y,d,:)
+    z_mat = x_mat * y_mat
+    permutedims(reshape(z_mat, size(x,1), size(x,3), :), (1,3,2))
+end
 
 @testset "batched_mul: Float64 * $TB" for TB in [Float64, Float32]
 
+    # Real
     A = randn(7,5,3)
     B = randn(TB, 5,7,3)
     C = randn(7,6,3)
@@ -37,7 +46,7 @@ end
     @test batched_mul(batched_transpose(A), C) ≈ bmm_test(A, C; transA = true)
     @test batched_mul(A, batched_transpose(A)) ≈ bmm_test(A, A; transB = true)
 
-
+    # Complex
     cA = randn(Complex{Float64}, 7,5,3)
     cB = randn(Complex{TB}, 5,7,3)
     cC = randn(Complex{Float64}, 7,6,3)
@@ -47,9 +56,13 @@ end
     @test batched_mul(batched_adjoint(cA), cC) ≈ bmm_adjtest(cA, cC; adjA = true)
     @test batched_mul(cA, batched_adjoint(cA)) ≈ bmm_adjtest(cA, cA; adjB = true)
 
+    # Wrappers which cancel
     @test batched_transpose(batched_transpose(A)) === A
+    @test batched_transpose(PermutedDimsArray(A, (2,1,3))) === A
     @test batched_adjoint(batched_adjoint(cA)) === cA
+    @test batched_transpose(batched_adjoint(cA)) isa NNlib.BatchedAdjoint
 
+    # Integers
     TBi = TB==Float64 ? Int64 : Int32
     iA = rand(1:99, 7,5,3)
     iB = TB.(rand(1:99, 5,7,3))
@@ -57,10 +70,37 @@ end
     @test batched_mul(iA, iB) == bmm_adjtest(iA, iB)
     @test batched_mul(cA, iB) ≈ bmm_adjtest(cA, iB)
 
+    # Errors
     @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 2,2,10))
     @test_throws DimensionMismatch batched_mul(rand(2,2,2), rand(TB, 10,2,2))
     @test_throws Exception batched_mul!(zeros(2,2,10), rand(2,2,2), rand(TB, 2,2,2))
 
+    # PermutedDimsArrays
+    for perm in [(1,3,2), (2,1,3)], fun in [identity, batched_adjoint], ty in [identity, complex]
+        A = randn(ty(Float64), 4,4,4)
+        B = randn(ty(TB), 4,4,4)
+        @test batched_mul(fun(A), PermutedDimsArray(B, perm)) ≈ batched_mul(fun(A), permutedims(B, perm))
+        @test batched_mul(fun(PermutedDimsArray(A, perm)), B) ≈ batched_mul(fun(permutedims(A, perm)), B)
+        # when TB=Float64, only the case  (2,1,3) batched_adjoint complex  goes to fallback
+    end
+
+    # PermutedDimsArray output
+    A′ = randn(4,3,2)
+    B′ = batched_adjoint(randn(TB, 5,3,2))
+    C1 = batched_mul(A′, B′) # size 4,5,2
+    C2 = PermutedDimsArray(zeros(5,2,4), (3,1,2)) # size 4,5,2
+    @test C1 ≈ batched_mul!(C2, A′, B′) # Float64: "Debug: transposing C = A * B into Cᵀ = Bᵀ * Aᵀ"
+    @test C1 ≈ C2
+
+    # 5-arg mul!
+    @test 10 .* C1 ≈ batched_mul!(C2, A′, B′, 10)
+    C2 .= 10
+    @test C1 .+ 100 ≈ batched_mul!(C2, A′, B′, 1, 10)
+
+    # Trivial batches for B
+    D′ = randn(TB, 3,5,1)
+    @test size(batched_mul(A′,D′)) == (4,5,2)
+    @test batched_mul(A′,D′) ≈ half_batched_mul(A′, D′)
 end
 
 @testset "BatchedAdjOrTrans interface * $TB" for TB in [Float64, Float32]

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -1,5 +1,5 @@
 using NNlib, Test, LinearAlgebra
-using NNlib: storage_type, is_strided
+using NNlib: storage_type, is_strided, batched_mul!
 
 function bmm_test(a,b; transA = false, transB = false)
     bs = size(a,3)
@@ -125,7 +125,7 @@ end
     end
 end
 
-@testset "storage_type"
+@testset "storage_type" begin
 
     @test storage_type(transpose(reshape(view(rand(10), 2:9),4,:))) == Vector{Float64}
     @test storage_type(transpose(reshape(view(1:10,     2:9),4,:))) == UnitRange{Int}


### PR DESCRIPTION
This is an alternative to #187. 

It similarly allows `batched_mul` to work on many `PermutedDimsArray`s, but does this just by calling `strides(A)` and branching. It also extends `batched_mul!` to take `α, β` scales like `mul!`.

It adds two functions `storage_type` and `is_strided`, both of which recursively unwrap things. This avoids trying to dispatch on `BatchedAdjoint{PermutedDimsArray{...,CuArray}}`... instead it can separately check the underlying storage, and whether it should be safe to call `strides(A)`.

It also improves `batched_gemm!` to multi-thread the batch index (using https://github.com/JuliaLang/julia/pull/36360 to save & restore the number of BLAS threads), and to allow `size(A,3)==1` (batch only B,C).
