### PR TITLE
Faster constant padding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,10 @@
 name: CI
+
 # env:
 #   JULIA_NUM_THREADS: 2
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
-    tags: '*'
+
+on: [push, pull_request]
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.julia-threads }} thread(s) - ${{ github.event_name }} 

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -7,7 +7,7 @@ export pad_constant, pad_repeat, pad_reflect, pad_zeros
 Pad the array `x` with zeros.
 Equivalent to [`pad_constant`](@ref) with the constant equal to 0. 
 """
-pad_zeros(x::AbstractArray, pad; dims = :) where M =
+pad_zeros(x::AbstractArray, pad; dims = :) =
   pad_constant(x, pad, 0; dims = dims)
 
 """
@@ -180,7 +180,6 @@ function pad_repeat(x::AbstractArray{F,N}, pad::NTuple{2,Int};
 
   return cat(xl, x, xr, dims = dims)
 end
-
 
 """
     pad_reflect(x, pad::Tuple; [dims])

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -55,6 +55,7 @@ end
 
 gen_pad(pad::Int, dims, N) = gen_pad(ntuple(_ -> pad, length(dims)), dims, N)
 gen_pad(pad::Int, dims::Colon, N) = ntuple(_ -> pad, 2N)
+gen_pad(pad, dims::Colon, N) = gen_pad(pad, ntuple(identity, N), N)
 function gen_pad(pad::NTuple{P,Int}, dims::NTuple{D,Int}, N) where {D,P}
   if P == 2N
     return pad
@@ -68,8 +69,9 @@ function gen_pad(pad::NTuple{P,Int}, dims::NTuple{D,Int}, N) where {D,P}
   elseif P == 2D
     is = pad_idx(pad, dims, N)
     ps = zeros(Int, 2N)
-    for (i,x) in enumerate(is)
-      ps[collect(x)] .= pad[collect(x)]
+    for x in is
+      i = collect(x)
+      @views ps[i] .= pad[i]
     end
     ntuple(i -> ps[i], 2N)
   else

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -69,7 +69,7 @@ function gen_pad(pad::NTuple{P,Int}, dims::NTuple{D,Int}, N) where {D,P}
     is = pad_idx(pad, dims, N)
     ps = zeros(Int, 2N)
     for (i,x) in enumerate(is)
-      ps[collect(x)] .= pad[[i, i+1]]
+      ps[collect(x)] .= pad[collect(x)]
     end
     ntuple(i -> ps[i], 2N)
   else

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -45,7 +45,7 @@ julia> pad_constant(r, (1, 2, 3, 4), 8)
 ```
 """
 pad_constant(x::AbstractArray{T,N}, pad::Int, val = 0; dims = :) where {T,N} =
-  pad_constant(x, ntuple(_ -> pad, 2N), val)
+  pad_constant(x, gen_pad(pad, dims, N), val)
 pad_constant(x::AbstractArray{T,N}, pad::Tuple, val = 0; dims = :) where {T,N} =
   pad_constant(x, gen_pad(pad, dims, N), val)
 
@@ -54,6 +54,7 @@ function pad_idx(pad, dims, N)
 end
 
 gen_pad(pad::Int, dims, N) = gen_pad(ntuple(_ -> pad, length(dims)), dims, N)
+gen_pad(pad::Int, dims::Colon, N) = ntuple(_ -> pad, 2N)
 function gen_pad(pad::NTuple{P,Int}, dims::NTuple{D,Int}, N) where {D,P}
   if P == 2N
     return pad

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -71,6 +71,8 @@ function gen_pad(pad::NTuple{P,Int}, dims::NTuple{D,Int}, N) where {D,P}
       ps[collect(x)] .= pad[[i, i+1]]
     end
     ntuple(i -> ps[i], 2N)
+  else
+    throw(ArgumentError("Passed padding $pad and dims $dims could not be parsed."))
   end
 end
 

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -7,7 +7,7 @@ export pad_constant, pad_repeat, pad_reflect, pad_zeros
 Pad the array `x` with zeros.
 Equivalent to [`pad_constant`](@ref) with the constant equal to 0. 
 """
-pad_zeros(x::AbstractArray, pad::NTuple{M,Int}; dims = 1:M÷2) where M =
+pad_zeros(x::AbstractArray, pad::NTuple{M,Int}; dims = :) where M =
   pad_constant(x, pad, 0; dims = dims)
 
 """
@@ -111,13 +111,13 @@ function size_and_center(x, pad::NTuple{N,Int}) where N
 end
 
 function rrule(::typeof(pad_constant), x::AbstractArray,
-               pad::NTuple{M,Int}, val = 0; 
-               dims = 1:M÷2) where M
+               pad::NTuple{M,Tuple{Int,Int}}, val = 0; 
+               dims = :) where M
   szx = size(x)
