### PR TITLE
Fix multithreading bug in ∇conv_filter_im2col

### DIFF
--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -95,9 +95,8 @@ function ∇conv_filter_im2col!(
     N = channels_out(cdims)
     K = prod(output_size(cdims))
     
-    @threads for batch_idx in 1:size(x,5)
-        # col_slice is a thread-local workspace
-        col_slice = view(col, :, :, threadid())
+    for batch_idx in 1:size(x,5)
+        col_slice = view(col, :, :, 1)
 
         im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
         GC.@preserve col_slice, dw, dy, begin

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -51,7 +51,7 @@ function conv_im2col!(
         col_slice = view(col, :, :, threadid())
 
         im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
-        GC.@preserve col_slice, w, y, begin
+        GC.@preserve col_slice w y begin
             col_ptr = pointer(col_slice)
             w_ptr = pointer(w)
             y_ptr = pointer(y, (batch_idx - 1)*M*N + 1)
@@ -99,7 +99,7 @@ function ∇conv_filter_im2col!(
         col_slice = view(col, :, :, 1)
 
         im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
-        GC.@preserve col_slice, dw, dy, begin
+        GC.@preserve col_slice dw dy begin
             col_ptr = pointer(col_slice)
             dy_ptr = pointer(dy,(batch_idx - 1)*K*N + 1)
             dw_ptr = pointer(dw)
@@ -149,7 +149,7 @@ function ∇conv_data_im2col!(
         # col_slice is a thread-local workspace
         col_slice = view(col, :, :, threadid())
 
-        GC.@preserve col_slice, w, dy, begin
+        GC.@preserve col_slice w dy begin
             dy_ptr = pointer(dy, (batch_idx - 1)*M*K + 1)
             w_ptr = pointer(w)
             col_ptr = pointer(col_slice)

--- a/src/impl/depthwiseconv_im2col.jl
+++ b/src/impl/depthwiseconv_im2col.jl
@@ -36,7 +36,7 @@ function depthwiseconv_im2col!(
         # We do a separate convolution for each channel in x, as we must
         for c_in in 1:channels_in(cdims)
             # Walk each pointer forward as we process each input channel
-            GC.@preserve col_slice, w, y, begin
+            GC.@preserve col_slice w y begin
                 col_ptr = pointer(col_slice, (c_in-1)*M*K+1)
                 w_ptr = pointer(w, (c_in-1)*K*N+1)
                 y_ptr = pointer(y, ((batch_idx - 1)*channels_in(cdims) + c_in - 1)*M*N + 1)
@@ -74,7 +74,7 @@ function ∇depthwiseconv_filter_im2col!(
         # We do a separate convolution for each channel in x, as we must
         for c_in in 1:channels_in(cdims)
             # Walk each pointer forward as we process each input channel
-            GC.@preserve col_slice, dw, dy, begin
+            GC.@preserve col_slice dw dy begin
                 col_ptr = pointer(col_slice, (c_in - 1)*M*K + 1)
                 dy_ptr = pointer(dy, (batch_idx - 1)*N*K*channels_in(cdims) + (c_in - 1)*K*N + 1)
                 dw_ptr = pointer(dw, (c_in - 1)*M*N + 1)
@@ -114,7 +114,7 @@ function ∇depthwiseconv_data_im2col!(
 
         # We do a separate convolution for each channel in x, as we must
         for cidx in 1:channels_in(cdims)
-            GC.@preserve col_slice, w, dy, begin
+            GC.@preserve col_slice w dy begin
                 # Walk each pointer forward as we process each input channel
                 dy_ptr = pointer(dy, (batch_idx - 1)*M*K*channels_in(cdims)+(cidx - 1)*K*M + 1)
                 w_ptr = pointer(w, (cidx - 1)*K*N + 1)


### PR DESCRIPTION
Fixes issue #197.

The issue is caused by threading, and if `JULIA_NUM_THREADS` is greater than 1, it can be reproduced with the following MWE, which compares the gradients computed with `∇conv_filter_im2col` to those computed with `∇conv_filter_direct`.
```julia
using NNlib, Random

function compare_grad()
    Random.seed!(0)

    x = rand(50,1,10)
    w = rand(3,1,1)
    dy = rand(50,1,10)

    cdims = DenseConvDims(size(x), size(w); stride=1, padding=1)
    dw1 = NNlib.∇conv_filter_im2col(x, dy, cdims)
    dw2 = NNlib.∇conv_filter_direct(x, dy, cdims)
    maximum(abs, dw1-dw2)
end
```
In a correct implementation, `compare_grad()` should always return zero. Since the random seed is set to zero, the result should also be deterministic. However, when using multithreading it returns seemingly random large numbers:
```julia
julia> Base.Threads.nthreads()
4

julia> compare_grad()
28.640897825466183

julia> compare_grad()
15.199002081309956

julia> compare_grad()
26.932418843285404
```

This is caused because `∇conv_filter_im2col!` uses a threaded for-loop that attempts to accumulate the result to a single array `dw`, causing write conflicts.

I fixed this issue simply by disabling threading for this loop. Another option would be to introduce another thread-specific workspace for `dw`, and accumulate over threads, but I suspect this will not be worth it.

This PR also fixes some bugs involving `GC.@preserve` by removing commas from the argument list. Commas in this context cause the arguments to be treated as a tuple, as can be seen from the following example:
```julia
julia> @macroexpand @GC.preserve x y begin end
:($(Expr(:gc_preserve, quote
    #= REPL[11]:1 =#
end, :x, :y)))

julia> @macroexpand @GC.preserve x, y, begin end
:($(Expr(:gc_preserve, :((x, y, begin
          #= REPL[10]:1 =#
      end)))))
```