### PR TITLE
Support reverse_indices for integer, tuple, CartesianIndex index

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,15 +15,22 @@ maximum_dims(dims::AbstractArray{<:Integer}) = (maximum(dims), )
 maximum_dims(dims::AbstractArray{NTuple{N, T}}) where {N,T} = ntuple(i -> maximum(x->x[i], dims), N)
 maximum_dims(dims::AbstractArray{CartesianIndex{N}}) where {N} = ntuple(i -> maximum(x->x[i], dims), N)
 
-function reverse_indices!(rev::AbstractArray, idx::AbstractArray)
+function reverse_indices!(rev::AbstractArray, idx::AbstractArray{<:Tuple})
     for (ind, val) in pairs(Array(idx))
-        push!(rev[val], ind)
+        push!(rev[val...], ind)
     end
     # if CUDA supports `unique`, a more efficient version:
     # cidx in CartesianIndices(idx)
     # for i = unique(idx)
     #     rev[i] = cidx[idx .== i]
     # end
+    rev
+end
+
+function reverse_indices!(rev::AbstractArray, idx::AbstractArray)
+    for (ind, val) in pairs(Array(idx))
+        push!(rev[val], ind)
+    end
     rev
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,3 +11,26 @@
             (4,6,2) (5,3,2) (4,4,4)])
     @test NNlib.maximum_dims(ind4) == (5,6,9)
 end
+
+@testset "reverse_indices" begin
+    res = [
+        CartesianIndex.([(1,1), (2,3)]),
+        CartesianIndex.([(1,2), (2,2)]),
+        CartesianIndex.([(3,1), (1,3), (2,4), (3,4)]),
+        CartesianIndex.([(2,1), (1,4)]),
+        CartesianIndex.([(3,2), (3,3)])
+    ]
+    idx = [1 2 3 4;
+           4 2 1 3;
+           3 5 5 3]
+    @test NNlib.reverse_indices(idx) == res
+    idx = [(1,) (2,) (3,) (4,);
+           (4,) (2,) (1,) (3,);
+           (3,) (5,) (5,) (3,)]
+    @test NNlib.reverse_indices(idx) == res
+    idx = CartesianIndex.(
+        [(1,) (2,) (3,) (4,);
+        (4,) (2,) (1,) (3,);
+        (3,) (5,) (5,) (3,)])
+    @test NNlib.reverse_indices(idx) == res
+end


### PR DESCRIPTION
related to #326.
Fix commit of "fix gradient of scatter for mean" in FluxML/NNlibCUDA.jl#13
I add some tests for it.