### PR TITLE
fix meanpool bug #229

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 deps/usr
 deps.jl
 *.log
+.vscode
 Manifest.toml

--- a/src/impl/pooling_direct.jl
+++ b/src/impl/pooling_direct.jl
@@ -32,7 +32,7 @@ for name in (:max, :mean)
 
         # Each loop, we initialize `m` to something, set that here.
         m_init = if $(name == :max)
-            typemin(T)
+            T <: AbstractFloat ? nextfloat(typemin(T)) : typemin(T)
         elseif $(name == :mean)
             T(0)
         else
@@ -84,27 +84,21 @@ for name in (:max, :mean)
                 for kd in 1:kernel_d
                     input_kd = project(d, stride_d, pad_d_lo) + (kd - 1) * dil_d
                     if input_kd <= 0 || input_kd > depth
-                        if $(name == :max)
-                            m = max(m, 0.0)
-                        end
+                        # add here condition for handling options for paded value handling  
                         continue
                     end
 
                     for kh in 1:kernel_h
                         input_kh = project(h, stride_h, pad_h_lo) + (kh - 1) * dil_h
                         if input_kh <= 0 || input_kh > height
-                            if $(name == :max)
-                                m = max(m, 0.0)
-                            end
+                            # add here condition for handling options for paded value handling  
                             continue
                         end
 
                         for kw in 1:kernel_w
                             input_kw = project(w, stride_w, pad_w_lo) + (kw - 1) * dil_w
                             if input_kw <= 0 || input_kw > width
-                                if $(name == :max)
-                                    m = max(m, 0.0)
-                                end
+                                # add here condition for handling options for paded value handling  
                                 continue
                             end
 

--- a/src/impl/pooling_direct.jl
+++ b/src/impl/pooling_direct.jl
@@ -5,7 +5,7 @@ using Statistics
 for name in (:max, :mean)
     @eval function $((Symbol("$(name)pool_direct!")))(
                     y::AbstractArray{T,5}, x::AbstractArray{T,5},
-                    pdims::PoolDims; alpha::T = T(1), beta::T = T(0)) where {T}
+                    pdims::PoolDims; alpha::T=T(1), beta::T=T(0)) where {T}
         @assert beta == T(0) "beta not supported yet"
         check_dims(size(x), size(y), pdims)
 
@@ -22,12 +22,12 @@ for name in (:max, :mean)
         padded_regions, central_region = calc_padding_regions(pdims)
 
         # A helper function to project from output (w, h) to input (input_w, input_h)
-        @inline project(idx, stride, pad) = (idx - 1)*stride - pad + 1
+        @inline project(idx, stride, pad) = (idx - 1) * stride - pad + 1
 
         # If we're doing mean pooling, we represent division by kernel size by rolling it
         # into the `alpha` multiplier.
         if $(name == :mean)
-            alpha = alpha/prod(kernel_size(pdims))
+            alpha = alpha / prod(kernel_size(pdims))
         end
 
         # Each loop, we initialize `m` to something, set that here.
@@ -54,9 +54,9 @@ for name in (:max, :mean)
                 kh in 1:kernel_h,
                 kw in 1:kernel_w
 
-                input_kd = project(d, stride_d, pad_d_lo) + (kd - 1)*dil_d
-                input_kh = project(h, stride_h, pad_h_lo) + (kh - 1)*dil_h
-                input_kw = project(w, stride_w, pad_w_lo) + (kw - 1)*dil_w
+                input_kd = project(d, stride_d, pad_d_lo) + (kd - 1) * dil_d
+                input_kh = project(h, stride_h, pad_h_lo) + (kh - 1) * dil_h
+                input_kw = project(w, stride_w, pad_w_lo) + (kw - 1) * dil_w
 
                 # This conditional will be optimized away at compile time
                 if $(name == :max)
@@ -67,7 +67,7 @@ for name in (:max, :mean)
                     error("Unimplemented codegen path")
                 end
             end
