### PR TITLE
fix allocate_threadpool when NNPACK_CPU_THREADS is set

### DIFF
--- a/src/nnpack/NNPACK.jl
+++ b/src/nnpack/NNPACK.jl
@@ -34,8 +34,8 @@ Allows NNPACK to intelligently choose which threadpool to use for getting the be
 performance.
 """
 function allocate_threadpool()
-    global NNPACK_CPU_THREADS = NNPACK_CPU_THREADS > 8 ? UInt64(8) : floor(log2(NNPACK_CPU_THREADS))
-    for i in 1:Int(NNPACK_CPU_THREADS)
+    global NNPACK_CPU_THREADS = NNPACK_CPU_THREADS > 8 ? UInt64(8) : UInt64(exp2(floor(log2(NNPACK_CPU_THREADS))))
+    for i in 0:Int(log2(NNPACK_CPU_THREADS))
         threads = UInt64(2^i)
         push!(shared_threadpool_dict, threads => Ref(pthreadpool_create(threads)))
     end


### PR DESCRIPTION
This should fix issue #200 .
With this patch I have the following results for the convolution:
```bash
for i in 1 2 4 8; do 
   NNPACK_CPU_THREADS=$i julia --eval "using NNlib; @show Int(NNlib.NNPACK_CPU_THREADS); @time NNlib.conv(zeros(Float32,200,200,100,50),ones(Float32,4,4,100,100));"
 done
```


```
Int(NNlib.NNPACK_CPU_THREADS) = 1
  7.966892 seconds (508.67 k allocations: 1.494 GiB, 0.44% gc time)
Int(NNlib.NNPACK_CPU_THREADS) = 2
  4.303962 seconds (508.67 k allocations: 1.494 GiB, 0.81% gc time)
Int(NNlib.NNPACK_CPU_THREADS) = 4
  3.020974 seconds (508.67 k allocations: 1.494 GiB, 1.14% gc time)
Int(NNlib.NNPACK_CPU_THREADS) = 8
  2.539355 seconds (508.67 k allocations: 1.494 GiB, 1.37% gc time)
```