### PR TITLE
Widen `tanh_fast` signature

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.7.33"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,7 +13,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "2, 3.2"
-ChainRules = "1 - 1.17"
 ChainRulesCore = "0.9.45, 0.10, 1"
 Compat = "3.14"
 Requires = "0.5, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.7.32"
+version = "0.7.33"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.7.33"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,6 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "2, 3.2"
+ChainRules = "1 - 1.17"
 ChainRulesCore = "0.9.45, 0.10, 1"
 Compat = "3.14"
 Requires = "0.5, 1.0"

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -712,7 +712,7 @@ end
 
 # These approximations are very badly behaved for Float16; none are fast.
 # They are also a bit slower with ForwardDiff.Dual numbers, let's use Base:
-tanh_fast(x::Real) = Base.tanh(x)
+tanh_fast(x::Number) = Base.tanh(x)
 
 """
     sigmoid_fast(x)

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -743,6 +743,11 @@ end
 
 sigmoid_fast(x::Float16) = sigmoid(x)  # sigmoid_fast is extremely badly behaved at large x
 
+function sigmoid_fast(x::Number)
+    Base.depwarn("sigmoid only makes sense on real numbers, got $(typeof(x))", :sigmoid_fast)
+    sigmoid(x)
+end
+
 """
     NNlib.fast_act(f, [x::AbstractArray])
 


### PR DESCRIPTION
As noted here https://github.com/FluxML/NNlib.jl/pull/371#issuecomment-1011411925 defining as a fallback only `tanh_fast(::Real)` causes problems for Flux right now. And `tanh` of course makes sense for complex numbers.

But really, all the other activation functions only make sense for real numbers, since they often compare `x>0` etc. In the interests of sanity and sensible guard-rails, they should probably all have signature `::Real` not `::Any`. But can't be changed just yet.