### PR TITLE
permit NNlibCUDA to use Float16

### DIFF
--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -220,7 +220,7 @@ _batched_mul!(::Type, C, A, B, α::Number, β::Number) = batched_mul_generic!(C,
 _batched_mul!(::Type{DT}, C, A, B, α::Number, β::Number) where {DT<:DenseArray{T}} where {T<:BlasFloat} =
     _batched_try_gemm!(DT, C, A, B, α, β)
 
-function _batched_try_gemm!(::Type{DT}, C, A, B, α::Number, β::Number) where {DT<:DenseArray{T}} where {T<:BlasFloat}
+function _batched_try_gemm!(::Type{DT}, C, A, B, α::Number, β::Number) where {DT<:DenseArray{T}} where {T}
 
     alpha, beta = promote(α, β, zero(T))
     alpha isa T && beta isa T || return batched_mul_generic!(C, A, B, α, β)


### PR DESCRIPTION
in conjunction with https://github.com/FluxML/NNlibCUDA.jl/pull/32, add support for half-precision `gemm`, for which a special kernel is provided by Nvidia.  see https://github.com/JuliaGPU/CUDA.jl/pull/1080