### PR TITLE
Remove TODO about not defining broadcasted for ADs other than Zygote

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -229,9 +229,10 @@ for f in (:σ, :hardσ, :logσ, :hardtanh, :relu, :leakyrelu,
       error("Use broadcasting (`", $(string(f)), ".(x)`) to apply activation functions to arrays.")
 end
 
-# # This is a performance hack specifically for Zygote, because it doesn't handle fused
-# # broadcasts well
-# TODO: don't define these for ADs other than Zygote
+# Define rrules for broadcasted activation functions.
+# This is a performance hack is specifically for Zygote, because it doesn't handle fused
+# broadcasts well; but it generally should be good (or at least harmless) for any AD, as 
+# it saves ADing the broadcasting machinery.
 for (f, df) in [
     (:relu, :(x .> 0)),
     (:selu, :(dselu.(x))),


### PR DESCRIPTION
Follow up from #257 I think we should do this for all ADs,
and so the TODO shouldn't be there.

AFAICT, this code is basically just hand-unrolling what the AD would ideally do on its own.
So at worst it has basically no effect except maybe to reduce compile-time slightly.

We are talking about doing something like this for a whole bunch of scalar functions in ChainRules.
https://github.com/JuliaDiff/ChainRules.jl/issues/222

@willtebbutt what do you think?