-  y = pad_constant(x, pad, val; dims=dims)
+  y = pad_constant(x, pad, val; dims = dims)
   
   function pad_constant_pullback(Δ)
-    outsize, center = pad_outsize_and_center(szx, pad, dims)
+    outsize, center = size_and_center(x, pad)
     (NO_FIELDS, @thunk(Δ[center...]), DoesNotExist(),
      @thunk(sum(Δ) - sum(Δ[center...])),)
   end

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -29,17 +29,24 @@ defaults to the first `ndims(x)-2` dimension
 See also [`pad_reflect`](@ref) and [`pad_repeat`](@ref).
 
 ```jldoctest
-julia> pad_constant(reshape(1:4, 2, 2), (1, 2, 3, 4), 8)
+
+julia> r = reshape(1:4, 2, 2)
+2×2 reshape(::UnitRange{Int64}, 2, 2) with eltype Int64:
+ 1  3
+ 2  4
+
+julia> pad_constant(r, (1, 2, 3, 4), 8)
 5×9 Matrix{Int64}:
  8  8  8  8  8  8  8  8  8
  8  8  8  1  3  8  8  8  8
  8  8  8  2  4  8  8  8  8
  8  8  8  8  8  8  8  8  8
  8  8  8  8  8  8  8  8  8
-````
+```
 """
-function pad_constant(x::AbstractArray, pad::NTuple{M,Int}, val = 0; 
-                    dims = 1:M÷2) where M
+function pad_constant(x::AbstractArray, pad::NTuple{M,Int},
+                      val = 0; 
+                      dims = 1:M÷2) where M
   length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   outsize, center = pad_outsize_and_center(size(x), pad, dims)
@@ -72,8 +79,9 @@ function pad_outsize_and_center(sz::NTuple{N,Int}, pad, dims) where {N}
   return outsize, center
 end
 
-function rrule(::typeof(pad_constant), x::AbstractArray, pad::NTuple{M,Int}, val=0; 
-              dims=1:M÷2) where M
+function rrule(::typeof(pad_constant), x::AbstractArray,
+               pad::NTuple{M,Int}, val=0; 
+               dims=1:M÷2) where M
   szx = size(x)
   y = pad_constant(x, pad, val; dims=dims)
   
@@ -106,7 +114,14 @@ defaults to the first `ndims(x)-2` dimensions
 See also [`pad_reflect`](@ref) and [`pad_constant`](@ref).
 
 ```jldoctest
-julia> pad_repeat(reshape(1:9, 3, 3), (1,2,3,4))
+
+julia> r = reshape(1:9, 3, 3)
+3×3 reshape(::UnitRange{Int64}, 3, 3) with eltype Int64:
+ 1  4  7
+ 2  5  8
+ 3  6  9
+
+julia> pad_repeat(r, (1,2,3,4))
 6×10 Matrix{Int64}:
  1  1  1  1  4  7  7  7  7  7
  1  1  1  1  4  7  7  7  7  7
@@ -162,7 +177,14 @@ defaults to the first `ndims(x)-2` dimensions
 See also [`pad_repeat`](@ref) and [`pad_constant`](@ref).
 
 ```jldoctest
-julia> pad_reflect(reshape(1:9, 3, 3), (1,2,1,2))
+
+julia> r = reshape(1:9, 3, 3)
+3×3 reshape(::UnitRange{Int64}, 3, 3) with eltype Int64:
+ 1  4  7
+ 2  5  8
+ 3  6  9
+
+julia> pad_reflect(r, (1,2,1,2))
 6×6 Matrix{Int64}:
  5  2  5  8  5  2
  4  1  4  7  4  1
@@ -173,7 +195,7 @@ julia> pad_reflect(reshape(1:9, 3, 3), (1,2,1,2))
 ```
 """
 function pad_reflect(x::AbstractArray, pad::NTuple{M,Int}; 
-                    dims=1:M÷2) where M
+                     dims=1:M÷2) where M
   length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   for (i, d) in enumerate(dims)