-            y[w, h, d, c, batch_idx] = alpha*m + beta*y[w, h, d, c, batch_idx]
+            y[w, h, d, c, batch_idx] = alpha * m + beta * y[w, h, d, c, batch_idx]
         end
 
         # Next, the padded regions
@@ -82,23 +82,29 @@ for name in (:max, :mean)
                 # do so by putting in a bunch of conditionals.  :/
                 m = m_init
                 for kd in 1:kernel_d
-                    input_kd = project(d, stride_d, pad_d_lo) + (kd - 1)*dil_d
+                    input_kd = project(d, stride_d, pad_d_lo) + (kd - 1) * dil_d
                     if input_kd <= 0 || input_kd > depth
-                        m = max(m, 0.0)
+                        if $(name == :max)
+                            m = max(m, 0.0)
+                        end
                         continue
                     end
 
                     for kh in 1:kernel_h
-                        input_kh = project(h, stride_h, pad_h_lo) + (kh - 1)*dil_h
+                        input_kh = project(h, stride_h, pad_h_lo) + (kh - 1) * dil_h
                         if input_kh <= 0 || input_kh > height
-                            m = max(m, 0.0)
+                            if $(name == :max)
+                                m = max(m, 0.0)
+                            end
                             continue
                         end
 
                         for kw in 1:kernel_w
-                            input_kw = project(w, stride_w, pad_w_lo) + (kw - 1)*dil_w
+                            input_kw = project(w, stride_w, pad_w_lo) + (kw - 1) * dil_w
                             if input_kw <= 0 || input_kw > width
-                                m = max(m, 0.0)
+                                if $(name == :max)
+                                    m = max(m, 0.0)
+                                end
                                 continue
                             end
 
@@ -112,7 +118,7 @@ for name in (:max, :mean)
                         end
                     end
                 end
-                y[w, h, d, c, batch_idx] = alpha*m + beta*y[w, h, d, c, batch_idx]
+                y[w, h, d, c, batch_idx] = alpha * m + beta * y[w, h, d, c, batch_idx]
             end
         end
 
@@ -125,7 +131,7 @@ for name in (:max, :mean)
     @eval function $((Symbol("∇$(name)pool_direct!")))(
                     dx::AbstractArray{T,5}, dy::AbstractArray{T,5},
                     y::AbstractArray{T,5}, x::AbstractArray{T,5},
-                    pdims::PoolDims; alpha::T = T(1), beta::T = T(0)) where {T}
+                    pdims::PoolDims; alpha::T=T(1), beta::T=T(0)) where {T}
         check_dims(size(x), size(dy), pdims)
 
         width, height, depth = input_size(pdims)
@@ -141,12 +147,12 @@ for name in (:max, :mean)
         padded_regions, central_region = calc_padding_regions(pdims)
 
         # A helper function to project from output (w, h) to input (input_w, input_h)
-        @inline project(idx, stride, pad) = (idx - 1)*stride - pad + 1
+        @inline project(idx, stride, pad) = (idx - 1) * stride - pad + 1
 
         # If we're doing mean pooling, we represent division by kernel size by rolling
         # it into the `alpha` multiplier.
         if $(name == :mean)
-            alpha = alpha/prod(kernel_size(pdims))
+            alpha = alpha / prod(kernel_size(pdims))
         end
 
         # Start with the central region
@@ -166,9 +172,9 @@ for name in (:max, :mean)
                 kh in 1:kernel_h,
                 kw in 1:kernel_w
 
-                input_kd = project(d, stride_d, pad_d_lo) + (kd - 1)*dil_d
-                input_kh = project(h, stride_h, pad_h_lo) + (kh - 1)*dil_h
-                input_kw = project(w, stride_w, pad_w_lo) + (kw - 1)*dil_w
+                input_kd = project(d, stride_d, pad_d_lo) + (kd - 1) * dil_d
+                input_kh = project(h, stride_h, pad_h_lo) + (kh - 1) * dil_h
+                input_kw = project(w, stride_w, pad_w_lo) + (kw - 1) * dil_w
 
                 # This conditional will be optimized away at compile time,
                 # or my name isn't shengdan jingyu
