### PR TITLE
Adapt rules for batched_* wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 version = "0.7.16"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -1,6 +1,7 @@
 using LinearAlgebra
 
 import Base: -
+import Adapt: adapt_structure, adapt
 
 _batched_doc = """
     batched_transpose(A::AbstractArray{T,3})
@@ -100,3 +101,6 @@ function rrule(::typeof(batched_adjoint), A::AbstractArray{<:Any,3})
     b_adjoint_back(Δ) = (NO_FIELDS, batched_adjoint(Δ))
     batched_adjoint(A), b_adjoint_back
 end
+
+adapt_structure(to, x::BatchedAdjoint) = BatchedAdjoint(adapt(to, parent(x)))
+adapt_structure(to, x::BatchedTranspose) = BatchedTranspose(adapt(to, parent(x)))


### PR DESCRIPTION
Add adapt rules for the batch wrappers.

Usually you are not supposed to ever see the batched_* wrappers but they make some unfortunate appearance in second derivatives.

```julia
using NNlib, Zygote, CUDA

W = rand(Float32, 1, 1, 2) |> cu
x = rand(Float32, 1, 1) |> cu

function ftest(W)
    gz, back = Zygote.pullback(x -> NNlib.batched_mul(W, x), x)
    back(gz)[1]
end

y, back = Zygote.pullback(ftest, W)
back(y)[1]
```

without adapt rule:

```
ERROR: GPU compilation of kernel broadcast_kernel(CUDA.CuKernelContext, CuDeviceArray{Float32,3,1}, Base.Broadcast.Broadcasted{Nothing,Tuple{Base.OneTo{Int64},Base.OneTo{Int64},Base.OneTo{Int64}},typeof(Zygote.accum),Tuple{Base.Broadcast.Extruded{CuDeviceArray{Float32,3,1},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}},Base.Broadcast.Extruded{NNlib.BatchedAdjoint{Float32,CuArray{Float32,3}},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}}}}, Int64) failed
KernelError: passing and using non-bitstype argument

Argument 4 to your kernel function is of type Base.Broadcast.Broadcasted{Nothing,Tuple{Base.OneTo{Int64},Base.OneTo{Int64},Base.OneTo{Int64}},typeof(Zygote.accum),Tuple{Base.Broadcast.Extruded{CuDeviceArray{Float32,3,1},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}},Base.Broadcast.Extruded{NNlib.BatchedAdjoint{Float32,CuArray{Float32,3}},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}}}}, which is not isbits:
  .args is of type Tuple{Base.Broadcast.Extruded{CuDeviceArray{Float32,3,1},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}},Base.Broadcast.Extruded{NNlib.BatchedAdjoint{Float32,CuArray{Float32,3}},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}}} which is not isbits.
    .2 is of type Base.Broadcast.Extruded{NNlib.BatchedAdjoint{Float32,CuArray{Float32,3}},Tuple{Bool,Bool,Bool},Tuple{Int64,Int64,Int64}} which is not isbits.
      .x is of type NNlib.BatchedAdjoint{Float32,CuArray{Float32,3}} which is not isbits.
        .parent is of type CuArray{Float32,3} which is not isbits.
          .ctx is of type CuContext which is not isbits.
```