### PR TITLE
trigger op specialization in scatter

### DIFF
--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -70,7 +70,7 @@ julia> NNlib.scatter!(*, fill(0.5, 2, 4), [1 10; 100 1000], [3,2])
  0.5  500.0  50.0  0.5
 ```
 """
-function scatter!(op, dst::AbstractArray, src::AbstractArray, idx::AbstractArray)
+function scatter!(op::OP, dst::AbstractArray, src::AbstractArray, idx::AbstractArray) where OP
     dims = scatter_dims(dst, src, idx)
     colons = Base.ntuple(_->Colon(), dims)
     for k in CartesianIndices(idx)
@@ -127,11 +127,11 @@ julia> NNlib.scatter(*, [10,200,3000], [1,4,2]; init = 10, dstsize = 6)
     10
 ```
 """
-function scatter(op,
+function scatter(op::OP,
                 src::AbstractArray{Tsrc,Nsrc},
                 idx::AbstractArray{Tidx,Nidx};
-                init = nothing, dstsize = nothing) where {Tsrc,Tidx,Nsrc,Nidx}
-    
+                init = nothing, dstsize = nothing) where {Tsrc,Tidx,Nsrc,Nidx,OP}
+
     dims = Nsrc - Nidx
     dstsz = isnothing(dstsize) ? (size(src)[1:dims]..., maximum_dims(idx)...) : dstsize 
     dst = similar(src, Tsrc, dstsz)
@@ -140,7 +140,7 @@ function scatter(op,
     scatter!(op, dst, src, idx)
 end
 
-scatter_empty(op, T) = Base.reduce_empty(op, T)
+scatter_empty(op::OP, T) where OP = Base.reduce_empty(op, T)
 scatter_empty(op::typeof(-), T) = zero(T)
 scatter_empty(op::typeof(/), T) = one(T)
 scatter_empty(op::typeof(min), T) = typemax(T)

--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -140,7 +140,7 @@ function scatter(op::OP,
     scatter!(op, dst, src, idx)
 end
 
-scatter_empty(op::OP, T) where OP = Base.reduce_empty(op, T)
+scatter_empty(op, T) = Base.reduce_empty(op, T)
 scatter_empty(op::typeof(-), T) = zero(T)
 scatter_empty(op::typeof(/), T) = one(T)
 scatter_empty(op::typeof(min), T) = typemax(T)


### PR DESCRIPTION
It is easy to forget about this [performance tip](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing)

With this PR we get a >100x speedup by triggering specialization on `op`  :exploding_head: 


```julia
using Random, NNlib, BenchmarkTools

n = 100
m = 500
idx = rand(1:n, m)
src = rand(m)
dst = zeros(m)

@btime NNlib.scatter!(+, d, $src, $idx)  setup=(d=copy($dst));
#  343.351 μs (3500 allocations: 226.56 KiB)  # master
#  2.830 μs (0 allocations: 0 bytes)                  # this PR
 ```


Related to https://github.com/CarloLucibello/GraphNeuralNetworks.jl/issues/124  cc @learning-chip