### PR TITLE
fix hardsigmoid and use float(x) instead of x/1 

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -33,13 +33,13 @@ end
 const sigmoid = σ
 
 """
-    hardσ(x, a=0.2) = max(0, min(1, a * x + 0.5))
+    hardσ(x) = max(0, min(1, (x + 1)/2)
 
 Segment-wise linear approximation of sigmoid.
 See [BinaryConnect: Training Deep Neural Networks withbinary weights during propagations](https://arxiv.org/abs/1511.00363).
 """
-hardσ(x, a=0.2) = oftype(x/1, max(zero(x/1), min(one(x/1), oftype(x/1,a) * x + oftype(x/1,0.5))))
-    
+hardσ(x) = max(zero(x), min(one(x), (x + 1) / 2))
+
 const hardsigmoid = hardσ
 
 """
@@ -56,7 +56,7 @@ const logsigmoid = logσ
 Segment-wise linear approximation of tanh. Cheaper  and  more  computational  efficient version of tanh.
 See [Large Scale Machine Learning](https://ronan.collobert.com/pub/matos/2004_phdthesis_lip6.pdf).
 """
-hardtanh(x) = max(-one(x), min( one(x), x))
+hardtanh(x) = max(-one(x), min(one(x), x))
 
 """
     relu(x) = max(0, x)
@@ -73,7 +73,7 @@ Leaky [Rectified Linear Unit](https://en.wikipedia.org/wiki/Rectifier_(neural_ne
 activation function.
 You can also specify the coefficient explicitly, e.g. `leakyrelu(x, 0.01)`.
 """
-leakyrelu(x, a = oftype(x/1, 0.01)) = max(a * x, x/1)
+leakyrelu(x, a=0.01f0) = max(a * x, x)
 
 """
     relu6(x) = min(max(0, x), 6)
@@ -93,8 +93,8 @@ Randomized Leaky [Rectified Linear Unit](https://arxiv.org/abs/1505.00853)
 activation function.
 You can also specify the bound explicitly, e.g. `rrelu(x, 0.0, 1.0)`.
 """
-function rrelu(x, l = 1 / 8.0, u = 1 / 3.0)
-    a = oftype(x / 1, (u - l) * rand() + l)
+function rrelu(x::T, l=1/8f0, u=1/3f0) where T<:Number
+    a = (u - l) * rand(float(T)) + l
     return leakyrelu(x, a)
 end
 
