### PR TITLE
Silence some warnings

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -285,7 +285,7 @@ for front_name in (:conv, :∇conv_data, :∇conv_filter,
                         y::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
                         in2::AbstractArray{T2,N}, cdims::ConvDims;
                         kwargs...) where {yT, T1, T2, N}
-            if yT <: AbstractFloat  # don't print warning for ForwardDiff.Dual
+            if yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                           "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -285,8 +285,10 @@ for front_name in (:conv, :∇conv_data, :∇conv_filter,
                         y::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
                         in2::AbstractArray{T2,N}, cdims::ConvDims;
                         kwargs...) where {yT, T1, T2, N}
-            @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
+            if yT <: AbstractFloat  # don't print warning for ForwardDiff.Dual
+                @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                           "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
+            end
             $(Symbol("$(front_name)_direct!"))(y, in1, in2, cdims; kwargs...)
         end
     end


### PR DESCRIPTION
This avoids: 
```
┌ Warning: Slow fallback implementation invoked for conv!  You probably don't want this; check your datatypes.
[183](https://github.com/FluxML/Flux.jl/runs/5079634118?check_suite_focus=true#step:6:183)
│   yT = ForwardDiff.Dual{Nothing, Float32, 8}
[184](https://github.com/FluxML/Flux.jl/runs/5079634118?check_suite_focus=true#step:6:184)
│   T1 = ForwardDiff.Dual{Nothing, Float32, 8}
[185](https://github.com/FluxML/Flux.jl/runs/5079634118?check_suite_focus=true#step:6:185)
│   T2 = Float32
[186](https://github.com/FluxML/Flux.jl/runs/5079634118?check_suite_focus=true#step:6:186)
└ @ NNlib ~/.julia/packages/NNlib/JQe1Z/src/conv.jl:288
[187](https://github.com/FluxML/Flux.jl/runs/5079634118?check_suite_focus=true#step:6:187)
```
You will still get the warning if you mix Float32 & Float64, but not for dual numbers. 

Xref #349. I'm not sure that's closed, as they still take the slow path. But it's not by mistake. 