@@ -183,7 +205,7 @@ function pad_reflect(x::AbstractArray, pad::NTuple{M,Int};
 end
 
 function pad_reflect(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
-                    dims::Int = 1) where {F,N}
+                     dims::Int = 1) where {F,N}
   lpad, rpad = pad
   
   n = size(x, dims)

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -7,12 +7,12 @@ export pad_constant, pad_repeat, pad_reflect, pad_zeros
 Pad the array `x` with zeros.
 Equivalent to [`pad_constant`](@ref) with the constant equal to 0. 
 """
-pad_zeros(x::AbstractArray, pad::NTuple{M,Int}; dims=1:M÷2) where M =
-  pad_constant(x, pad, 0; dims=dims)
+pad_zeros(x::AbstractArray, pad::NTuple{M,Int}; dims = 1:M÷2) where M =
+  pad_constant(x, pad, 0; dims = dims)
 
 """
-    pad_constant(x, pad::Tuple, val=0; [dims])
-    pad_constant(x, pad::Int, val=0; [dims])
+    pad_constant(x, pad::Tuple, val = 0; [dims])
+    pad_constant(x, pad::Int, val = 0; [dims])
 
 Pad the array `x` with the constant value `val`.
 
@@ -38,9 +38,9 @@ julia> pad_constant(reshape(1:4, 2, 2), (1, 2, 3, 4), 8)
  8  8  8  8  8  8  8  8  8
 ````
 """
-function pad_constant(x::AbstractArray, pad::NTuple{M,Int}, val=0; 
-                    dims=1:M÷2) where M
-  length(dims) == M÷2 ||
+function pad_constant(x::AbstractArray, pad::NTuple{M,Int}, val = 0; 
+                    dims = 1:M÷2) where M
+  length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   outsize, center = pad_outsize_and_center(size(x), pad, dims)
   y = fill!(similar(x, eltype(x), outsize), val)
@@ -52,13 +52,13 @@ function pad_outsize_and_center(sz::NTuple{N,Int}, pad, dims) where {N}
   leftpad, rightpad = pad[1:2:end], pad[2:2:end]
   
   outsize = ntuple(N) do i
-              k = findfirst(==(i), dims)
-              if k === nothing
-                return sz[i]
-              else
-                return sz[i] + leftpad[k] + rightpad[k]
-              end
-            end::NTuple{N,Int}
+     k = findfirst(==(i), dims)
+     if k === nothing
+       return sz[i]
+     else
+       return sz[i] + leftpad[k] + rightpad[k]
+     end
+   end::NTuple{N,Int}
   
   leftcorner = ones(Int, N)
   rightcorner = collect(outsize)
@@ -67,8 +67,8 @@ function pad_outsize_and_center(sz::NTuple{N,Int}, pad, dims) where {N}
     rightcorner[d] -= rightpad[i]
   end
   center = ntuple(N) do i
-            leftcorner[i]:rightcorner[i]
-          end 
+    leftcorner[i]:rightcorner[i]
+  end 
   return outsize, center
 end
 
@@ -79,11 +79,8 @@ function rrule(::typeof(pad_constant), x::AbstractArray, pad::NTuple{M,Int}, val
   
   function pad_constant_pullback(Δ)
     outsize, center = pad_outsize_and_center(szx, pad, dims)
-    (NO_FIELDS, 
-    @thunk(Δ[center...]), 
-    DoesNotExist(),
-    @thunk(sum(Δ) - sum(Δ[center...])), 
-    )
+    (NO_FIELDS, @thunk(Δ[center...]), DoesNotExist(),
+     @thunk(sum(Δ) - sum(Δ[center...])),)
   end
   
   return y, pad_constant_pullback
@@ -121,7 +118,7 @@ julia> pad_repeat(reshape(1:9, 3, 3), (1,2,3,4))
 """
 function pad_repeat(x::AbstractArray, pad::NTuple{M,Int}; 
                     dims=1:M÷2) where M
-  length(dims) == M÷2 ||
+  length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   for (i, d) in enumerate(dims)
     x = pad_repeat(x, (pad[2i-1], pad[2i]); dims=d)