@@ -105,10 +105,9 @@ Exponential Linear Unit activation function.
 See [Fast and Accurate Deep Network Learning by Exponential Linear Units](https://arxiv.org/abs/1511.07289).
 You can also specify the coefficient explicitly, e.g. `elu(x, 1)`.
 """
-elu(x, α=1) = ifelse(x ≥ 0, x/1, α * (exp(x) - 1))
+elu(x, α=1) = ifelse(x ≥ 0, x, α * (exp(x) - 1))
 
-deriv_elu(x, Ω, α=1) = ifelse(x ≥ 0, one(x), Ω + α)
-
+deriv_elu(Ω, α=1) = ifelse(Ω ≥ 0, one(Ω), Ω + α)
 
 """
     gelu(x) = 0.5x * (1 + tanh(√(2/π) * (x + 0.044715x^3)))
@@ -117,10 +116,11 @@ deriv_elu(x, Ω, α=1) = ifelse(x ≥ 0, one(x), Ω + α)
 activation function.
 """
 function gelu(x)
-    λ = oftype(x / 1, √(2 / π))
-    α = oftype(x / 1, 0.044715)
-    x/2 * (1 + tanh(λ * (x + α * x^3)))
+    α = 0.044715f0
+    x/2 * (1 + tanh(gelu_λ * (x + α * x^3)))
 end
+
+const gelu_λ = √(2f0 / π)
 
 """
     swish(x) = x * σ(x)
@@ -148,15 +148,14 @@ Scaled exponential linear units.
 See [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515).
 """
 function selu(x)
-    λ = oftype(x/1, 1.0507009873554804934193349852946)
-    α = oftype(x/1, 1.6732632423543772848170429916717)
-    λ * ifelse(x > 0, x/1, α * (exp(x) - 1))
+    selu_λ * ifelse(x > 0, x, selu_α * (exp(x) - 1))
 end
 
+const selu_λ = convert(Float32, 1.0507009873554804934193349852946)
+const selu_α = convert(Float32, 1.6732632423543772848170429916717)
+
 function deriv_selu(Ω)
-    λ = oftype(Ω/1, 1.0507009873554804934193349852946)
-    α = oftype(Ω/1, 1.6732632423543772848170429916717)
-    return ifelse(Ω > 0, λ, Ω + α*λ)
+    ifelse(Ω > 0, selu_λ, Ω + selu_α*selu_λ)
 end
 
 """
@@ -165,7 +164,7 @@ end
 Continuously Differentiable Exponential Linear Units
 See [Continuously Differentiable Exponential Linear Units](https://arxiv.org/abs/1704.07483).
 """
-celu(x, α=1) = ifelse(x ≥ 0, x/1, α * (exp(x/α) - 1))
+celu(x, α=1) = ifelse(x ≥ 0, x, α * (exp(x/α) - 1))
 
 """
     trelu(x, theta=1) = x > theta ? x : 0
@@ -181,7 +180,7 @@ const thresholdrelu = trelu
 
 See [Quadratic Polynomials Learn Better Image Features](http://www.iro.umontreal.ca/~lisa/publications2/index.php/attachments/single/205).
 """
-softsign(x) = x / (one(x) + abs(x))
+softsign(x) = x / (1 + abs(x))
 
 """
     softplus(x) = log(exp(x) + 1)
@@ -195,8 +194,9 @@ softplus(x) = ifelse(x > 0, x + log1p(exp(-x)), log1p(exp(x)))
 
 Return `log(cosh(x))` which is computed in a numerically stable way.
 """
-logcosh(x) = x + softplus(-2x) - log(oftype(x, 2))
+logcosh(x) = x + softplus(-2x) - log2f0
 
+const log2f0 = log(2f0)
 
 """
     mish(x) = x * tanh(softplus(x))
@@ -219,7 +219,7 @@ tanhshrink(x) = x - tanh(x)
 
 See [Softshrink Activation Function](https://www.gabormelli.com/RKB/Softshrink_Activation_Function).
 """
-softshrink(x, λ = oftype(x/1, 0.5)) = min(max(zero(x), x - λ), x + λ)
+softshrink(x, λ=0.5f0) = min(max(zero(x), x - λ), x + λ)
 
 # Provide an informative error message if activation functions are called with an array
 for f in ACTIVATIONS
@@ -241,7 +241,7 @@ UNARY_ACTS = [ # f, df
     (:hardtanh,     :(-1 < x < 1)),
     (:selu,         :(deriv_selu(Ω))),
     (:σ,            :(conj(Ω * (1 - Ω)))),
-    (:elu,          :(deriv_elu(x, Ω))),
+    (:elu,          :(deriv_elu(Ω))),
     ]
 
 for (f, df) in UNARY_ACTS
@@ -260,7 +260,7 @@ end
 
 
 BINARY_ACTS = [ # f, df1, df2
-    (:elu, :(deriv_elu(x1, Ω, x2)), :(DoesNotExist())), # TODO use real deriv instead of DNE
+    (:elu, :(deriv_elu(Ω, x2)), :(DoesNotExist())), # TODO use real deriv instead of DNE
     ]
 
 for (f, df1, df2) in BINARY_ACTS

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -58,7 +58,7 @@ const logsigmoid = logσ
 Segment-wise linear approximation of tanh. Cheaper  and  more  computational  efficient version of tanh.
 See [Large Scale Machine Learning](https://ronan.collobert.com/pub/matos/2004_phdthesis_lip6.pdf).
 """
-hardtanh(x) = max(-1, min(1, x))
+hardtanh(x) = max(-one(x), min(one(x), x))
 
 """
     relu(x) = max(0, x)
@@ -66,7 +66,7 @@ hardtanh(x) = max(-1, min(1, x))
 [Rectified Linear Unit](https://en.wikipedia.org/wiki/Rectifier_(neural_networks))
 activation function.
 """
-relu(x) = max(0, x)
+relu(x) = max(zero(x), x)
 
 """
     leakyrelu(x, a=0.01) = max(a*x, x)
@@ -84,7 +84,7 @@ leakyrelu(x, a=oftf(x, 0.01)) = max(a * x, x)
 activation function capped at 6.
 See [Convolutional Deep Belief Networks on CIFAR-10](https://www.cs.toronto.edu/~kriz/conv-cifar10-aug2010.pdf)
 """
-relu6(x) = min(relu(x), 6)
+relu6(x) = min(relu(x), oftype(x, 6))
 
 """
     rrelu(x, l=1/8, u=1/3) = max(a*x, x)
@@ -107,7 +107,7 @@ Exponential Linear Unit activation function.
 See [Fast and Accurate Deep Network Learning by Exponential Linear Units](https://arxiv.org/abs/1511.07289).
 You can also specify the coefficient explicitly, e.g. `elu(x, 1)`.
 """
-elu(x, α=1) = ifelse(x ≥ 0, x, α * (exp(x) - 1))
+elu(x, α=1) = ifelse(x ≥ 0, float(x), α * (exp(x) - 1))
 
 deriv_elu(Ω, α=1) = ifelse(Ω ≥ 0, 1, Ω + α)
 
@@ -171,7 +171,7 @@ end
 Continuously Differentiable Exponential Linear Units
 See [Continuously Differentiable Exponential Linear Units](https://arxiv.org/abs/1704.07483).
 """
-celu(x, α=1) = ifelse(x ≥ 0, x, α * (exp(x/α) - 1))
+celu(x, α=1) = ifelse(x ≥ 0, float(x), α * (exp(x/α) - 1))
 
 """
     trelu(x, theta=1) = x > theta ? x : 0

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -15,6 +15,17 @@ function test_value_float_precision_preserving(a)
     end
 end
 
+function test_value_int_input_forces_float64(a)
+    @testset "$(a): " begin
+        for T in [Int32, Int64]
+            for val in [-10, -1, 0, 1, 10]
+                val = @inferred a(T(val))
+                @test typeof(val) == Float64
+            end
+        end
+    end
+end
+
 function test_gradient_float_precision_preserving(a)
     @testset "$(a): " begin
         for T in [Float16, Float32, Float64]
@@ -99,6 +110,34 @@ end
     x = rand(5)
     for a in ACTIVATION_FUNCTIONS
         @test_throws ErrorException a(x)
+    end
+end
+
+@testset "Test Integer64 and Integer32 inputs will force Float64 outputs" begin
+    test_value_int_input_forces_float64.(filter(x -> (x != relu && x != relu6 && x != hardtanh && x != trelu), ACTIVATION_FUNCTIONS))
+
+    @testset "relu: " begin
+        # relu doesn't have to force floating point outputs
+        @test typeof(relu(Int64(1))) == Int64
+        @test typeof(relu(Int32(1))) == Int32
+    end
+
+    @testset "relu6: " begin
+        # relu6 doesn't have to force floating point outputs
+        @test typeof(relu6(Int64(1))) == Int64
+        @test typeof(relu6(Int32(1))) == Int32
+    end
+
+    @testset "hardtanh: " begin
+        # hardtanh doesn't have to force floating point outputs
+        @test typeof(hardtanh(Int64(1))) == Int64
+        @test typeof(hardtanh(Int32(1))) == Int32
+    end
+
+    @testset "trelu: " begin
+        # trelu doesn't have to force floating point outputs
+        @test typeof(trelu(Int64(1))) == Int64
+        @test typeof(trelu(Int32(1))) == Int32
     end
 end
 


### PR DESCRIPTION
~~We do a lot of wasteful divisions in the effort of being type stable with integer inputs, something which we don't really care about. 
With this PR we still support integer inputs but we focus on Float32 and Float64 performances.
I remove all those `x/1` divisions and  `oftype(x/1, someconstant)` conversions.
As a result, the code is also much nicer. 
This PR is breaking for integer inputs and also disrespectful of Float16, since all constants are now Float32. 
We should benchmark  before merging (if we want to merge)
This PR makes some of the function type-unstable with integer inputs~~
 
- Fix the hardsigmoid definition, not matching the cited paper, so that now it matches the pytorch definition.
- Replace the occurrencies of `x / 1`  with `float(x)` for clarity