### PR TITLE
Fixes #293 and #294

### DIFF
--- a/src/padding.jl
+++ b/src/padding.jl
@@ -111,18 +111,8 @@ end
 @inline tuplejoin(x, y) = (x..., y...)
 @inline tuplejoin(x, y, z...) = tuplejoin(tuplejoin(x, y), z...)
 
-function pad_zeros_tuple(pad::NTuple{L,Int}, N) where L
-  ntuple(2N) do i
-    if i <= L
-      pad[i]
-    else
-      0
-    end
-  end
-end
-
 gen_pad(pad::Int, dims, N) = gen_pad(ntuple(_ -> pad, length(dims)), dims, N)
-gen_pad(pad::Int, dims::Colon, N) = ntuple(_ -> pad, 2N)
+gen_pad(pad::Int, dims::Colon, N) = ntuple(_ -> (pad, pad), N)
 gen_pad(pad, dims::Colon, N) = gen_pad(pad, ntuple(identity, N), N)
 gen_pad(pad::Int, dims::Int, N) = gen_pad((pad,pad), (dims,), N)
 function gen_pad(pad::NTuple{L,Int}, dims::NTuple{D,Int}, N) where {L,D}
@@ -147,18 +137,16 @@ end
 
 # Expects length(pad) == 2M
 function pad_constant(x::AbstractArray{T,M}, pad::NTuple{N,Tuple{Int,Int}}, val = 0) where {T,M,N}
-  p = pad_zeros_tuple(tuplejoin(reverse.(pad)...), M)
-  sz, c = size_and_center(x, p)
+  # p = pad_zeros_tuple(tuplejoin(reverse.(pad)...), M)
+  sz, c = size_and_center(x, pad)
   res = fill!(similar(x, sz...), val)
-  res[c..., ntuple(_ -> Colon(), Val(M - 2))...] = x
+  res[c...] = x
   res
 end
 
-function size_and_center(x, pad::NTuple{N,Int}) where N
-  ds = 1:2:N
-  dst = ntuple(i -> ds[i], N÷2)
-  sz = map(i -> pad[i] + pad[i+1], dst) .+ size(x)
-  center = broadcast((x,y) -> x .+ y, axes(x), pad[2:2:end]::NTuple{N÷2,Int})
+function size_and_center(x, pad::NTuple{N,NTuple{2, Int}}) where N
+  sz = ntuple(i -> pad[i][1] + pad[i][2], N) .+ size(x)
+  center = broadcast((x,y) -> x .+ y, axes(x), ntuple(i -> pad[i][1], N))
   sz, center
 end
 

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -137,7 +137,6 @@ end
 
 # Expects length(pad) == 2M
 function pad_constant(x::AbstractArray{T,M}, pad::NTuple{N,Tuple{Int,Int}}, val = 0) where {T,M,N}
-  # p = pad_zeros_tuple(tuplejoin(reverse.(pad)...), M)
   sz, c = size_and_center(x, pad)
   res = fill!(similar(x, sz...), val)
   res[c...] = x

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -42,6 +42,7 @@
 
   gradtest(x -> pad_constant(x, 2), rand(2,2,2))
   gradtest(x -> pad_constant(x, (2, 1, 1, 2)), rand(2,2))
+  gradtest(x -> pad_constant(x, (2, 1,)), rand(2))
 end
 
 @testset "padding repeat" begin

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -12,6 +12,9 @@
   p = NNlib.gen_pad(1, (1,2,3), 4)
   @test p == ((1, 1), (1, 1), (1, 1), (0, 0))
 
+  p = NNlib.gen_pad(3, :, 2)
+  @test p == ((3, 3), (3, 3))
+
   y = pad_constant(x, (3, 2, 4))
   @test size(y) == (8, 6, 10)
   @test y[4:5, 3:4, 5:6] ≈ x
@@ -35,7 +38,10 @@
 
   @test size(pad_constant(x, 1, dims = 1)) == (4,2,2)
 
+  @test all(pad_zeros(randn(2), (1, 2))[[1, 4, 5]] .== 0)
+
   gradtest(x -> pad_constant(x, 2), rand(2,2,2))
+  gradtest(x -> pad_constant(x, (2, 1, 1, 2)), rand(2,2))
 end
 
 @testset "padding repeat" begin


### PR DESCRIPTION
This PR fixes #293 and #294, and in the process moves to using only `((l1, r1), ..., (ln, rn))` representation of padding internally instead of both that and `(l1, r1, ..., ln, rn)`. This means that we can simplify the codebase a bit.