### PR TITLE
Add benchmarks, part 1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,20 @@
+name: Benchmark
+on:
+  - pull_request
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.5'
+      - run: git fetch origin '+refs/heads/master:refs/remotes/origin/master'
+      - run: git branch master origin/master
+      - run: |
+          julia --project=benchmark -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: julia --project=benchmark benchmark/runbenchmarks.jl

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ deps/usr
 deps.jl
 *.log
 ./Manifest.toml
+benchmark/*.json

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,12 @@
+using BenchmarkTools
+using NNlib
+
+const SUITE = BenchmarkGroup()
+
+SUITE["activations"] = BenchmarkGroup()
+
+x = rand(64, 64)
+
+for f in NNlib.ACTIVATIONS
+    SUITE["activations"][string(f)] = @benchmarkable $f.($x)
+end

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -1,0 +1,81 @@
+# Copied from
+# https://github.com/kul-forbes/ProximalOperators.jl/tree/master/benchmark
+using ArgParse
+using PkgBenchmark
+using Markdown
+
+function displayresult(result)
+    md = sprint(export_markdown, result)
+    md = replace(md, ":x:" => "❌")
+    md = replace(md, ":white_check_mark:" => "✅")
+    display(Markdown.parse(md))
+end
+
+function printnewsection(name)
+    println()
+    println()
+    println()
+    printstyled("▃" ^ displaysize(stdout)[2]; color=:blue)
+    println()
+    printstyled(name; bold=true)
+    println()
+    println()
+end
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table! s begin
+        "--target"
+            help = "the branch/commit/tag to use as target"
+            default = "HEAD"
+        "--baseline"
+            help = "the branch/commit/tag to use as baseline"
+            default = "master"
+        "--retune"
+            help = "force re-tuning (ignore existing tuning data)"
+            action = :store_true
+    end
+
+    return parse_args(s)
+end
+
+function main()
+    parsed_args = parse_commandline()
+
+    mkconfig(; kwargs...) =
+        BenchmarkConfig(
+            env = Dict(
+                "JULIA_NUM_THREADS" => "1",
+            );
+            kwargs...
+        )
+
+    target = parsed_args["target"]
+    group_target = benchmarkpkg(
+        dirname(@__DIR__),
+        mkconfig(id = target),
+        resultfile = joinpath(@__DIR__, "result-$(target).json"),
+        retune = parsed_args["retune"],
+    )
+
+    baseline = parsed_args["baseline"]
+    group_baseline = benchmarkpkg(
+        dirname(@__DIR__),
+        mkconfig(id = baseline),
+        resultfile = joinpath(@__DIR__, "result-$(baseline).json"),
+    )
+
+    printnewsection("Target result")
+    displayresult(group_target)
+
+    printnewsection("Baseline result")
+    displayresult(group_baseline)
+
+    judgement = judge(group_target, group_baseline)
+
+    printnewsection("Judgement result")
+    displayresult(judgement)
+end
+
+main()


### PR DESCRIPTION
Given the increasing importance of NNlib in the ML ecosystem, I believe it's time to add automatic benchmarks. This PR is based on the amazing PkgBenchmark.jl and [config from ProximalOperators.jl](https://github.com/kul-forbes/ProximalOperators.jl/tree/master/benchmark). This is only partial improvement since benchmark code compares a change with a baseline in master, but current master doesn't have any benchmarks at all, so **benchmark job will fail by design**. All the following PRs (with or without changes to the benchmarks) should work fine. 

To be precise, here's what this PR does: 

* adds a set of simple benchmarks which can be triggered from the command line using `julia --project=benchmark benchmark/runbenchmarks.jl`
* adds GitHub Actions job to run these benchmarks automatically on every PR

What this PR does not:

* doesn't provide finished and verified work - this kind of things can only be tested by merging into master and seeing CI's output; yet I'll try to finalize it reasonably quickly
* doesn't add a comprehensive benchmark set - I think we need to add them step by step