### PR TITLE
Add a `LICENSE.md file` for the `NNlibCUDA.jl` package

### DIFF
--- a/lib/NNlibCUDA/LICENSE.md
+++ b/lib/NNlibCUDA/LICENSE.md
@@ -1,0 +1,22 @@
+The NNlib.jl package is licensed under the MIT "Expat" License:
+
+> Copyright (c) 2017-19: Julia Computing, Inc., Mike J Innes, and Contributors
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+> 


### PR DESCRIPTION
Each subdirectory package needs to have its own copy of the license file. This is because when we distribute tarballs (e.g. via the Pkg server), the tarball only includes the subdirectory package. So we need to make sure that the subdirectory has a license; otherwise, the tarball won't have a license.

cc: @CarloLucibello 