@@ -130,19 +127,19 @@ function pad_repeat(x::AbstractArray, pad::NTuple{M,Int};
 end
 
 function pad_repeat(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
-                    dims::Int=1) where {F,N}
+                    dims::Int = 1) where {F,N}
   lpad, rpad = pad
 
   xlborder = selectdim(x, dims, 1:1)
-  nrepl = ntuple(i -> i==dims ? lpad : 1, N)
-  xl = repeat(xlborder, outer=nrepl)
+  nrepl = ntuple(i -> i == dims ? lpad : 1, N)
+  xl = repeat(xlborder, outer = nrepl)
 
   n = size(x, dims)
   xrborder = selectdim(x, dims, n:n)
-  nrepr = ntuple(i -> i==dims ? rpad : 1, N)
-  xr = repeat(xrborder, outer=nrepr)
+  nrepr = ntuple(i -> i == dims ? rpad : 1, N)
+  xr = repeat(xrborder, outer = nrepr)
 
-  return cat(xl, x, xr, dims=dims)
+  return cat(xl, x, xr, dims = dims)
 end
 
 
@@ -177,16 +174,16 @@ julia> pad_reflect(reshape(1:9, 3, 3), (1,2,1,2))
 """
 function pad_reflect(x::AbstractArray, pad::NTuple{M,Int}; 
                     dims=1:M÷2) where M
-  length(dims) == M÷2 ||
+  length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   for (i, d) in enumerate(dims)
-    x = pad_reflect(x, (pad[2i-1], pad[2i]); dims=d)
+    x = pad_reflect(x, (pad[2i-1], pad[2i]); dims = d)
   end  
   return x
 end
 
 function pad_reflect(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
-                    dims::Int=1) where {F,N}
+                    dims::Int = 1) where {F,N}
   lpad, rpad = pad
   
   n = size(x, dims)
@@ -195,15 +192,15 @@ function pad_reflect(x::AbstractArray{F,N}, pad::NTuple{2,Int};
   # Alternative selection, not sure which is faster...
   # xl = reverse(selectdim(x, dims, 2:lpad+1), dims)
   # xr = reverse(selectdim(x, dims, n-rpad:n-1), dims)
-  return cat(xl, x, xr, dims=dims)
+  return cat(xl, x, xr, dims = dims)
 end
 
 # convenience methods for symmetric and homogeneous padding
 pad_repeat(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
-  pad_repeat(x, ntuple(_ -> pad, 2length(dims)); dims=dims)
+  pad_repeat(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
 pad_reflect(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
-  pad_reflect(x, ntuple(_ -> pad, 2length(dims)); dims=dims)
+  pad_reflect(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
 pad_zeros(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
-  pad_zeros(x, ntuple(_ -> pad, 2length(dims)); dims=dims)
+  pad_zeros(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
 pad_constant(x::AbstractArray{F,N}, pad::Int, val=0; dims=1:N-2) where {F,N} =
-  pad_constant(x, ntuple(_ -> pad, 2length(dims)), val; dims=dims)
+  pad_constant(x, ntuple(_ -> pad, 2length(dims)), val; dims = dims)

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -71,7 +71,7 @@ gen_pad(pad::Int, dims, N) = gen_pad(ntuple(_ -> pad, length(dims)), dims, N)
 gen_pad(pad::Int, dims::Colon, N) = ntuple(_ -> pad, 2N)
 gen_pad(pad, dims::Colon, N) = gen_pad(pad, ntuple(identity, N), N)
 function gen_pad(pad::NTuple{L,Int}, dims::NTuple{D,Int}, N) where {L,D}
-  ntuple(Val(N)) do d
+  ntuple(N) do d
    if d in dims
      if L == D
        ix = findfirst(==(d), dims)
@@ -91,10 +91,10 @@ end
 
 
 # Expects length(pad) == 2M
-function pad_constant(x::AbstractArray{T,M}, pad::NTuple{N,Int}, val = 0) where {T,M,N}
-  p = pad_zeros_tuple(pad, M)
+function pad_constant(x::AbstractArray{T,M}, pad::NTuple{N,Tuple{Int,Int}}, val = 0) where {T,M,N}
+  # p = pad_zeros_tuple(pad, M)
   # @show pad
-  # p = tuplejoin(pad...)
+  p = pad_zeros_tuple(tuplejoin(pad...), M)
   sz, c = size_and_center(x, p)
   res = fill!(similar(x, sz...), val)
   res[c..., ntuple(_ -> Colon(), Val(M - 2))...] = x

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -53,6 +53,7 @@ function pad_idx(pad, dims, N)
   is = zip( (2 .* dims) .- 1, (2 .* dims))
 end
 
+gen_pad(pad::Int, dims, N) = gen_pad(ntuple(_ -> pad, length(dims)), dims, N)
 function gen_pad(pad::NTuple{P,Int}, dims::NTuple{D,Int}, N) where {D,P}
   if P == 2N
     return pad

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -19,7 +19,7 @@
   @test all(y .== 0)
 
   @test pad_constant(x, (3, 2, 4)) ≈ pad_zeros(x, (3, 2, 4))
-  @test pad_zeros(x, 2) ≈ pad_zeros(x, (2,2)) 
+  @test pad_zeros(x, 2) ≈ pad_zeros(x, (2,2,2)) 
   
   y = pad_constant(x, (3, 2, 4, 5), 1.2, dims = (1,3))
   @test size(y) == (7, 2, 11)

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -21,7 +21,7 @@
   @test pad_constant(x, (3, 2, 4)) ≈ pad_zeros(x, (3, 2, 4))
   @test pad_zeros(x, 2) ≈ pad_zeros(x, (2,2)) 
   
-  y = pad_constant(x, (3, 2, 4, 5), 1.2, dims=(1,3))
+  y = pad_constant(x, (3, 2, 4, 5), 1.2, dims = (1,3))
   @test size(y) == (7, 2, 11)
   @test y[3:4, 1:2, 6:7] ≈ x
   y[3:4, 1:2, 6:7] .= 1.2

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -1,6 +1,17 @@
 @testset "padding constant" begin
   x = rand(2, 2, 2)  
-  
+
+  p = NNlib.gen_pad((1,2,3,4,5,6), (1,2,3), 4)
+  @test p == (1, 2, 3, 4, 5, 6, 0, 0)
+
+  @test_throws ArgumentError NNlib.gen_pad((1,2,3,4,5,), (1,2,3), 4)
+
+  p = NNlib.gen_pad((1,3), (1,3), 4)
+  @test (1, 1, 0, 0, 3, 3, 0, 0)
+
+  p = NNlib.gen_pad(1, (1,2,3), 4)
+  @test (1, 1, 1, 1, 1, 1, 0, 0)
+
   y = @inferred pad_constant(x, (3, 2, 4, 5))
   @test size(y) == (7, 11, 2)
   @test y[4:5, 5:6, :] ≈ x

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -7,7 +7,7 @@
   @test_throws ArgumentError NNlib.gen_pad((1,2,3,4,5,), (1,2,3), 4)
 
   p = NNlib.gen_pad((1,3), (1,3), 4)
-  @test p == NNlib.gen_pad((1,3), (1,3), 4)
+  @test p == ((1, 1), (0, 0), (3, 3), (0, 0))
 
   p = NNlib.gen_pad(1, (1,2,3), 4)
   @test p == ((1, 1), (1, 1), (1, 1), (0, 0))
@@ -23,8 +23,8 @@
   
   y = pad_constant(x, (3, 2, 4, 5), 1.2, dims = (1,3))
   @test size(y) == (7, 2, 11)
-  @test y[3:4, 1:2, 6:7] ≈ x
-  y[3:4, 1:2, 6:7] .= 1.2
+  @test y[4:5, 1:2, 5:6] ≈ x
+  y[4:5, 1:2, 5:6] .= 1.2
   @test all(y .== 1.2)
   
   @test pad_constant(x, (2,2,2,2), 1.2, dims = (1,3)) ≈

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -2,29 +2,29 @@
   x = rand(2, 2, 2)  
 
   p = NNlib.gen_pad((1,2,3,4,5,6), (1,2,3), 4)
-  @test p == (1, 2, 3, 4, 5, 6, 0, 0)
+  @test p == ((1, 2), (3, 4), (5, 6), (0, 0))
 
   @test_throws ArgumentError NNlib.gen_pad((1,2,3,4,5,), (1,2,3), 4)
 
   p = NNlib.gen_pad((1,3), (1,3), 4)
-  @test p == (1, 1, 0, 0, 3, 3, 0, 0)
+  @test p == NNlib.gen_pad((1,3), (1,3), 4)
 
   p = NNlib.gen_pad(1, (1,2,3), 4)
-  @test p == (1, 1, 1, 1, 1, 1, 0, 0)
+  @test p == ((1, 1), (1, 1), (1, 1), (0, 0))
 
-  y = @inferred pad_constant(x, (3, 2, 4))
-  @test size(y) == (7, 11, 2)
-  @test y[4:5, 5:6, :] ≈ x
-  y[4:5, 5:6, :] .= 0
+  y = pad_constant(x, (3, 2, 4))
+  @test size(y) == (8, 6, 10)
+  @test y[4:5, 3:4, 5:6] ≈ x
+  y[4:5, 3:4, 5:6] .= 0
   @test all(y .== 0)
 
   @test pad_constant(x, (3, 2, 4)) ≈ pad_zeros(x, (3, 2, 4))
   @test pad_zeros(x, 2) ≈ pad_zeros(x, (2,2)) 
   
-  y = @inferred pad_constant(x, (3, 2, 4, 5), 1.2, dims=(1,3))
+  y = pad_constant(x, (3, 2, 4, 5), 1.2, dims=(1,3))
   @test size(y) == (7, 2, 11)
-  @test y[4:5, :, 5:6] ≈ x
-  y[4:5, :, 5:6] .= 1.2
+  @test y[3:4, 1:2, 6:7] ≈ x
+  y[3:4, 1:2, 6:7] .= 1.2
   @test all(y .== 1.2)
   
   @test pad_constant(x, (2,2,2,2), 1.2, dims = (1,3)) ≈

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -7,18 +7,18 @@
   @test_throws ArgumentError NNlib.gen_pad((1,2,3,4,5,), (1,2,3), 4)
 
   p = NNlib.gen_pad((1,3), (1,3), 4)
-  @test (1, 1, 0, 0, 3, 3, 0, 0)
+  @test p == (1, 1, 0, 0, 3, 3, 0, 0)
 
   p = NNlib.gen_pad(1, (1,2,3), 4)
-  @test (1, 1, 1, 1, 1, 1, 0, 0)
+  @test p == (1, 1, 1, 1, 1, 1, 0, 0)
 
-  y = @inferred pad_constant(x, (3, 2, 4, 5))
+  y = @inferred pad_constant(x, (3, 2, 4))
   @test size(y) == (7, 11, 2)
   @test y[4:5, 5:6, :] ≈ x
   y[4:5, 5:6, :] .= 0
   @test all(y .== 0)
 
-  @test pad_constant(x, (3, 2, 4, 5)) ≈ pad_zeros(x, (3, 2, 4, 5))
+  @test pad_constant(x, (3, 2, 4)) ≈ pad_zeros(x, (3, 2, 4))
   @test pad_zeros(x, 2) ≈ pad_zeros(x, (2,2)) 
   
   y = @inferred pad_constant(x, (3, 2, 4, 5), 1.2, dims=(1,3))
@@ -27,10 +27,10 @@
   y[4:5, :, 5:6] .= 1.2
   @test all(y .== 1.2)
   
-  @test pad_constant(x, (2, 2, 2, 2), 1.2, dims=(1,3)) ≈
-          pad_constant(x, 2, 1.2, dims=(1,3))
+  @test pad_constant(x, (2,2,2,2), 1.2, dims = (1,3)) ≈
+          pad_constant(x, 2, 1.2, dims = (1,3))
   
-  gradtest(x -> pad_constant(x, (2,2,2,2)), rand(2,2,2))
+  gradtest(x -> pad_constant(x, 2), rand(2,2,2))
 end
 
 @testset "padding repeat" begin


### PR DESCRIPTION
We should clean up the dimension handling - which needs the extra `gen_pad` which uses arrays in some cases. We can get rid of those, I think.

```Julia
julia> @btime NNlib.pad_constant($r, (2,2,2,2,0,0,0,0));
  558.871 ns (5 allocations: 1.06 KiB)

# master
julia> @btime NNlib.pad_constant($r, (2,2,2,2,0,0,0,0));
  1.644 μs (29 allocations: 2.45 KiB)
```