### PR TITLE
add `rrule(::typeof(∇conv_filter)`

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -327,19 +327,6 @@ for conv in [:conv, :depthwiseconv]
         end
         return $∇conv_data(x, w, cdims; kw...), $∇conv_data_pullback
     end
-
-    # @eval function rrule(::typeof($∇conv_filter), x, dy, cdims; kw...)
-    #     function $∇conv_filter_pullback(Δ)
-    #         Δ = colmajor(Δ)
-    #         return (
-    #             NoTangent(),
-    #             @thunk($∇conv_data(dy, unthunk(Δ), cdims, kw...)),
-    #             @thunk($conv(x, unthunk(Δ), cdims, kw...)),
-    #             NoTangent(),
-    #         )
-    #     end
-    #     return $∇conv_filter(x, dy, cdims; kw...), $∇conv_filter_pullback
-    # end
 end
 
 function rrule(::typeof(∇conv_filter), x, dy, cdims; kw...)

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -331,11 +331,11 @@ end
 
 function rrule(::typeof(∇conv_filter), x, dy, cdims; kw...)
     function ∇conv_filter_pullback(Δ)
-        Δ = colmajor(Δ)
+        Δ1 = colmajor(unthunk(Δ))
         return (
             NoTangent(),
-            @thunk(∇conv_data(dy, unthunk(Δ), cdims, kw...)),
-            @thunk(conv(x, unthunk(Δ), cdims, kw...)),
+            @thunk(∇conv_data(dy, Δ1, cdims, kw...)),
+            @thunk(conv(x, Δ1, cdims, kw...)),
             NoTangent(),
         )
     end

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -327,6 +327,32 @@ for conv in [:conv, :depthwiseconv]
         end
         return $∇conv_data(x, w, cdims; kw...), $∇conv_data_pullback
     end
+
+    # @eval function rrule(::typeof($∇conv_filter), x, dy, cdims; kw...)
+    #     function $∇conv_filter_pullback(Δ)
+    #         Δ = colmajor(Δ)
+    #         return (
+    #             NoTangent(),
+    #             @thunk($∇conv_data(dy, unthunk(Δ), cdims, kw...)),
+    #             @thunk($conv(x, unthunk(Δ), cdims, kw...)),
+    #             NoTangent(),
+    #         )
+    #     end
+    #     return $∇conv_filter(x, dy, cdims; kw...), $∇conv_filter_pullback
+    # end
+end
+
+function rrule(::typeof(∇conv_filter), x, dy, cdims; kw...)
+    function ∇conv_filter_pullback(Δ)
+        Δ = colmajor(Δ)
+        return (
+            NoTangent(),
+            @thunk(∇conv_data(dy, unthunk(Δ), cdims, kw...)),
+            @thunk(conv(x, unthunk(Δ), cdims, kw...)),
+            NoTangent(),
+        )
+    end
+    return ∇conv_filter(x, dy, cdims; kw...), ∇conv_filter_pullback
 end
 
 # Use NNPACK if it is available and the operation is supported

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -734,6 +734,10 @@ end
   # else
     gradtest((y, w) -> sum(∇conv_data(y, w, cdims)), y, w)
   # end
+    gradtest((x, y) -> ∇conv_filter(x, y, cdims), x, y)
+    if spatial_rank < 3
+        gradtest((x, y) -> sum(∇conv_filter(x, y, cdims)), x, y)
+    end
 
   dcdims = DepthwiseConvDims(x, w)
   gradtest((x, w) -> depthwiseconv(x, w, dcdims), x, w)


### PR DESCRIPTION
``gradtest`` for ``sum(∇conv_filter(x, y, cdims))`` sometimes failing for 3d convolutions.