### PR TITLE
Improvements to `batched_mul`

### DIFF
--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -16,7 +16,8 @@ _unbatch(A::BatchedAdjOrTrans) = parent(A)
 Batched matrix multiplication. Result has `C[:,:,k] == A[:,:,k] * B[:,:,k]` for all `k`.
 If `size(B,3) == 1` then instead `C[:,:,k] == A[:,:,k] * B[:,:,1]`, and similarly for `A`.
 
-To transpose each matrix, apply `batched_adjoint` or `batched_transpose` to the array:
+To transpose each matrix, apply `batched_transpose` to the array,
+or `batched_adjoint` for conjugate-transpose:
 ```julia
 julia> A, B = randn(2,5,17), randn(5,9,17);
 
@@ -102,6 +103,9 @@ either `A` or `B` may lack a batch index.
 
 ```julia
 julia> randn(16,8,32) ⊠ randn(8,4) |> size
+(16, 4, 32)
+
+julia> randn(16,8,32) ⊠ randn(8,4,1) |> size  # equivalent
 (16, 4, 32)
 
 julia> randn(16,8) ⊠ randn(8,4,32) |> size

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -104,13 +104,17 @@ end
     @test size(batched_mul(A′,D′)) == (4,5,2)
     @test batched_mul(A′,D′) ≈ half_batched_mul(A′, D′)
 
-    # Large output
+    # Large output, multi-threaded path
     if TB == Float64
         N = 50
         A = rand(N,N,N)
         B = rand(N,N,N)
         C = reshape(reduce(hcat, [vec(A[:,:,k] * B[:,:,k]) for k in 1:N]), N,N,N)
         @test C ≈ A ⊠ B
+
+        D = rand(N,N,1)
+        E = reshape(reduce(hcat, [vec(A[:,:,k] * D[:,:,1]) for k in 1:N]), N,N,N)
+        @test E ≈ A ⊠ D
     end
 end
 

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -103,6 +103,15 @@ end
     D′ = randn(TB, 3,5,1)
     @test size(batched_mul(A′,D′)) == (4,5,2)
     @test batched_mul(A′,D′) ≈ half_batched_mul(A′, D′)
+
+    # Large output
+    if TB == Float64
+        N = 50
+        A = rand(N,N,N)
+        B = rand(N,N,N)
+        C = reshape(reduce(hcat, [vec(A[:,:,k] * B[:,:,k]) for k in 1:N]), N,N,N)
+        @test C ≈ A ⊠ B
+    end
 end
 
 @testset "BatchedAdjOrTrans interface * $TB" for TB in [Float64, Float32]
@@ -196,12 +205,5 @@ end
     @test is_strided(batched_transpose(A))
     @test !is_strided(batched_adjoint(A .+ im))
     @test is_strided(batched_transpose(A .+ im))
-
-    #=
-    using SparseArrays
-    @test !is_strided(sparse(M))
-    using NamedDims
-    @test is_strided(NamedDimsArray(M,(:a, :b))) # and 0.029 ns, 0 allocations
-    =#
 
 end


### PR DESCRIPTION
This adds:
* multi-threading via `Threads.@spawn`, which is disabled for very small problems
* methods `batched_mul(::Array{T,3}, ::Matrix)` which reshape to a 3-array
* unicode alias `⊠` for infix use
* a function `batched_vec(::Array{T,3}, ::Matrix)` which reshapes so that the matrix is a batch of vectors
* more detailed docstrings.

I've marked it draft as it refers to things being added here: https://github.com/JuliaMath/TensorCore.jl/pull/1. But that could be removed for now. 