### PR TITLE
improve bilinear upsampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.7.10"
+version = "0.7.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -29,9 +29,6 @@ The interpolation grid is identical to the one used by open-cv.
 
 Currently only 2d upsampling is supported.
 """
-function upsample_bilinear end
-
-# this is the user-facing part
 function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); outsize::Union{Nothing,NTuple{2,Integer}}=nothing) where T
     w,h,c,n = size(x)
     if outsize===nothing
@@ -150,8 +147,6 @@ end
 # Outputs
 - `dx`: downsampled version of `Δ`
 """
-function ∇upsample_bilinear end
-
 function ∇upsample_bilinear(Δ::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); outsize::Union{Nothing,NTuple{2,Integer}}=nothing) where T
     w,h,c,n = size(Δ)
     if outsize===nothing

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -171,22 +171,13 @@ end
 # Outputs
 - `dx`: downsampled version of `Δ`
 """
-function ∇upsample_bilinear(Δ::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
-    w,h,c,n = Base.size(Δ)
-    if scale != (1,1) && size !== nothing
-        error("Please provide either scale or size, not both. Got scale=$scale and size=$size.")
-    end
-    if size===nothing
-        out_w = ceil(Int, w/scale[1])
-        out_h = ceil(Int, h/scale[2])
-    else
-        out_w, out_h = size
+function ∇upsample_bilinear(Δ::AbstractArray{T,4}; size::NTuple{2,Integer}) where T
+    out_w, out_h = size
     end
     dx = zeros(T, out_w, out_h, c, n)
     return ∇upsample_bilinear_whcn!(Δ, dx)
 end
 
-∇upsample_bilinear(Δ, scale::Real; size=nothing) = ∇upsample_bilinear(Δ, (scale, scale); size=size)
 
 function ∇upsample_bilinear_whcn!(Δ::AbstractArray{T,4}, grad_input::AbstractArray{T,4}) where T
     size(grad_input)[3:4] == size(Δ)[3:4] || error("Number of input and output channels and batches must match. Got input $(size(input)) and output $(size(output))")

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -222,7 +222,7 @@ end
 function ChainRulesCore.rrule(::typeof(upsample_bilinear), x, scale; size=nothing)
     Ω = upsample_bilinear(x, scale; size=size)
     function upsample_bilinear_pullback(Δ)
-        (NO_FIELDS, ∇upsample_bilinear(Δ, scale; size=(Base.size(x,1),Base.size(x,2))), DoesNotExist())
+        (NO_FIELDS, ∇upsample_bilinear(Δ; size=(Base.size(x,1),Base.size(x,2))), DoesNotExist())
     end
     return Ω, upsample_bilinear_pullback
 end

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -20,13 +20,13 @@ end
     upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); outsize::Union{Nothing,NTuple{2,Integer}}=nothing)
 
 Upsamples the first 2 dimensions of the array `x` by the upsample factors stored in `scale`,
-using bilinear interpolation. The interpolation is identical to the one used by pytorch.
+using bilinear interpolation.
 
 The size of the output is equal to
 `(scale[1]*S1, scale[2]*S2, S3, S4)`, where `S1, S2, S3, S4 = size(x)`.
 
 Examples:
-```
+```julia
 upsample_bilinear(x, (2, pi)) # real scaling factors are allowed
 upsample_bilinear(x; outsize=(64,64)) # note the semicolon, outsize is a keyword argument
 ```

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -20,13 +20,16 @@ end
     upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); outsize::Union{Nothing,NTuple{2,Integer}}=nothing)
 
 Upsamples the first 2 dimensions of the array `x` by the upsample factors stored in `scale`,
-using bilinear interpolation.
+using bilinear interpolation. The interpolation is identical to the one used by pytorch.
 
 The size of the output is equal to
 `(scale[1]*S1, scale[2]*S2, S3, S4)`, where `S1, S2, S3, S4 = size(x)`.
 
-The interpolation grid is identical to the one used by open-cv.
-
+Examples:
+```
+upsample_bilinear(x, (2, pi)) # real scaling factors are allowed
+upsample_bilinear(x; outsize=(64,64)) # note the semicolon, outsize is a keyword argument
+```
 Currently only 2d upsampling is supported.
 """
 function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); outsize::Union{Nothing,NTuple{2,Integer}}=nothing) where T

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -219,7 +219,7 @@ function ∇upsample_bilinear_whcn!(Δ::AbstractArray{T,4}, grad_input::Abstract
     return grad_input
 end
 
-function ChainRulesCore.rrule(::typeof(upsample_bilinear), x, scale; size=nothing)
+function ChainRulesCore.rrule(::typeof(upsample_bilinear), x, scale=(1,1); size=nothing)
     Ω = upsample_bilinear(x, scale; size=size)
     function upsample_bilinear_pullback(Δ)
         (NO_FIELDS, ∇upsample_bilinear(Δ; size=(Base.size(x,1),Base.size(x,2))), DoesNotExist())

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -213,7 +213,7 @@ end
 function ChainRulesCore.rrule(::typeof(upsample_bilinear), x; size)
     Ω = upsample_bilinear(x; size=size)
     function upsample_bilinear_pullback(Δ)
-        (NO_FIELDS, ∇upsample_bilinear(Δ; size=(Base.size(x,1),Base.size(x,2))), DoesNotExist())
+        (NO_FIELDS, ∇upsample_bilinear(Δ; size=(Base.size(x,1),Base.size(x,2))))
     end
     return Ω, upsample_bilinear_pullback
 end

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -34,7 +34,10 @@ Currently only 2d upsampling is supported.
 """
 function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
     w,h,c,n = Base.Base.size(x)
-    if size===nothing
+    if scale != (1,1) && size !== nothing
+        error("Please provide either scale or size, not both. Got scale=$scale and size=$size.")
+    end
+    if size === nothing
         out_w = floor(Int, scale[1]*w)
         out_h = floor(Int, scale[2]*h)
     else
@@ -100,6 +103,9 @@ end
 """
 function ∇upsample_bilinear(Δ::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
     w,h,c,n = Base.size(Δ)
+    if scale != (1,1) && size !== nothing
+        error("Please provide either scale or size, not both. Got scale=$scale and size=$size.")
+    end
     if size===nothing
         out_w = ceil(Int, w/scale[1])
         out_h = ceil(Int, h/scale[2])

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -44,6 +44,8 @@ function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); o
     return upsample_bilinear_whcn!(y, x)
 end
 
+upsample_bilinear(x, scale::Real; outsize=nothing) = upsample_bilinear(x, (scale,scale); outsize=outsize)
+
 # this is the core function which works on arrays of arbitrary size
 # the implementation is a translation of https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
 # which implements open-cv style linear interpolation / upsampling
@@ -107,6 +109,8 @@ function ∇upsample_bilinear(Δ::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1
     dx = zeros(T, out_w, out_h, c, n)
     return ∇upsample_bilinear_whcn!(Δ, dx)
 end
+
+∇upsample_bilinear(Δ, scale::Real; outsize=nothing) = ∇upsample_bilinear(Δ, (scale, scale); outsize=outsize)
 
 function ∇upsample_bilinear_whcn!(Δ::AbstractArray{T,4}, grad_input::AbstractArray{T,4}) where T
     size(grad_input)[3:4] == size(Δ)[3:4] || error("Number of input and output channels and batches must match. Got input $(size(input)) and output $(size(output))")

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -89,12 +89,13 @@ using bilinear interpolation.
 The size of the output is equal to
 `(scale[1]*S1, scale[2]*S2, S3, S4)`, where `S1, S2, S3, S4 = size(x)`.
 
+As an alternative to using `scale`, the resulting image `size` can be directly specified with a keyword argument.
+
 Examples:
 ```julia
 upsample_bilinear(x, (2, pi)) # real scaling factors are allowed
-upsample_bilinear(x; size=(64,64)) # note the semicolon, size is a keyword argument
+upsample_bilinear(x; size=(64,64)) # specify ouput size
 ```
-Currently only 2d upsampling is supported.
 """
 function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
     w,h,c,n = Base.size(x)
@@ -163,7 +164,7 @@ function upsample_bilinear_whcn!(output::AbstractArray{T,4}, input::AbstractArra
 end
 
 """
-    ∇upsample_bilinear(Δ::AbstractArray{T,4}; size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
+    ∇upsample_bilinear(Δ::AbstractArray{T,4}; size::NTuple{2,Integer}) where T
 
 # Arguments
 - `Δ`: Incoming gradient array, backpropagated from downstream layers

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -97,7 +97,7 @@ upsample_bilinear(x; size=(64,64)) # note the semicolon, size is a keyword argum
 Currently only 2d upsampling is supported.
 """
 function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
-    w,h,c,n = Base.Base.size(x)
+    w,h,c,n = Base.size(x)
     if scale != (1,1) && size !== nothing
         error("Please provide either scale or size, not both. Got scale=$scale and size=$size.")
     end

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -49,6 +49,12 @@ end
 
 upsample_bilinear(x, scale::Real; size=nothing) = upsample_bilinear(x, (scale,scale); size=size)
 
+function upsample_bilinear(x::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size=nothing) where T<:Integer
+    y = float.(x)
+    res = upsample_bilinear(y, scale; size=size)
+    return round.(T, res)
+end
+
 # this is the core function which works on arrays of arbitrary size
 # the implementation is a translation of https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
 # which implements open-cv style linear interpolation / upsampling

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -163,21 +163,21 @@ function upsample_bilinear_whcn!(output::AbstractArray{T,4}, input::AbstractArra
 end
 
 """
-    ∇upsample_bilinear(Δ::AbstractArray{T,4}, scale::NTuple{2,Real}=(1,1); size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
+    ∇upsample_bilinear(Δ::AbstractArray{T,4}; size::Union{Nothing,NTuple{2,Integer}}=nothing) where T
 
 # Arguments
-- `Δ`: incoming gradient array that has been upsampled using the upsample factors in `scale`
+- `Δ`: Incoming gradient array, backpropagated from downstream layers
+- `size`: Lateral (W,H) size of the image upsampled in the first place
 
 # Outputs
-- `dx`: downsampled version of `Δ`
+- `dx`: Downsampled version of `Δ`
 """
 function ∇upsample_bilinear(Δ::AbstractArray{T,4}; size::NTuple{2,Integer}) where T
+    _, _, c, n = Base.size(Δ)
     out_w, out_h = size
-    end
     dx = zeros(T, out_w, out_h, c, n)
     return ∇upsample_bilinear_whcn!(Δ, dx)
 end
-
 
 function ∇upsample_bilinear_whcn!(Δ::AbstractArray{T,4}, grad_input::AbstractArray{T,4}) where T
     size(grad_input)[3:4] == size(Δ)[3:4] || error("Number of input and output channels and batches must match. Got input $(size(input)) and output $(size(output))")

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -319,7 +319,7 @@ end
 # test "true" strided case, see https://github.com/FluxML/NNlib.jl/issues/205
 
 
-# obtained with 
+# obtained with
 # using FiniteDifferences
 maxpool_answer_nature = Dict(
     "rank1" => Dict(
@@ -327,62 +327,62 @@ maxpool_answer_nature = Dict(
         "k2s1p0" => (size = (2,),
             stride = 1,
             pad = 0,
-    
-            x = reshape([ 
+
+            x = reshape([
                 0.0299635,  0.233456,  0.596161,   0.161514,  0.0094027
             ], 5, 1, 1), # width, channel, batch_size
-    
+
             dx_maxpool = reshape([
                  0.0, 1.0, 2.0, 1.0, 0.0
             ], 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                  0.5, 1.0, 1.0, 1.0, 0.5
             ], 5, 1, 1),),
         "k2s1p1" => (size = (2,),
             stride = 1,
             pad = 1,
-            
-            x = reshape([ 
+
+            x = reshape([
                 0.0299635,  0.233456,  0.596161,   0.161514,  0.0094027
             ], 5, 1, 1),
-    
+
             dx_maxpool = reshape([
                  1.0, 1.0, 2.0, 1.0, 1.0
             ], 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                  1.0, 1.0, 1.0, 1.0, 1.0
             ], 5, 1, 1),),
         "k3s1p1" => (size = (3,),
             stride = 1,
             pad = 1,
-    
-            x = reshape([ 
+
+            x = reshape([
                 0.0299635,  0.233456,  0.596161,   0.161514,  0.0094027
             ], 5, 1, 1),
-    
+
             dx_maxpool = reshape([
                  0.0, 1.0, 3.0, 1.0, 0.0
             ], 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                  0.6666666666, 1.0, 1.0, 1.0, 0.6666666666
             ], 5, 1, 1),),
         "k3s2p1" => (size = (3,),
             stride = 2,
             pad = 1,
-    
-            x = reshape([ 
+
+            x = reshape([
                 0.0299635,  0.233456,  0.596161,   0.161514,  0.0094027
             ], 5, 1, 1),
-    
+
             dx_maxpool = reshape([
                  0.0, 1.0, 1.0, 1.0, 0.0
             ], 5, 1, 1),
-            
+
             dx_meanpool = reshape([
-                 0.333333333, 
+                 0.333333333,
                  0.666666666,
                  0.333333333,
                  0.666666666,
@@ -395,7 +395,7 @@ maxpool_answer_nature = Dict(
             stride = 1,
             pad = 0,
 
-            x = reshape([ 
+            x = reshape([
                 0.0299635  0.233456  0.596161   0.161514  0.0094027
                 0.389984   0.235158  0.579525   0.301893  0.561358
                 0.0830242  0.483759  0.914904   0.253871  0.820061
@@ -408,9 +408,9 @@ maxpool_answer_nature = Dict(
                 1.0  0.0  0.0  0.0  1.0
                 0.0  1.0  4.0  0.0  2.0
                 0.0  1.0  0.0  2.0  0.0
-                0.0  2.0  0.0  0.0  0.0  
+                0.0  2.0  0.0  0.0  0.0
             ], 5, 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                 0.25  0.5  0.5  0.5  0.25
                 0.5   1.0  1.0  1.0  0.5
@@ -421,8 +421,8 @@ maxpool_answer_nature = Dict(
         "k2s1p1" => (size = (2, 2),
             stride = 1,
             pad = 1,
-            
-            x = reshape([ 
+
+            x = reshape([
                 0.0299635  0.233456  0.596161   0.161514  0.0094027
                 0.389984   0.235158  0.579525   0.301893  0.561358
                 0.0830242  0.483759  0.914904   0.253871  0.820061
@@ -437,7 +437,7 @@ maxpool_answer_nature = Dict(
                 1.0  1.0  0.0  2.0  0.0
                 2.0  4.0  1.0  0.0  3.0
             ], 5, 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                 1.0  1.0  1.0  1.0  1.0
                 1.0  1.0  1.0  1.0  1.0
@@ -449,7 +449,7 @@ maxpool_answer_nature = Dict(
             stride = 1,
             pad = 1,
 
-            x = reshape([ 
+            x = reshape([
                 0.0299635  0.233456  0.596161   0.161514  0.0094027
                 0.389984   0.235158  0.579525   0.301893  0.561358
                 0.0830242  0.483759  0.914904   0.253871  0.820061
@@ -464,7 +464,7 @@ maxpool_answer_nature = Dict(
                 0.0  1.0  0.0  3.0  0.0
                 0.0  3.0  0.0  0.0  0.0
             ], 5, 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                 0.444444  0.666667  0.666667  0.666667  0.444444
                 0.666667  1.0       1.0       1.0       0.666667
@@ -476,7 +476,7 @@ maxpool_answer_nature = Dict(
             stride = 2,
             pad = 1,
 
-            x = reshape([ 
+            x = reshape([
                 0.0299635  0.233456  0.596161   0.161514  0.0094027
                 0.389984   0.235158  0.579525   0.301893  0.561358
                 0.0830242  0.483759  0.914904   0.253871  0.820061
@@ -491,7 +491,7 @@ maxpool_answer_nature = Dict(
                 0.0  1.0  0.0  2.0  0.0
                 0.0  1.0  0.0  0.0  0.0
             ], 5, 5, 1, 1),
-            
+
             dx_meanpool = reshape([
                 0.111111  0.222222  0.111111  0.222222  0.111111
                 0.222222  0.444444  0.222222  0.444444  0.222222
@@ -505,7 +505,7 @@ maxpool_answer_nature = Dict(
         "k2s1p0" => (size = (2, 2, 2),
             stride = 1,
             pad = 0,
-    
+
             x = reshape(cat([
                     0.82584   0.416818  0.92668   0.471931
                     0.798798  0.131608  0.344556  0.79681
@@ -524,7 +524,7 @@ maxpool_answer_nature = Dict(
                     0.640221  0.28811   0.129229  0.97571
                     0.953795  0.1316    0.94538   0.705337
                 ],dims=3), 4,4,3,1,1),
-    
+
             dx_maxpool = reshape(cat([
                      1.0  0.0  2.0  0.0
                      1.0  0.0  0.0  0.0
@@ -543,7 +543,7 @@ maxpool_answer_nature = Dict(
                      0.0  0.0  0.0  2.0
                      1.0  0.0  1.0  0.0
                 ],dims=3), 4,4,3,1,1),
-            
+
             dx_meanpool = reshape(cat([
                      0.125  0.25  0.25  0.125
                      0.25   0.5   0.5   0.25
@@ -565,7 +565,7 @@ maxpool_answer_nature = Dict(
         "k2s1p1" => (size = (2, 2, 2),
             stride = 1,
             pad = 1,
-            
+
             x = reshape(cat([
                     0.82584   0.416818  0.92668   0.471931
                     0.798798  0.131608  0.344556  0.79681
@@ -584,7 +584,7 @@ maxpool_answer_nature = Dict(
                     0.640221  0.28811   0.129229  0.97571
                     0.953795  0.1316    0.94538   0.705337
                 ],dims=3), 4,4,3,1,1),
-    
+
             dx_maxpool = reshape(cat([
                      8.0  0.0  8.0  2.0
                      4.0  0.0  1.0  4.0
@@ -603,7 +603,7 @@ maxpool_answer_nature = Dict(
                      3.0  0.0  0.0  8.0
                      8.0  0.0  6.0  1.0
                 ],dims=3), 4,4,3,1,1),
-            
+
             dx_meanpool = reshape(cat([
                      1.0  1.0  1.0  1.0
                      1.0  1.0  1.0  1.0
@@ -625,7 +625,7 @@ maxpool_answer_nature = Dict(
         "k3s1p1" => (size = (3, 3, 2),
             stride = 1,
             pad = 1,
-    
+
             x = reshape(cat([
                     0.82584   0.416818  0.92668   0.471931
                     0.798798  0.131608  0.344556  0.79681
@@ -644,7 +644,7 @@ maxpool_answer_nature = Dict(
                     0.640221  0.28811   0.129229  0.97571
                     0.953795  0.1316    0.94538   0.705337
                 ],dims=3), 4,4,3,1,1),
-    
+
             dx_maxpool = reshape(cat([
                      4.0  0.0  12.0  0.0
                      3.0  0.0   0.0  2.0
@@ -663,7 +663,7 @@ maxpool_answer_nature = Dict(
                      0.0  0.0  0.0  12.0
                      8.0  0.0  0.0   0.0
                 ],dims=3), 4,4,3,1,1),
-            
+
             dx_meanpool = reshape(cat([
                      0.444444  0.666667  0.666667  0.444444
                      0.666667  1.0       1.0       0.666667
@@ -685,7 +685,7 @@ maxpool_answer_nature = Dict(
         "k3s2p1" => (size = (3, 3, 2),
             stride = 2,
             pad = 1,
-    
+
             x = reshape(cat([
                     0.82584   0.416818  0.92668   0.471931
                     0.798798  0.131608  0.344556  0.79681
@@ -704,7 +704,7 @@ maxpool_answer_nature = Dict(
                     0.640221  0.28811   0.129229  0.97571
                     0.953795  0.1316    0.94538   0.705337
                 ],dims=3), 4,4,3,1,1),
-    
+
             dx_maxpool = reshape(cat([
                      1.0  0.0  1.0  0.0
                      1.0  0.0  0.0  1.0
@@ -723,7 +723,7 @@ maxpool_answer_nature = Dict(
                      0.0  0.0  0.0  1.0
                      1.0  0.0  0.0  0.0
                 ],dims=3), 4,4,3,1,1),
-            
+
             dx_meanpool = reshape(cat([
                      0.0555556  0.111111  0.0555556  0.0555556
                      0.111111   0.222222  0.111111   0.111111
@@ -750,7 +750,7 @@ maxpool_answer_nature = Dict(
     # issue #205
     function check(config, T)
         # CHECK DEFAULT
-        pdims = PoolDims(config.x, config.size; stride=config.stride, padding=config.pad)        
+        pdims = PoolDims(config.x, config.size; stride=config.stride, padding=config.pad)
         x = T.(config.x)
         y_maxpool = NNlib.maxpool(x, pdims)
         y_meanpool = NNlib.meanpool(x, pdims)
@@ -813,15 +813,15 @@ end
 @testset "AutoDiff: spatial_rank=$spatial_rank" for spatial_rank in (1, 2)
   x = rand(rng, repeat([10], spatial_rank)..., 3, 2)
   pdims = PoolDims(x, 2)
-  gradtest(x -> maxpool(x, pdims), x; broken=spatial_rank <= 2)
+  gradtest(x -> maxpool(x, pdims), x, broken=spatial_rank <= 0) # was <= 2 before
   gradtest(x -> meanpool(x, pdims), x)
-  gradtest(x -> sum(maxpool(x, pdims)), x, broken=spatial_rank == 2)
+  gradtest(x -> sum(maxpool(x, pdims)), x, broken=spatial_rank == 0)  # was == 2 before
   gradtest(x -> sum(meanpool(x, pdims)), x)
 
   #https://github.com/FluxML/NNlib.jl/issues/188
   k = ntuple(_ -> 2, spatial_rank)  # Kernel size of pool in ntuple format
-  gradtest(x -> maxpool(x, k), x; broken=spatial_rank <= 2)
+  gradtest(x -> maxpool(x, k), x, broken=spatial_rank <= 0) # was <= 2 before
   gradtest(x -> meanpool(x, k), x)
-  gradtest(x -> sum(maxpool(x, k)), x, broken=spatial_rank == 2)
+  gradtest(x -> sum(maxpool(x, k)), x, broken=spatial_rank == 0) # was == 2 before
   gradtest(x -> sum(meanpool(x, k)), x)
 end

--- a/test/upsample.jl
+++ b/test/upsample.jl
@@ -39,7 +39,7 @@ end
     # additional grad check, also compliant with pytorch
     o = ones(Float32,6,4,2,1)
     grad_true = 6*ones(Float32,2,2,2,1)
-    @test ∇upsample_bilinear(o, (3,2)) ≈ grad_true
+    @test ∇upsample_bilinear(o; size = (2,2)) ≈ grad_true
 
     y_true_2 = Rational{Int}[1//1  5//4  6//4  7//4 2//1;
                              3//2  7//4  8//4  9//4 5//2;

--- a/test/upsample.jl
+++ b/test/upsample.jl
@@ -36,6 +36,15 @@
      # check for real-valued single-number argument and type stability for rationals
     upsample_bilinear(x, 2.5) == y_true_2
 
+    # check Integer support for forward pass
+    # grads are always assumed to be floats, so no extension there
+    x = UInt8[1 3; 3 5][:,:,:,:]
+    y_true_int = UInt8[1 2 3; 2 3 4; 3 4 5][:,:,:,:]
+    y = upsample_bilinear(x, 1.5)
+
+    @test eltype(y) == UInt8
+    @test y == y_true_int
+
     # this test can be performed again, as soon as the corresponding CUDA functionality is merged
 
     # if CUDA.has_cuda()

--- a/test/upsample.jl
+++ b/test/upsample.jl
@@ -4,7 +4,7 @@
     x = cat(x,x; dims=4)
 
     # this output matches the one of pytorch v1.5.0
-    # nn.UpsamplingBilinear2d(scale_factor=(3,2))
+    # nn.UpsamplingBilinear2d(scale_factor=(3,2), align_corners=True)
     # for above x
     y_true = Float32[ 1//1  4//3   5//3   2//1;
                       7//5 26//15 31//15 12//5;
@@ -26,6 +26,15 @@
     o = ones(Float32,6,4,1,1)
     grad_true = Float32[6 6; 6 6][:,:,:,:]
     @test ∇upsample_bilinear(o, (3,2)) ≈ grad_true
+
+    y_true_2 = Rational{Int}[1//1  5//4  6//4  7//4 2//1;
+                             3//2  7//4  8//4  9//4 5//2;
+                             4//2  9//4 10//4 11//4 6//2;
+                             5//2 11//4 12//4 13//4 7//2;
+                             3//1 13//4 14//4 15//4 4//1][:,:,:,:]
+
+     # check for real-valued single-number argument and type stability for rationals
+    upsample_bilinear(x, 2.5) == y_true_2
 
     # this test can be performed again, as soon as the corresponding CUDA functionality is merged
 

--- a/test/upsample.jl
+++ b/test/upsample.jl
@@ -3,12 +3,12 @@
     x = cat(x,x; dims=3)
     x = cat(x,x; dims=4)
 
-    y_true = [ 1//1  4//3   5//3   2//1;
-            7//5 26//15 31//15 12//5;
-            9//5 32//15 37//15 14//5;
-           11//5 38//15 43//15 16//5;
-           13//5 44//15 49//15 18//5;
-            3//1 10//3  11//3   4//1]
+    y_true = Float32[ 1//1  4//3   5//3   2//1;
+                      7//5 26//15 31//15 12//5;
+                      9//5 32//15 37//15 14//5;
+                     11//5 38//15 43//15 16//5;
+                     13//5 44//15 49//15 18//5;
+                      3//1 10//3  11//3   4//1][:,:,:,:]
     y_true = cat(y_true,y_true; dims=3)
     y_true = cat(y_true,y_true; dims=4)
 
@@ -17,7 +17,7 @@
     @test eltype(y) == Float32
     @test y ≈ y_true
 
-    gradtest(x->upsample_bilinear(x, (3, 2)), x, atol=1e-4)
+    gradtest(x->upsample_bilinear(x, (3, 2)), x, atol=1e-3) # works to higher precision for Float64
 
     # this test can be performed again, as soon as the corresponding CUDA functionality is merged
 

--- a/test/upsample.jl
+++ b/test/upsample.jl
@@ -23,8 +23,8 @@
     gradtest(x->upsample_bilinear(x, (3, 2)), x, atol=1e-3) # works to higher precision for Float64
 
     # additional grad check, also compliant with pytorch
-    o = ones(Float32,6,4,1,1)
-    grad_true = Float32[6 6; 6 6][:,:,:,:]
+    o = ones(Float32,6,4,2,1)
+    grad_true = 6*ones(Float32,2,2,2,1)
     @test ∇upsample_bilinear(o, (3,2)) ≈ grad_true
 
     y_true_2 = Rational{Int}[1//1  5//4  6//4  7//4 2//1;

--- a/test/upsample.jl
+++ b/test/upsample.jl
@@ -3,6 +3,9 @@
     x = cat(x,x; dims=3)
     x = cat(x,x; dims=4)
 
+    # this output matches the one of pytorch v1.5.0
+    # nn.UpsamplingBilinear2d(scale_factor=(3,2))
+    # for above x
     y_true = Float32[ 1//1  4//3   5//3   2//1;
                       7//5 26//15 31//15 12//5;
                       9//5 32//15 37//15 14//5;
@@ -18,6 +21,11 @@
     @test y ≈ y_true
 
     gradtest(x->upsample_bilinear(x, (3, 2)), x, atol=1e-3) # works to higher precision for Float64
+
+    # additional grad check, also compliant with pytorch
+    o = ones(Float32,6,4,1,1)
+    grad_true = Float32[6 6; 6 6][:,:,:,:]
+    @test ∇upsample_bilinear(o, (3,2)) ≈ grad_true
 
     # this test can be performed again, as soon as the corresponding CUDA functionality is merged
 


### PR DESCRIPTION
Sorry to bother you again! But this stuff didn't let me sleep, so here is a CPU implementation. See [GPU PR](https://github.com/JuliaGPU/CUDA.jl/pull/636) here.

- [x] parallelized
- [x] faster than current implementation
- [x] open-cv and pytorch compliant
- [x] tests pass <- breaking tests seem unrelated (?)

I reviewed the tests of the current implementation and found it a bit strange, actually. So this one comes with a bit different tests.

Mean benchmark times in ms, upsampling by a factor of 2,
tested on 12 threads @3.7Ghz, julia 1.7

32x32x1024x1
|   | before  | after  |
|---|---|---|
| forward  | 53  | 2.7  |
| backward  | 94  |  0.8 |

196x196x128x1
|   | before  | after  |
|---|---|---|
| forward  | 318  | 21  |
| backward  | 64  |  3.6 |

single threaded:

32x32x1024x1
|   | before  | after  |
|---|---|---|
| forward  | 50  | 27  |
| backward  | 71  |  7.5 |

196x196x128x1
|   | before  | after  |
|---|---|---|
| forward  | 300  | 150  |
| backward  | 56  |  35 |

Single core would rock with cwhn tensor layout, but parallelized they are more or less the same.

Kind regards! :)