### PR TITLE
Avoiding scalar indexing in cuda

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,7 +12,4 @@ Return the maximum value for each dimension. An array of dimensions `dims` is ac
 The maximum of each dimension in the element is computed.
 """
 maximum_dims(dims::AbstractArray{<:Integer}) = (maximum(dims), )
-
-function maximum_dims(dims::AbstractArray{<:Tuple})
-    Tuple(maximum(xs) for xs in zip(dims...))
-end
+maximum_dims(dims::AbstractArray{NTuple{N, T}}) where {N,T} = Tuple(maximum(x->x[i], dims) for i = 1:N)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,4 +12,4 @@ Return the maximum value for each dimension. An array of dimensions `dims` is ac
 The maximum of each dimension in the element is computed.
 """
 maximum_dims(dims::AbstractArray{<:Integer}) = (maximum(dims), )
-maximum_dims(dims::AbstractArray{NTuple{N, T}}) where {N,T} = Tuple(maximum(x->x[i], dims) for i = 1:N)
+maximum_dims(dims::AbstractArray{NTuple{N, T}}) where {N,T} = ntuple(i -> maximum(x->x[i], dims), N)


### PR DESCRIPTION
Existing implementation use scalar indexing for cuarray. To avoid using scalar indexing, refactoring is done.