### PR TITLE
Add faster `tanh` implementation(s)

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -665,6 +665,8 @@ may be wrong by 5 eps, a reduction by less than one decimal digit.
 
 For `x::Float32` this is usually about 10 times faster,
 with a smaller speedup for `x::Float64`.
+
+See also [`sigmoid_fast`](@ref).
 """
 @inline function tanh_fast(x::Float32)
     x2 = abs2(x)
@@ -689,6 +691,9 @@ tanh_fast(x::Float16) = Base.tanh(x) # Other approximations are very badly behav
     sigmoid_fast(x)
 
 This is a faster, and very slightly less accurate, version of `sigmoid`.
+For `x::Float32, perhaps 3 times faster, and maximum errors 2 eps instead of 1.
+
+See also [`tanh_fast`](@ref).
 """
 @inline function sigmoid_fast(x::Real)
     t = @fastmath exp(-abs(x))

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -694,10 +694,10 @@ end
     exp2x = @fastmath exp(x + x)
     y = (exp2x - 1) / (exp2x + 1) 
     # That has large errors near zero; using `expm1` would more accurate, but about as slow as `tanh`.
-    # Instead, we switch to an Taylor series. This is very accurate within its range:
+    # Instead, we switch to a polynomial, which is very accurate within its range, < 2 eps:
     x2 = x * x
-    ypoly = x * evalpoly(x2, (1.0, -0.33333333333333337, 0.1333333333332623, -0.0539682539194502, 0.021869476267930975, -0.00886184042142138, 0.0035188503873932893))
-    ifelse(x2 > 900.0, sign(y), ifelse(x2 < 0.02, oftype(y, ypoly), y))
+    ypoly = x * evalpoly(x2, (1.0, -0.33333333333324583, 0.13333333325511604, -0.05396823125794372, 0.02186660872609521, -0.008697141630499953))
+    ifelse(x2 > 900.0, sign(y), ifelse(x2 < 0.017, oftype(y, ypoly), y))
 end
 
 tanh_fast(x::Float16) = Base.tanh(x) # Other approximations are very badly behaved for Float16; none are fast.

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -669,6 +669,7 @@ may be wrong by 5 eps, a reduction by less than one decimal digit.
 
 For `x::Float32` this is usually about 10 times faster,
 with a smaller speedup for `x::Float64`.
+For any other number types, it just calls `tanh`.
 
 See also [`sigmoid_fast`](@ref).
 
@@ -690,7 +691,7 @@ julia> hard_tanh(0.5f0)
     ifelse(x2 < 66f0, x * (n / d), sign(x))
 end
 
-@inline function tanh_fast(x::Real)
+@inline function tanh_fast(x::Float64)
     exp2x = @fastmath exp(x + x)
     y = (exp2x - 1) / (exp2x + 1) 
     # That has large errors near zero; using `expm1` would more accurate, but about as slow as `tanh`.
@@ -700,7 +701,9 @@ end
     ifelse(x2 > 900.0, sign(y), ifelse(x2 < 0.017, oftype(y, ypoly), y))
 end
 
