### PR TITLE
scatter cleanup and fix min/max

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.7.19"
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.7.19"
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -13,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "2, 3.2"
-ChainRulesCore = "0.9"
+ChainRulesCore = "0.9.44"
 Compat = "3.14"
 Requires = "0.5, 1.0"
 julia = "1.6"

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -268,7 +268,7 @@ end
 
 
 BINARY_ACTS = [ # f, df1, df2
-    (:elu, :(deriv_elu(Ω, x2)), :(DoesNotExist())), # TODO use real deriv instead of DNE
+    (:elu, :(deriv_elu(Ω, x2)), :(NoTangent())), # TODO use real deriv instead of DNE
     ]
 
 for (f, df1, df2) in BINARY_ACTS

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -227,7 +227,7 @@ for conv in [:conv, :depthwiseconv]
                 NO_FIELDS,
                 @thunk($∇conv_data(Δ, w, cdims, kw...)),
                 @thunk($∇conv_filter(x, Δ, cdims, kw...)),
-                DoesNotExist(),
+                NoTangent(),
             )
         end
         return $conv(x, w, cdims; kw...), $conv_pullback
@@ -240,7 +240,7 @@ for conv in [:conv, :depthwiseconv]
                 NO_FIELDS,
                 @thunk($conv(Δ, w, cdims, kw...)),
                 @thunk($∇conv_filter(Δ, x, cdims, kw...)),
-                DoesNotExist(),
+                NoTangent(),
             )
         end
         return $∇conv_data(x, w, cdims; kw...), $∇conv_data_pullback

--- a/src/gather.jl
+++ b/src/gather.jl
@@ -21,7 +21,7 @@ or multiple `dst` columns.
 See [`gather`](@ref) for an allocating version.
 """
 function gather!(dst::AbstractArray, src::AbstractArray, idx::AbstractArray)
-    dims = _check_dims(src, dst, idx)
+    dims = scatter_dims(src, dst, idx)
     colons = ntuple(i -> Colon(), dims)
     for k in CartesianIndices(idx)
         _view(dst, colons, k) .= _view(src, colons, idx[k])

--- a/src/gather.jl
+++ b/src/gather.jl
@@ -77,7 +77,7 @@ end
 ∇gather_src(Δ, src_size, idx) = scatter!(+, fill!(similar(Δ, eltype(Δ), src_size), 0), Δ, idx)
 
 function rrule(::typeof(gather!), dst::AbstractArray, src::AbstractArray, idx::AbstractArray)
-    y = gather!(copy(dst), src, idx)
+    y = gather!(dst, src, idx)
     src_size = size(src)
     gather!_pullback(Δ) = (NO_FIELDS, NoTangent(), ∇gather_src(Δ, src_size, idx), NoTangent())
     y, gather!_pullback

--- a/src/gather.jl
+++ b/src/gather.jl
@@ -79,6 +79,6 @@ end
 function rrule(::typeof(gather!), dst::AbstractArray, src::AbstractArray, idx::AbstractArray)
     y = gather!(copy(dst), src, idx)
     src_size = size(src)
-    gather!_pullback(Δ) = (NO_FIELDS, DoesNotExist(), ∇gather_src(Δ, src_size, idx), DoesNotExist())
+    gather!_pullback(Δ) = (NO_FIELDS, NoTangent(), ∇gather_src(Δ, src_size, idx), NoTangent())
     y, gather!_pullback
 end

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -155,7 +155,7 @@ function rrule(::typeof(pad_constant), x::AbstractArray{T,N},
   function pad_constant_pullback(Δ)
     p = gen_pad(pad, dims, N)
     outsize, center = size_and_center(x, p)
-    (NO_FIELDS, @thunk(Δ[center...]), DoesNotExist(), DoesNotExist(),)
+    (NO_FIELDS, @thunk(Δ[center...]), NoTangent(), NoTangent(),)
   end
   return y, pad_constant_pullback
 end

--- a/src/pooling.jl
+++ b/src/pooling.jl
@@ -173,7 +173,7 @@ for pool in [:maxpool, :meanpool]
     pullback = Symbol(pool, :_pullback)
     @eval function rrule(::typeof($pool), x, pdims::PoolDims; kw...)
         Ω = $pool(x, pdims; kw...)
-        $pullback(Δ) = (NO_FIELDS, $∇pool(Δ, Ω, x, pdims; kw...), DoesNotExist())
+        $pullback(Δ) = (NO_FIELDS, $∇pool(Δ, Ω, x, pdims; kw...), NoTangent())
         return Ω, $pullback
     end
 end

--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -19,18 +19,8 @@ dimensionality of the scattered objects.
 """
 function scatter_dims(X::AbstractArray{Tx,Nx}, 
                      Y::AbstractArray{Ty,Ny},
-                     idx::AbstractArray{Tidx,Nidx}) where
-                     {Tx,Ty,Tidx<:IntOrIntTuple,Nx,Ny,Nidx}
+                     idx::AbstractArray{Tidx,Nidx}) where {Tx,Ty,Tidx,Nx,Ny,Nidx}
     M = typelength(Tidx)