@@ -179,15 +185,15 @@ for name in (:max, :mean)
                     # Uncomment line below if using with non-precise output (e.g. by NNPACK)
                     # if abs(y_idx - x[x_idxs...]) < 1e-5 && !maxpool_already_chose
                     if y_idx ≈ x[x_idxs...] && !maxpool_already_chose
-                            dx[x_idxs...] += dy_idx*alpha + beta*dx[x_idxs...]
+                        dx[x_idxs...] += dy_idx * alpha + beta * dx[x_idxs...]
                         maxpool_already_chose = true
                     # Maxpooling does not support `beta` right now.  :(
-                    #else
+                    # else
                     #    dx[x_idxs...] = T(0) + beta*dx[x_idxs...]
                     end
                 elseif $(name == :mean)
                     # Either does meanpool :(
-                    dx[x_idxs...] = dy_idx*alpha + dx[x_idxs...]
+                    dx[x_idxs...] = dy_idx * alpha + dx[x_idxs...]
                 else
                     error("Unimplemented codegen path")
                 end
@@ -210,19 +216,19 @@ for name in (:max, :mean)
                 # In these loops, we have to check that we're not reaching off the edge,
                 # we do so by putting in a bunch of conditionals.  :/
                 for kd in 1:kernel_d
-                    input_kd = project(d, stride_d, pad_d_lo) + (kd - 1)*dil_d
+                    input_kd = project(d, stride_d, pad_d_lo) + (kd - 1) * dil_d
                     if input_kd <= 0 || input_kd > depth
                         continue
                     end
 
                     for kh in 1:kernel_h
-                        input_kh = project(h, stride_h, pad_h_lo) + (kh - 1)*dil_h
+                        input_kh = project(h, stride_h, pad_h_lo) + (kh - 1) * dil_h
                         if input_kh <= 0 || input_kh > height
                             continue
                         end
 
                         for kw in 1:kernel_w
-                            input_kw = project(w, stride_w, pad_w_lo) + (kw - 1)*dil_w
+                            input_kw = project(w, stride_w, pad_w_lo) + (kw - 1) * dil_w
                             if input_kw <= 0 || input_kw > width
                                 continue
                             end
@@ -233,13 +239,13 @@ for name in (:max, :mean)
                                 # Uncomment line below if using with non-precise output
                                 # if abs(y_idx - x[x_idxs...]) < 1e-5 && !maxpool_already_chose
                                 if y_idx ≈ x[x_idxs...] && !maxpool_already_chose
-                                    dx[x_idxs...] += dy_idx*alpha + beta*dx[x_idxs...]
+                                    dx[x_idxs...] += dy_idx * alpha + beta * dx[x_idxs...]
                                     maxpool_already_chose = true
-                                #else
+                                # else
                                 #    dx[x_idxs...] = T(0) + beta*dx[x_idxs...]
                                 end
                             elseif $(name == :mean)
