### PR TITLE
use vmap for all activations

### DIFF
--- a/src/activation.jl
+++ b/src/activation.jl
@@ -118,7 +118,7 @@ elu(x::RealOrFloatType, α = one(x)) = vifelse(x ≥ 0, x / one(x), α * (exp(x)
 activation function.
 """
 function gelu(x::RealOrFloatType)
-    p = oftype(x / 1, π)
+    p = oftype(x / 1, Float64(π))
     λ = oftype(x / 1, √(2 / p))
     α = oftype(x / 1, 0.044715)
     h = oftype(x / 1, 0.5)
@@ -166,7 +166,7 @@ end
 Continuously Differentiable Exponential Linear Units
 See [Continuously Differentiable Exponential Linear Units](https://arxiv.org/pdf/1704.07483.pdf).
 """
-celu(x::RealOrFloatType, α::Real = one(x)) = vifelse(x ≥ 0, x / one(x), α * (exp(x/α) - one(x)))
+celu(x::RealOrFloatType, α::RealOrFloatType = one(x)) = vifelse(x ≥ 0, x / one(x), α * (exp(x/α) - one(x)))
 
 
 """
@@ -230,8 +230,5 @@ softshrink(x::RealOrFloatType, λ = oftype(x/1, 0.5)) = min(max(zero(x), x - λ)
 for f in (:σ, :hardσ, :logσ, :hardtanh, :relu, :leakyrelu, :relu6, :rrelu, :elu, :gelu, :swish, :lisht, :selu, :celu, :trelu, :softsign, :softplus, :logcosh, :mish, :tanhshrink, :softshrink)
     @eval $(f)(x::AbstractArray, args...) =
       error("Use broadcasting (`", $(string(f)), ".(x)`) to apply activation functions to arrays.")
-end
-
-for f in (:σ, :tanh)
     @eval Base.broadcasted(::typeof($f), x::Array{T, N}) where {T <: Union{Float64, Float32}, N} = vmap($f, x)
 end

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -1,6 +1,7 @@
 export σ, sigmoid, hardσ, hardsigmoid, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, swish, selu, celu, softplus, softsign, logσ,
        logsigmoid, logcosh, mish, tanhshrink, softshrink, thresholdrelu, trelu, lisht
 
+import Base: tanh
 import LoopVectorization: vifelse
 using LoopVectorization.SLEEFPirates: FloatType
 

--- a/src/activation.jl
+++ b/src/activation.jl
@@ -227,7 +227,7 @@ See [Softshrink Activation Function](https://www.gabormelli.com/RKB/Softshrink_A
 softshrink(x::RealOrFloatType, λ = oftype(x/1, 0.5)) = min(max(zero(x), x - λ), x + λ)
 
 # Provide an informative error message if activation functions are called with an array
-for f in (:σ, :hardσ, :logσ, :hardtanh, :relu, :leakyrelu, :relu6, :rrelu, :elu, :gelu, :swish, :lisht, :selu, :celu, :trelu, :softsign, :softplus, :logcosh, :mish, :tanhshrink, :softshrink)
+for f in (:σ, :hardσ, :logσ, :tanh, :hardtanh, :relu, :leakyrelu, :relu6, :rrelu, :elu, :gelu, :swish, :lisht, :selu, :celu, :trelu, :softsign, :softplus, :logcosh, :mish, :tanhshrink, :softshrink)
     @eval $(f)(x::AbstractArray, args...) =
       error("Use broadcasting (`", $(string(f)), ".(x)`) to apply activation functions to arrays.")
     @eval Base.broadcasted(::typeof($f), x::Array{T, N}) where {T <: Union{Float64, Float32}, N} = vmap($f, x)

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -117,7 +117,7 @@ end
             x = rand(T, 5)
             for a in ACTIVATION_FUNCTIONS
                 @test a.(x) ≈ map(a, x)
-                @test Zygote.gradient(z -> sum(a.(z)), x)[1] == a'.(x)
+                @test isapprox(gradient(z -> sum(a.(z)), x)[1], a'.(x))
             end
         end
     end

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -1,6 +1,6 @@
 using NNlib, Test, Zygote
 
-ACTIVATION_FUNCTIONS = [σ, hardσ, logσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
+ACTIVATION_FUNCTIONS = [σ, hardσ, logσ, tanh, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];
 
 function test_value_float_precision_preserving(a)
     @testset "$(a): " begin

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -112,6 +112,15 @@ end
         end
     end
 
+    @testset "Broadcasting" begin
+        for T in (Float32, Float64)
+            x = rand(T, 5)
+            for a in ACTIVATION_FUNCTIONS
+                @test a.(x) ≈ map(a, x)
+            end
+        end
+    end
+ 
     @testset "Test Integer64 and Integer32 inputs will force Float64 outputs" begin
         test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6 && x != hardtanh && x != trelu), ACTIVATION_FUNCTIONS))
 

--- a/test/activation.jl
+++ b/test/activation.jl
@@ -117,10 +117,11 @@ end
             x = rand(T, 5)
             for a in ACTIVATION_FUNCTIONS
                 @test a.(x) ≈ map(a, x)
+                @test Zygote.gradient(z -> sum(a.(z)), x)[1] == a'.(x)
             end
         end
     end
- 
+
     @testset "Test Integer64 and Integer32 inputs will force Float64 outputs" begin
         test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6 && x != hardtanh && x != trelu), ACTIVATION_FUNCTIONS))
 


### PR DESCRIPTION
fix #220 

```julia
using NNlib, BenchmarkTools

ACTIVATION_FUNCTIONS = [σ, hardσ, logσ, hardtanh, relu, leakyrelu, relu6, rrelu, elu, gelu, celu, swish, lisht, selu, trelu, softplus, softsign, logcosh, mish, tanhshrink, softshrink];

for T in (Float32, Float64)
    x = rand(T, 500)
    for a in ACTIVATION_FUNCTIONS
        @show a
        @btime $a.($x)
        @btime map($a, $x)
    end
end
a = NNlib.σ
  753.493 ns (1 allocation: 2.13 KiB)
  4.052 μs (2 allocations: 2.14 KiB)
a = NNlib.hardσ
  644.024 ns (1 allocation: 2.13 KiB)
  1.653 μs (2 allocations: 2.14 KiB)
a = NNlib.logσ
  2.659 μs (1 allocation: 2.13 KiB)
  27.581 μs (2 allocations: 2.14 KiB)
a = NNlib.hardtanh
  542.984 ns (1 allocation: 2.13 KiB)
  2.261 μs (2 allocations: 2.14 KiB)
a = NNlib.relu
  576.228 ns (1 allocation: 2.13 KiB)
  716.754 ns (2 allocations: 2.14 KiB)
a = NNlib.leakyrelu
  531.237 ns (1 allocation: 2.13 KiB)
  1.965 μs (2 allocations: 2.14 KiB)
a = NNlib.relu6
  524.547 ns (1 allocation: 2.13 KiB)
  1.252 μs (2 allocations: 2.14 KiB)
a = NNlib.rrelu
  919.600 ns (1 allocation: 2.13 KiB)
  5.401 μs (2 allocations: 2.14 KiB)
a = NNlib.elu
  794.806 ns (1 allocation: 2.13 KiB)
  3.864 μs (2 allocations: 2.14 KiB)
a = NNlib.gelu
  1.525 μs (1 allocation: 2.13 KiB)
  11.793 μs (2 allocations: 2.14 KiB)
a = NNlib.celu
  824.069 ns (1 allocation: 2.13 KiB)
  3.813 μs (2 allocations: 2.14 KiB)
a = NNlib.swish
  799.932 ns (1 allocation: 2.13 KiB)
  4.438 μs (2 allocations: 2.14 KiB)
a = NNlib.lisht
  1.367 μs (1 allocation: 2.13 KiB)
  9.907 μs (2 allocations: 2.14 KiB)
a = NNlib.selu
  779.846 ns (1 allocation: 2.13 KiB)
  4.023 μs (2 allocations: 2.14 KiB)
a = NNlib.trelu
  524.082 ns (1 allocation: 2.13 KiB)
  654.231 ns (2 allocations: 2.14 KiB)
a = NNlib.softplus
  2.565 μs (1 allocation: 2.13 KiB)
  28.825 μs (2 allocations: 2.14 KiB)
a = NNlib.softsign
  565.306 ns (1 allocation: 2.13 KiB)
  807.525 ns (2 allocations: 2.14 KiB)
a = NNlib.logcosh
  2.840 μs (1 allocation: 2.13 KiB)
  31.271 μs (2 allocations: 2.14 KiB)
a = NNlib.mish
  4.533 μs (1 allocation: 2.13 KiB)
  46.708 μs (2 allocations: 2.14 KiB)
a = NNlib.tanhshrink
  1.415 μs (1 allocation: 2.13 KiB)
  9.858 μs (2 allocations: 2.14 KiB)
a = NNlib.softshrink
  528.125 ns (1 allocation: 2.13 KiB)
  2.321 μs (2 allocations: 2.14 KiB)

a = NNlib.σ
  1.169 μs (1 allocation: 4.06 KiB)
  5.805 μs (2 allocations: 4.08 KiB)
a = NNlib.hardσ
  838.711 ns (1 allocation: 4.06 KiB)
  1.612 μs (2 allocations: 4.08 KiB)
a = NNlib.logσ
  5.995 μs (1 allocation: 4.06 KiB)
  34.751 μs (2 allocations: 4.08 KiB)
a = NNlib.hardtanh
  677.167 ns (1 allocation: 4.06 KiB)
  2.299 μs (2 allocations: 4.08 KiB)
a = NNlib.relu
  745.859 ns (1 allocation: 4.06 KiB)
  722.837 ns (2 allocations: 4.08 KiB)
a = NNlib.leakyrelu
  742.216 ns (1 allocation: 4.06 KiB)
  1.854 μs (2 allocations: 4.08 KiB)
a = NNlib.relu6
  723.690 ns (1 allocation: 4.06 KiB)
  1.297 μs (2 allocations: 4.08 KiB)
a = NNlib.rrelu
  1.327 μs (1 allocation: 4.06 KiB)
  5.316 μs (2 allocations: 4.08 KiB)
a = NNlib.elu
  1.120 μs (1 allocation: 4.06 KiB)
  5.244 μs (2 allocations: 4.08 KiB)
a = NNlib.gelu
  3.206 μs (1 allocation: 4.06 KiB)
  15.002 μs (2 allocations: 4.08 KiB)
a = NNlib.celu
  1.176 μs (1 allocation: 4.06 KiB)
  5.046 μs (2 allocations: 4.08 KiB)
a = NNlib.swish
  1.181 μs (1 allocation: 4.06 KiB)
  5.662 μs (2 allocations: 4.08 KiB)
a = NNlib.lisht
  2.822 μs (1 allocation: 4.06 KiB)
  13.317 μs (2 allocations: 4.08 KiB)
a = NNlib.selu
  1.079 μs (1 allocation: 4.06 KiB)
  5.663 μs (2 allocations: 4.08 KiB)
a = NNlib.trelu
  774.219 ns (1 allocation: 4.06 KiB)
  785.364 ns (2 allocations: 4.08 KiB)
a = NNlib.softplus
  5.846 μs (1 allocation: 4.06 KiB)
  37.976 μs (2 allocations: 4.08 KiB)
a = NNlib.softsign
  718.581 ns (1 allocation: 4.06 KiB)
  993.700 ns (2 allocations: 4.08 KiB)
a = NNlib.logcosh
  6.133 μs (1 allocation: 4.06 KiB)
  45.347 μs (2 allocations: 4.08 KiB)
a = NNlib.mish
  11.400 μs (1 allocation: 4.06 KiB)
  57.121 μs (2 allocations: 4.08 KiB)
a = NNlib.tanhshrink
  2.799 μs (1 allocation: 4.06 KiB)
  13.361 μs (2 allocations: 4.08 KiB)
a = NNlib.softshrink
  729.505 ns (1 allocation: 4.06 KiB)
  2.459 μs (2 allocations: 4.08 KiB)
```