-    dims = scatter_dims(Nx, Ny, M, Nidx)
-    size(X)[1:dims] == size(Y)[1:dims] || throw(ArgumentError("Incompatible input shapes."))
-    size(Y)[dims+1:end] == size(idx) || throw(ArgumentError("Incompatible input shapes."))
-    return dims
-end
-
-function scatter_dims(X::AbstractArray{Tx,Nx}, 
-                     Y::AbstractArray{Ty,Ny},
-                     idx::AbstractArray{CartesianIndex{M},Nidx}) where {Tx,Ty,Nx,Ny,M,Nidx}
     dims = scatter_dims(Nx, Ny, M, Nidx)
     size(X)[1:dims] == size(Y)[1:dims] || throw(ArgumentError("Incompatible input shapes."))
     size(Y)[dims+1:end] == size(idx) || throw(ArgumentError("Incompatible input shapes."))

--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -85,9 +85,9 @@ end
 Scatter operation allocating a destination array `dst` and 
 calling `scatter!(op, dst, src, idx)` on it.
 
-If `init` is provided it is used to initialized the content of `dst`,
-otherwise tries to guess it from the reduction operator `op`
-(e.g. `init = 0` for `op = +`). 
+If `init` is provided, it is used to initialize the content of `dst`.
+Otherwise, the init values is inferred from the reduction operator `op`
+for some common operators (e.g. `init = 0` for `op = +`). 
 
 See [`scatter!`](@ref) for the details.
 """

--- a/src/upsample.jl
+++ b/src/upsample.jl
@@ -76,7 +76,7 @@ end
 
 function rrule(::typeof(upsample_nearest), x::AbstractArray, s::Tuple)
     Ω = upsample_nearest(x, s)
-    upsample_nearest_pullback(Δ) = (NO_FIELDS, ∇upsample_nearest(Δ, s), DoesNotExist())
+    upsample_nearest_pullback(Δ) = (NO_FIELDS, ∇upsample_nearest(Δ, s), NoTangent())
     return Ω, upsample_nearest_pullback
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,8 +26,8 @@ end
 
 function count_indices(idx::AbstractArray)
     counts = zero.(idx)
-    for i = unique(idx)
-        counts += sum(idx.==i) * (idx.==i)
+    for i in unique(idx)
+        counts += sum(idx .== i) * (idx .== i)
     end
     return counts
 end
@@ -35,7 +35,7 @@ end
 function divide_by_counts!(xs, idx::AbstractArray, dims)
     colons = Base.ntuple(_->Colon(), dims)
     counts = count_indices(idx)
-    for i = CartesianIndices(counts)
+    for i in CartesianIndices(counts)
         view(xs, colons..., i) ./= counts[i]
     end
     return xs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,43 +6,45 @@ using FiniteDifferences: FiniteDifferenceMethod, central_fdm
 import Zygote
 using Zygote: gradient
 using StableRNGs
+using CUDA
+
 
 const rng = StableRNG(123)
 
 include("test_utils.jl")
 
-@testset "Activation Functions" begin
-    include("activations.jl")
-end
+# @testset "Activation Functions" begin
+#     include("activations.jl")
+# end
 
-@testset "Batched Multiplication" begin
-    include("batchedmul.jl")
-end
+# @testset "Batched Multiplication" begin
+#     include("batchedmul.jl")
+# end
 
-@testset "Convolution" begin
-    include("conv.jl")
-    include("conv_bias_act.jl")
-end
+# @testset "Convolution" begin
+#     include("conv.jl")
+#     include("conv_bias_act.jl")
+# end
 
-@testset "Inference" begin
-    include("inference.jl")
-end
+# @testset "Inference" begin
+#     include("inference.jl")
+# end
 
-@testset "Pooling" begin
-    include("pooling.jl")
-end
+# @testset "Pooling" begin
+#     include("pooling.jl")
+# end
 
-@testset "Padding" begin
-    include("padding.jl")
-end
+# @testset "Padding" begin
+#     include("padding.jl")
+# end
 
-@testset "Softmax" begin
-    include("softmax.jl")
-end
+# @testset "Softmax" begin
+#     include("softmax.jl")
+# end
 
-@testset "Upsampling" begin
-    include("upsample.jl")
-end
+# @testset "Upsampling" begin
+#     include("upsample.jl")
+# end
 
 @testset "Gather" begin
     include("gather.jl")
@@ -56,7 +58,6 @@ end
     include("utils.jl")
 end
 
-using CUDA
 
 if VERSION >= v"1.6" && CUDA.functional()
     if get(ENV, "NNLIB_TEST_CUDA", "false") == "true"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using NNlib, Test, Statistics, Random
 using ChainRulesCore, ChainRulesTestUtils
 using Base.Broadcast: broadcasted
 import FiniteDifferences
-using FiniteDifferences: FiniteDifferenceMethod, central_fdm
 import Zygote
 using Zygote: gradient
 using StableRNGs
@@ -13,38 +12,38 @@ const rng = StableRNG(123)
 
 include("test_utils.jl")
 
-# @testset "Activation Functions" begin
-#     include("activations.jl")
-# end
+@testset "Activation Functions" begin
+    include("activations.jl")
+end
 
-# @testset "Batched Multiplication" begin
-#     include("batchedmul.jl")
-# end
+@testset "Batched Multiplication" begin
+    include("batchedmul.jl")
+end
 
-# @testset "Convolution" begin
-#     include("conv.jl")
-#     include("conv_bias_act.jl")
-# end
+@testset "Convolution" begin
+    include("conv.jl")
+    include("conv_bias_act.jl")
+end
 
-# @testset "Inference" begin
-#     include("inference.jl")
-# end
+@testset "Inference" begin
+    include("inference.jl")
+end
 
-# @testset "Pooling" begin
-#     include("pooling.jl")
-# end
+@testset "Pooling" begin
+    include("pooling.jl")
+end
 
-# @testset "Padding" begin
-#     include("padding.jl")
-# end
+@testset "Padding" begin
+    include("padding.jl")
+end
 
-# @testset "Softmax" begin
-#     include("softmax.jl")
-# end
+@testset "Softmax" begin
+    include("softmax.jl")
+end
 
-# @testset "Upsampling" begin
-#     include("upsample.jl")
-# end
+@testset "Upsampling" begin
+    include("upsample.jl")
+end
 
 @testset "Gather" begin
     include("gather.jl")

--- a/test/scatter.jl
+++ b/test/scatter.jl
@@ -182,29 +182,23 @@ end
 
 @testset "∇scatter" begin
     T = Float64
+    fdm(op) = op == min ? :backward : :forward
+    # fdm(op) = :forward
+
     @testset "∂dst" begin
-        for op in (+, -, *, /)
-            # TODO: get max, min pass tests
-            gradtest(xs -> scatter!(op, copy(xs), srcs[(0, true)], idxs[:int]), T.(dsts[0]))
-            gradtest(xs -> scatter!(op, copy(xs), srcs[(1, true)], idxs[:int]), T.(dsts[1]))
+        for op in (+, -, *, /, mean, max, min)
+            gradtest(xs -> scatter!(op, copy(xs), srcs[(0, true)], idxs[:int]), T.(dsts[0]), fdm=fdm(op))
+            gradtest(xs -> scatter!(op, copy(xs), srcs[(1, true)], idxs[:int]), T.(dsts[1]), fdm=fdm(op))
         end
-        gradtest(xs -> scatter!(mean, copy(xs), srcs[(0, true)], idxs[:int]), T.(dsts[0]))
-        gradtest(xs -> scatter!(mean, copy(xs), srcs[(1, true)], idxs[:int]), T.(dsts[1]))
     end
 
     @testset "∂src" begin
-        for op in (+, -, *, /)
-            # TODO: get max, min pass tests
-            gradtest(xs -> scatter!(op, T.(dsts[0]), xs, idxs[:int]), T.(srcs[(0, true)]))
-            gradtest(xs -> scatter!(op, T.(dsts[1]), xs, idxs[:int]), T.(srcs[(1, true)]))
+        for op in (+, -, *, /, mean, max, min)
+            gradtest(xs -> scatter!(op, T.(dsts[0]), xs, idxs[:int]), T.(srcs[(0, true)]), fdm=fdm(op))
+            gradtest(xs -> scatter!(op, T.(dsts[1]), xs, idxs[:int]), T.(srcs[(1, true)]), fdm=fdm(op))
 
-            gradtest(xs -> scatter(op, xs, idxs[:int]), T.(srcs[(0, false)]))
-            gradtest(xs -> scatter(op, xs, idxs[:int]), T.(srcs[(1, false)]))
+            gradtest(xs -> scatter(op, xs, idxs[:int]), T.(srcs[(0, false)]), fdm=fdm(op))
+            gradtest(xs -> scatter(op, xs, idxs[:int]), T.(srcs[(1, false)]), fdm=fdm(op))
         end
-        gradtest(xs -> scatter!(mean, T.(dsts[0]), xs, idxs[:int]), T.(srcs[(0, true)]))
-        gradtest(xs -> scatter!(mean, T.(dsts[1]), xs, idxs[:int]), T.(srcs[(1, true)]))
-
-        gradtest(xs -> scatter(mean, xs, idxs[:int]), T.(srcs[(0, false)]))
-        gradtest(xs -> scatter(mean, xs, idxs[:int]), T.(srcs[(1, false)]))
     end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -12,7 +12,7 @@ Applies also `ChainRulesTestUtils.test_rrule` if the rrule for `f` is explicitly
 """
 function gradtest(f, xs...; atol=1e-6, rtol=1e-6, fkwargs=NamedTuple(),
                     check_rrule=false,
-                    fdm=:forward, 
+                    fdm=:central, 
                     check_broadcast=false,
                     skip=false, broken=false)
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -12,6 +12,7 @@ Applies also `ChainRulesTestUtils.test_rrule` if the rrule for `f` is explicitly
 """
 function gradtest(f, xs...; atol=1e-6, rtol=1e-6, fkwargs=NamedTuple(),
                     check_rrule=false,
+                    fdm=:forward, 
                     check_broadcast=false,
                     skip=false, broken=false)
 
@@ -31,9 +32,16 @@ function gradtest(f, xs...; atol=1e-6, rtol=1e-6, fkwargs=NamedTuple(),
     end
 
     y_true = h(xs...)
+    if fdm == :central
+        fdm_obj = FiniteDifferences.central_fdm(5, 1)
+    elseif fdm == :forward
+        fdm_obj = FiniteDifferences.forward_fdm(5, 1)
+    elseif fdm == :backward
+        fdm_obj = FiniteDifferences.backward_fdm(5, 1)
+    end
+    # @show fdm fdm_obj
 
-    fdm = central_fdm(5, 1)
-    gs_fd = FiniteDifferences.grad(fdm, h, xs...)
+    gs_fd = FiniteDifferences.grad(fdm_obj, h, xs...)
 
     y_ad, pull = Zygote.pullback(h, xs...)
     gs_ad = pull(one(y_ad))


### PR DESCRIPTION
Fix #317. The main problem was in the use of FiniteDifferences' central difference method on singularities of non-smooth functions. 