-                                dx[x_idxs...] += dy_idx*alpha + beta*dx[x_idxs...]
+                                dx[x_idxs...] += dy_idx * alpha + beta * dx[x_idxs...]
                             else
                                 error("Unimplemented codegen path")
                             end

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -323,6 +323,7 @@ end
 # using FiniteDifferences
 maxpool_answer_nature = Dict(
     "rank1" => Dict(
+        # kernel size 2, stride 1, pad 0
         "k2s1p0" => (size = (2,),
             stride = 1,
             pad = 0,
@@ -389,6 +390,7 @@ maxpool_answer_nature = Dict(
             ], 5, 1, 1),)
     ),
     "rank2" => Dict(
+        # kernel size 2, stride 1, pad 0
         "k2s1p0" => (size = (2, 2),
             stride = 1,
             pad = 0,
@@ -499,6 +501,7 @@ maxpool_answer_nature = Dict(
             ], 5, 5, 1, 1))
     ),
     "rank3" => Dict(
+        # kernel size 2, stride 1, pad 0
         "k2s1p0" => (size = (2, 2, 2),
             stride = 1,
             pad = 0,

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -1,4 +1,4 @@
-#using NNlib, Test
+# using NNlib, Test
 
 maxpool_answer_dict = Dict(
     1 => Dict(
@@ -250,15 +250,12 @@ meanpool_answer_dict = Dict(
 
 for rank in (1, 2, 3)
     @testset "pool$(rank)d" begin
-        for (pool, ∇pool, answer_dict) in (
-                # Main API name
-                (maxpool, ∇maxpool, maxpool_answer_dict),
+        for (pool, ∇pool, answer_dict) in ((maxpool, ∇maxpool, maxpool_answer_dict),
                 (meanpool, ∇meanpool, meanpool_answer_dict),
 
                 # _direct name
                 (NNlib.maxpool_direct, NNlib.∇maxpool_direct, maxpool_answer_dict),
-                (NNlib.meanpool_direct, NNlib.∇meanpool_direct, meanpool_answer_dict),
-            )
+                (NNlib.meanpool_direct, NNlib.∇meanpool_direct, meanpool_answer_dict),)
 
             @testset "$(pool)$(rank)d" begin
                 y = answer_dict[rank]["y"]
@@ -271,7 +268,7 @@ for rank in (1, 2, 3)
                 x = reshape(Float64[1:prod(size(dx));], size(dx)..., 1, 1)
 
                 # A "drop channels and batch dimension" helper
-                ddims(x) = dropdims(x, dims=(rank+1, rank+2))
+                ddims(x) = dropdims(x, dims=(rank + 1, rank + 2))
 
                 # Let's ensure that a 1x1x1 pooling kernel always just returns `x`
                 @test pool(x, PoolDims(x, 1)) == x
@@ -299,17 +296,17 @@ for rank in (1, 2, 3)
 end
 
 @testset "Pooling - Check Sizes" begin
-  x = rand(10, 10, 3, 10)
-  @test size(maxpool(x, (2, 2))) == (5, 5, 3, 10)
-  @test size(maxpool(x, (2, 2); pad = (1, 1), stride = (2, 2))) == (6, 6, 3, 10)
-  @test size(meanpool(x, (2, 2))) == (5, 5, 3, 10)
-  @test size(meanpool(x, (2, 2); pad = (1, 1), stride = (2, 2))) == (6, 6, 3, 10)
+    x = rand(10, 10, 3, 10)
+    @test size(maxpool(x, (2, 2))) == (5, 5, 3, 10)
+    @test size(maxpool(x, (2, 2); pad=(1, 1), stride=(2, 2))) == (6, 6, 3, 10)
+    @test size(meanpool(x, (2, 2))) == (5, 5, 3, 10)
+    @test size(meanpool(x, (2, 2); pad=(1, 1), stride=(2, 2))) == (6, 6, 3, 10)
 end
 
 # Add another test for 2d maxpool that uses an odd-length size:
 @testset "Issue #133" begin
     x = reshape([(1.:9.)...], 3, 3, 1, 1)
-    pdims = PoolDims(size(x), (2,2), padding = (1,1), stride = (2,2))
+    pdims = PoolDims(size(x), (2, 2), padding=(1, 1), stride=(2, 2))
     y = maxpool(x, pdims)
 
     dy = y .* 0 .+ 1
@@ -324,8 +321,7 @@ end
 # using FiniteDifferences
 maxpool_answer_nature = Dict(
     "rank1" => Dict(
-        "k2s1p0" => ( # kernel size 2, stride 1, pad 0
-            size = (2,),
+        "k2s1p0" => (size = (2,),
             stride = 1,
             pad = 0,
     
@@ -339,10 +335,8 @@ maxpool_answer_nature = Dict(
             
             dx_meanpool = reshape([
                  0.5, 1.0, 1.0, 1.0, 0.5
-            ], 5, 1, 1),
-        ),
-        "k2s1p1" => (
-            size = (2,),
+            ], 5, 1, 1),),
+        "k2s1p1" => (size = (2,),
             stride = 1,
             pad = 1,
             
@@ -356,11 +350,8 @@ maxpool_answer_nature = Dict(
             
             dx_meanpool = reshape([
                  1.0, 1.0, 1.0, 1.0, 1.0
-            ], 5, 1, 1),
-    
-        ),
-        "k3s1p1" => (
-            size = (3,),
+            ], 5, 1, 1),),
+        "k3s1p1" => (size = (3,),
             stride = 1,
             pad = 1,
     
@@ -374,11 +365,8 @@ maxpool_answer_nature = Dict(
             
             dx_meanpool = reshape([
                  0.6666666666, 1.0, 1.0, 1.0, 0.6666666666
-            ], 5, 1, 1),
-    
-        ),
-        "k3s2p1" => (
-            size = (3,),
+            ], 5, 1, 1),),
+        "k3s2p1" => (size = (3,),
             stride = 2,
             pad = 1,
     
@@ -396,12 +384,10 @@ maxpool_answer_nature = Dict(
                  0.333333333,
                  0.666666666,
                  0.333333333,
-            ], 5, 1, 1),
-        )
+            ], 5, 1, 1),)
     ),
     "rank2" => Dict(
-        "k2s1p0" => ( # kernel size 2, stride 1, pad 0
-            size = (2,2),
+        "k2s1p0" => (size = (2, 2),
             stride = 1,
             pad = 0,
 
@@ -427,10 +413,8 @@ maxpool_answer_nature = Dict(
                 0.5   1.0  1.0  1.0  0.5
                 0.5   1.0  1.0  1.0  0.5
                 0.25  0.5  0.5  0.5  0.25
-            ], 5, 5, 1, 1)
-        ),
-        "k2s1p1" => (
-            size = (2,2),
+            ], 5, 5, 1, 1)),
+        "k2s1p1" => (size = (2, 2),
             stride = 1,
             pad = 1,
             
@@ -456,10 +440,8 @@ maxpool_answer_nature = Dict(
                 1.0  1.0  1.0  1.0  1.0
                 1.0  1.0  1.0  1.0  1.0
                 1.0  1.0  1.0  1.0  1.0
-            ], 5, 5, 1, 1)
-        ),
-        "k3s1p1" => (
-            size = (3,3),
+            ], 5, 5, 1, 1)),
+        "k3s1p1" => (size = (3, 3),
             stride = 1,
             pad = 1,
 
@@ -485,10 +467,8 @@ maxpool_answer_nature = Dict(
                 0.666667  1.0       1.0       1.0       0.666667
                 0.666667  1.0       1.0       1.0       0.666667
                 0.444444  0.666667  0.666667  0.666667  0.444444
-            ], 5, 5, 1, 1)
-        ),
-        "k3s2p1" => (
-            size = (3,3),
+            ], 5, 5, 1, 1)),
+        "k3s2p1" => (size = (3, 3),
             stride = 2,
             pad = 1,
 
@@ -514,12 +494,10 @@ maxpool_answer_nature = Dict(
                 0.111111  0.222222  0.111111  0.222222  0.111111
                 0.222222  0.444444  0.222222  0.444444  0.222222
                 0.111111  0.222222  0.111111  0.222222  0.111111
-            ], 5, 5, 1, 1)
-        )
+            ], 5, 5, 1, 1))
     ),
     "rank3" => Dict(
-        "k2s1p0" => ( # kernel size 2, stride 1, pad 0
-            size = (2,2,2),
+        "k2s1p0" => (size = (2, 2, 2),
             stride = 1,
             pad = 0,
     
@@ -578,10 +556,8 @@ maxpool_answer_nature = Dict(
                      0.25   0.5   0.5   0.25
                      0.25   0.5   0.5   0.25
                      0.125  0.25  0.25  0.125
-                ],dims=3), 4,4,3,1,1)
-        ),
-        "k2s1p1" => (
-            size = (2,2,2),
+                ],dims=3), 4,4,3,1,1)),
+        "k2s1p1" => (size = (2, 2, 2),
             stride = 1,
             pad = 1,
             
@@ -640,10 +616,8 @@ maxpool_answer_nature = Dict(
                      1.0  1.0  1.0  1.0
                      1.0  1.0  1.0  1.0
                      1.0  1.0  1.0  1.0
-                ],dims=3), 4,4,3,1,1)
-        ),
-        "k3s1p1" => (
-            size = (3,3,2),
+                ],dims=3), 4,4,3,1,1)),
+        "k3s1p1" => (size = (3, 3, 2),
             stride = 1,
             pad = 1,
     
@@ -702,10 +676,8 @@ maxpool_answer_nature = Dict(
                      0.666667  1.0       1.0       0.666667
                      0.666667  1.0       1.0       0.666667
                      0.444444  0.666667  0.666667  0.444444
-                ],dims=3), 4,4,3,1,1)
-        ),
-        "k3s2p1" => (
-            size = (3,3,2),
+                ],dims=3), 4,4,3,1,1)),
+        "k3s2p1" => (size = (3, 3, 2),
             stride = 2,
             pad = 1,
     
@@ -764,8 +736,7 @@ maxpool_answer_nature = Dict(
                      0.111111   0.222222  0.111111   0.111111
                      0.0555556  0.111111  0.0555556  0.0555556
                      0.0555556  0.111111  0.0555556  0.0555556
-                ],dims=3), 4,4,3,1,1)
-        )
+                ],dims=3), 4,4,3,1,1))
     )
 )
 
