### PR TITLE
Fix the output type of reverse_indices

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,9 +35,11 @@ function reverse_indices!(rev::AbstractArray, idx::AbstractArray)
 end
 
 function reverse_indices(idx::AbstractArray)
-    rev = Array{Vector{CartesianIndex}}(undef, maximum_dims(idx)...)
+    max_dims = maximum_dims(idx)
+    T = CartesianIndex{length(size(idx))}
+    rev = Array{Vector{T}}(undef, max_dims...)
     for i in eachindex(rev)
-        rev[i] = CartesianIndex[]
+        rev[i] = T[]
     end
     return reverse_indices!(rev, idx)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,9 +34,18 @@ function reverse_indices!(rev::AbstractArray, idx::AbstractArray)
     rev
 end
 
-function reverse_indices(idx::AbstractArray)
+"""
+    reverse_indices(idx)
+
+Return the reverse indices of `idx`. The indices of `idx` will be values, and values of `idx` will be index.
+
+# Arguments
+
+- `idx`: The indices to be reversed. Accepts array or cuarray of integer, tuple or `CartesianIndex`.
+"""
+function reverse_indices(idx::AbstractArray{<:Any,N}) where N
     max_dims = maximum_dims(idx)
-    T = CartesianIndex{length(size(idx))}
+    T = CartesianIndex{N}
     rev = Array{Vector{T}}(undef, max_dims...)
     for i in eachindex(rev)
         rev[i] = T[]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -24,13 +24,16 @@ end
            4 2 1 3;
            3 5 5 3]
     @test NNlib.reverse_indices(idx) == res
+    @test NNlib.reverse_indices(idx) isa typeof(res)
     idx = [(1,) (2,) (3,) (4,);
            (4,) (2,) (1,) (3,);
            (3,) (5,) (5,) (3,)]
     @test NNlib.reverse_indices(idx) == res
+    @test NNlib.reverse_indices(idx) isa typeof(res)
     idx = CartesianIndex.(
         [(1,) (2,) (3,) (4,);
         (4,) (2,) (1,) (3,);
         (3,) (5,) (5,) (3,)])
     @test NNlib.reverse_indices(idx) == res
+    @test NNlib.reverse_indices(idx) isa typeof(res)
 end


### PR DESCRIPTION
Solve the issue related to FluxML/NNlibCUDA.jl#13.
`CartesianIndex` itself is not sufficient, but `CartesianIndex{N}` is the full type.
A full type is required to convert an object into cuarray and pass it into a cuda kernel.
At the same time, I am considering making an `reverse_indices` API for cuda.