-tanh_fast(x::Float16) = Base.tanh(x) # Other approximations are very badly behaved for Float16; none are fast.
+# These approximations are very badly behaved for Float16; none are fast.
+# They are also a bit slower with ForwardDiff.Dual numbers, let's use Base:
+tanh_fast(x::Real) = Base.tanh(x)
 
 """
     sigmoid_fast(x)

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -4,7 +4,7 @@
 # https://github.com/JuliaGPU/CuArrays.jl/issues/614
 
 ACTIVATIONS = [
-    :σ, :hardσ, :tanh_fast, :hardtanh, :relu,
+    :σ, :hardσ, :hardtanh, :relu,
     :leakyrelu, :relu6, :rrelu, :elu, :gelu, :swish, :selu,
     :celu, :softplus, :softsign, :logσ, :logcosh,
     :mish, :tanhshrink, :softshrink, :trelu, :lisht,

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -772,21 +772,3 @@ for (f, df1, df2) in BINARY_ACTS
         return Ω, $pullback
     end
 end
-
-# For some activation functions, the gradient can be written only in terms of Ω.
-# That means that `conv_bias_act` etc. can replace `Ω = σ.(x)` with `x .= σ.(x)`
-# to save allocations. (Not so easy to opt-in to this mechanism, sadly.)
-INPLACE_ACTS = [
-    (:σ,            :(conj(Ω * (1 - Ω)))),
-    (:relu,         :(Ω > 0)),
-    (:leakyrelu,    :(ifelse(Ω > 0, one(Ω), oftf(Ω, 0.01)))),  # only the 1-argument method
-    (:hardtanh,     :(-1 < Ω < 1)),
-    (:selu,         :(deriv_selu(Ω))),
-    (:elu,          :(deriv_elu(Ω))),
-
-    (:identity,     :true),
-    (:tanh,         :(conj(1 - Ω^2))),
-    (:tanh_fast,    :(conj(1 - Ω^2))),
-    (:tanh_faster,  :(conj(1 - Ω^2))),
-    (:sigmoid_fast, :(conj(Ω * (1 - Ω)))),
-    ]

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -694,7 +694,7 @@ end
     exp2x = @fastmath exp(x + x)
     y = (exp2x - 1) / (exp2x + 1) 
     # That has large errors near zero; using `expm1` would more accurate, but about as slow as `tanh`.
-    # Instead, we switch to a polynomial, which is very accurate within its range, < 2 eps:
+    # Instead, we switch to a polynomial, which is very accurate within its range:
     x2 = x * x
     ypoly = x * evalpoly(x2, (1.0, -0.33333333333324583, 0.13333333325511604, -0.05396823125794372, 0.02186660872609521, -0.008697141630499953))
     ifelse(x2 > 900.0, sign(y), ifelse(x2 < 0.017, oftype(y, ypoly), y))

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -678,8 +678,8 @@ end
     # That has bad errors near zero; using expm1 would be slower & more accurate.
     # Instead, we switch to an taylor series; seems to add about 50% to time.
     x2 = x * x
-    ypoly = x * evalpoly(x2, (0.9999999999999999, -0.33333333333309806, 0.13333333318143492, -0.053968217983868146 , 0.021865628148606587, -0.008671836868790176))
-    ifelse(x2 > 900.0, sign(y), ifelse(x2 < 0.017, oftype(y, ypoly), y))
+    ypoly = x * evalpoly(x2, (1.0, -0.33333333333333337, 0.1333333333332623, -0.0539682539194502, 0.021869476267930975, -0.00886184042142138, 0.0035188503873932893))
+    ifelse(x2 > 900.0, sign(y), ifelse(x2 < 0.02, oftype(y, ypoly), y))
 end
 
 tanh_fast(x::Float16) = Base.tanh(x) # Other approximations are very badly behaved for Float16; none are fast.

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -228,7 +228,6 @@ using NNlib: tanh_fast, tanh_faster, sigmoid_fast, _fast_stop
 @testset "$fast(::$T)" for T in [Float64, Float32], #, Float16]
     (fast, slow, atol, jump) in [
         (tanh_fast, tanh,       5*eps(T), 0     ), 
-        (tanh_faster, tanh,     1e-5,     1e-4  ), 
         (sigmoid_fast, sigmoid, 5*eps(T), 1e-25 )
     ] 
 
@@ -236,12 +235,6 @@ using NNlib: tanh_fast, tanh_faster, sigmoid_fast, _fast_stop
 
     @test Float64.(fast.(T.(-5:0.1:5))) ≈ slow.(-5:0.1:5)  atol = atol
     @test Float64.(fast.(T.(-200:13.3:200))) ≈ slow.(-200:13.3:200)  atol = atol
-
-    stop = _fast_stop(fast, one(T))
-    @test abs(fast(nextfloat(stop)) - fast(prevfloat(stop))) <= jump
-    @test abs(fast(nextfloat(-stop)) - fast(prevfloat(-stop))) <= jump
-    # @show fast(nextfloat(stop)) - fast(prevfloat(stop))
-    # @show fast(nextfloat(-stop)) - fast(prevfloat(-stop))
 end
 
 @testset "AutoDiff" begin

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -258,7 +258,7 @@ worst_eps(f, g, xs) = maximum(x -> abs(countepsfrom(f(x), g(big(x)))), xs)
         mean_eps(sigmoid, sigmoid, x64)  # 0.39246
         worst_eps(sigmoid, sigmoid, x64) # 1
 
-        @test mean_eps(sigmoid_fast, sigmoid, x64) < 0.2  # 0.1355
+        @test mean_eps(sigmoid_fast, sigmoid, x64) < 0.5  # 0.40432
         @test worst_eps(sigmoid_fast, sigmoid, x64) <= 5  # 2
 
         mean_eps(sigmoid, sigmoid, -x64)  # 0.37672
@@ -294,14 +294,14 @@ end
         mean_eps(sigmoid, sigmoid, x32)  # 0.38896
         worst_eps(sigmoid, sigmoid, x32) # 1
 
-        @test mean_eps(sigmoid_fast, sigmoid, x32) < 0.2  # 0.29848
-        @test worst_eps(sigmoid_fast, sigmoid, x32) <= 5  # 2
+        @test mean_eps(sigmoid_fast, sigmoid, x32) < 0.5  # 0.38896
+        @test worst_eps(sigmoid_fast, sigmoid, x32) <= 2  # 2
 
         mean_eps(sigmoid, sigmoid, -x32)  # 0.38088
         worst_eps(sigmoid, sigmoid, -x32) # 2
 
-        @test_broken mean_eps(sigmoid_fast, sigmoid, -x32) < 0.6  # 7.18142
-        @test_broken worst_eps(sigmoid_fast, sigmoid, -x32) <= 5  # 164
+        @test mean_eps(sigmoid_fast, sigmoid, -x32) < 0.5  # 0.38088
+        @test worst_eps(sigmoid_fast, sigmoid, -x32) <= 2  # 164
 
         @test sigmoid_fast.(xbig32) ≈ sigmoid.(xbig32)
         @test sigmoid_fast.(-xbig32) ≈ sigmoid.(-xbig32)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -281,10 +281,10 @@ end
         mean_eps(tanh, tanh, x32)  # 0.065
         worst_eps(tanh, tanh, x32) # 1
 
-        @test mean_eps(tanh_fast, tanh, x32) < 0.7  # 0.65414
+        @test mean_eps(tanh_fast, tanh, x32) < 0.8  # 0.65414
         @test worst_eps(tanh_fast, tanh, x32) <= 5  # 5
 
-        @test mean_eps(tanh_fast, tanh, -x32) < 0.7 # 0.65414
+        @test mean_eps(tanh_fast, tanh, -x32) < 0.8 # 0.65414
         @test worst_eps(tanh_fast, tanh, -x32) <= 5 # 5
 
         @test tanh_fast.(xbig32) ≈ tanh.(xbig32)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -235,6 +235,10 @@ end
 
 mean_eps(f, g, xs) = mean(x -> abs(countepsfrom(f(x), g(big(x)))), xs)
 worst_eps(f, g, xs) = maximum(x -> abs(countepsfrom(f(x), g(big(x)))), xs)
+function find_worst(f, g, xs)
+    c, i = findmax(x -> abs(countepsfrom(f(x), g(big(x)))), xs)
+    c, xs[i]
+end
 
 @testset "tanh_fast & sigmoid_fast: Float64" begin
     

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -301,7 +301,7 @@ end
         worst_eps(sigmoid, sigmoid, -x32) # 2
 
         @test mean_eps(sigmoid_fast, sigmoid, -x32) < 0.5  # 0.38088
-        @test worst_eps(sigmoid_fast, sigmoid, -x32) <= 2  # 164
+        @test worst_eps(sigmoid_fast, sigmoid, -x32) <= 2  # 2
 
         @test sigmoid_fast.(xbig32) ≈ sigmoid.(xbig32)
         @test sigmoid_fast.(-xbig32) ≈ sigmoid.(-xbig32)


### PR DESCRIPTION
This proposes to add faster, lower-precision, versions of `tanh` and friends. Motivation:
```julia
julia> @btime x * x   setup=(x=randn(Float32,100,100));
  20.250 μs (2 allocations: 39.11 KiB)  # mac M1, julia 1.7 + rosetta
  52.718 μs (2 allocations: 39.11 KiB)  # xeon E5-2603

julia> @btime y .= tanh.(x * x)   setup=(x=randn(Float32,100,100); y=similar(x));
  107.167 μs (2 allocations: 39.11 KiB)
  229.725 μs (2 allocations: 39.11 KiB)

julia> @btime y .= tanh_faster.(x * x)   setup=(x=randn(Float32,100,100); y=similar(x));
  27.125 μs (2 allocations: 39.11 KiB)
  67.623 μs (2 allocations: 39.11 KiB)
```
There has been talk of using LoopVectorization to speed this up instead. At least for the computers I tried, this lower-precision function is faster. Of course that may speed up other things, but `tanh` seem the outlier in terms of speed -- I quote times with matrix multiplication above, to illustrate that it dominates. 
```julia
julia> using LoopVectorization

julia> @btime vmap!(tanh, y, x * x)   setup=(x=randn(Float32,100,100); y=similar(x));
  62.542 μs (2 allocations: 39.11 KiB)
  99.213 μs (2 allocations: 39.11 KiB)

julia> @btime vmap!(tanh_faster, y, x * x)   setup=(x=randn(Float32,100,100); y=similar(x));  # with IfElse
  27.292 μs (2 allocations: 39.11 KiB)
  60.970 μs (2 allocations: 39.11 KiB)
```
WIP, `tanh_fast` was the initial idea, but at least for Float32, a rational approximation like `tanh_faster` seems like a better idea, roughly one less digit & another factor of 3 in speed. Both need some care not to give crazy answers at large `x`, the precise implementation could use some adjusting. Times & error measures in [this gist](https://gist.github.com/mcabbott/0acd91671894bced65209e054bf80796).

I also have no idea hot this interacts with GPU just yet. 