@@ -784,7 +755,7 @@ maxpool_answer_nature = Dict(
         # CHECK DIRECT
         y_maxpool_dir = NNlib.maxpool_direct(x, pdims)
         y_meanpool_dir = NNlib.meanpool_direct(x, pdims)
-        @test y_maxpool_dir ≈ y_maxpool  atol=1e-6
+        @test y_maxpool_dir ≈ y_maxpool  atol = 1e-6
         @test isapprox(config.dx_maxpool, NNlib.∇maxpool_direct(dy, y_maxpool_dir, x, pdims), rtol=1e-5)
         @test isapprox(config.dx_meanpool, NNlib.∇meanpool_direct(dy, y_meanpool_dir, x, pdims), rtol=1e-5)
 
@@ -792,9 +763,9 @@ maxpool_answer_nature = Dict(
         if NNlib.is_nnpack_available() && T == Float32
             if NNlib.nnpack_supported_operation(pdims)
                 y_maxpool_nnp = NNlib.maxpool_nnpack(x, pdims)
-                @test y_maxpool_nnp ≈ y_maxpool  atol=1e-6
+                @test y_maxpool_nnp ≈ y_maxpool  atol = 1e-6
                 # NNPACK maxpool gradient still missing
-                #@test isapprox(config.dx_maxpool, NNlib.∇maxpool_nnpack(dy, y_maxpool_nnp, config.x, pdims), rtol=1e-5)
+                # @test isapprox(config.dx_maxpool, NNlib.∇maxpool_nnpack(dy, y_maxpool_nnp, config.x, pdims), rtol=1e-5)
             end
         end
     end
@@ -808,11 +779,21 @@ maxpool_answer_nature = Dict(
     end
 
     # issue 210
-    x, k = rand(Float32,5,2,1,3), (2,1)
-    pdims1 = NNlib.PoolDims(x,k, padding=1,stride=1)
-    pdims2 = NNlib.PoolDims(x,k, padding=(1,0,0,0),stride=1)
-    @test maxpool(x, pdims1) isa Array{Float32, 4}
-    @test maxpool(x, pdims2) isa Array{Float32, 4}
+    x, k = rand(Float32, 5, 2, 1, 3), (2, 1)
+    pdims1 = NNlib.PoolDims(x, k, padding=1, stride=1)
+    pdims2 = NNlib.PoolDims(x, k, padding=(1, 0, 0, 0), stride=1)
+    @test maxpool(x, pdims1) isa Array{Float32,4}
+    @test maxpool(x, pdims2) isa Array{Float32,4}
+
+    # issue #229
+    x = ones(Float32, 4, 4, 1, 1) .* -1
+    pool = meanpool(x, PoolDims(x, 2, padding=1))
+    valid = reshape([
+    -0.25,  -0.5,  -0.25,
+    -0.5,   -1.0,  -0.5,
+    -0.25,  -0.5,  -0.25], (3, 3, 1, 1))
+    @test all(pool .== valid)
+    
     # if NNlib.is_nnpack_available()
     #     if NNlib.nnpack_supported_operation(pdims1)
     #         @test NNlib.maxpool_nnpack(x, pdims1) isa Array{Float32, 4}

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -250,7 +250,9 @@ meanpool_answer_dict = Dict(
 
 for rank in (1, 2, 3)
     @testset "pool$(rank)d" begin
-        for (pool, ∇pool, answer_dict) in ((maxpool, ∇maxpool, maxpool_answer_dict),
+        for (pool, ∇pool, answer_dict) in (
+                # Main API name
+                (maxpool, ∇maxpool, maxpool_answer_dict),
                 (meanpool, ∇meanpool, meanpool_answer_dict),
 
                 # _direct name
@@ -793,7 +795,7 @@ maxpool_answer_nature = Dict(
     -0.5,   -1.0,  -0.5,
     -0.25,  -0.5,  -0.25], (3, 3, 1, 1))
     @test all(pool .== valid)
-    
+
     # if NNlib.is_nnpack_available()
     #     if NNlib.nnpack_supported_operation(pdims1)
     #         @test NNlib.maxpool_nnpack(x, pdims1) isa Array{Float32, 4}


### PR DESCRIPTION
This fixes the errors returned by `meanpool` on edges. 
Core issue was that a `max(m, 0)` was applied to both mean and max pooling for padded elements. Instead, no operation should be performed for meanpool. 

For example, currently: 

```julia
julia> x = ones(Float32,4,4,1,1) .* -1
[:, :, 1, 1] =
 -1.0  -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0  -1.0

julia> pool = meanpool(x, PoolDims(x,2,padding=1))
3×3×1×1 Array{Float32,4}:
[:, :, 1, 1] =
 -0.25  -0.25  0.0
 -0.5   -1.0   0.0
  0.0    0.0   0.0

julia> pool = meanpool(CuArray(x), PoolDims(x,2,padding=1))
3×3×1×1 CuArray{Float32,4}:
[:, :, 1, 1] =
 -0.25  -0.5  -0.25
 -0.5   -1.0  -0.5
 -0.25  -0.5  -0.25
```

With this fix, the base cpu version now results in the same value. A test has been added. 

There's the issue raised by https://github.com/FluxML/NNlib.jl/issues/218 regarding the consistency between for maxpool between the CPU and GPU/CUDNN implementation that has not been addressed by this PR but that could be fixed in the meantime since it concerns the same code elements. It would simply involves to ignore the padded elements as well for the maxpool. 

Note: there's a couple of formatting that has been modified by Julia linter in vscode in the 2 modified files. I can revert those changes if needed, but I assume that these changes brought by the linter bring the code to expected format. 