### PR TITLE
Conjugate weight before multiplying it with input

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -100,7 +100,7 @@ for backend in (Symbol(), :_direct, :_im2col, :_nnpack)
                             dy::AbstractArray{yT,N}, w::AbstractArray{wT,N},
                             cdims::C; kwargs...) where {yT, wT, N, C <: ConvDims}
                 dx = similar(dy, input_size(cdims)..., channels_in(cdims), size(dy, N))
-                return $(Symbol("$(name)$(backend)!"))(dx, dy, w, cdims; kwargs...)
+                return conj($(Symbol("$(name)$(backend)!"))(dx, dy, w, cdims; kwargs...))
             end
         end
     end
@@ -113,7 +113,7 @@ for backend in (Symbol(), :_direct, :_im2col, :_nnpack)
                         cdims::ConvDims; kwargs...) where {xT, yT, N}
             dw = similar(dy, kernel_size(cdims)..., channels_in(cdims) ÷ groupcount(cdims),
                                                     channels_out(cdims))
-            return $(Symbol("∇conv_filter$(backend)!"))(dw, x, dy, cdims; kwargs...)
+            return conj($(Symbol("∇conv_filter$(backend)!"))(dw, x, dy, cdims; kwargs...))
         end
     end
 

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -35,7 +35,7 @@ for (gemm, elt) in gemm_datatype_mappings
                                beta::$(elt), C::Ptr{$elt})
             # Convert our compile-time transpose marker to a char for BLAS
             convtrans(V::Val{false}) = 'N'
-            convtrans(V::Val{true})  = $elt <: Complex ? 'C' : 'T'
+            convtrans(V::Val{true})  = 'C'
 
             if transA == Val(false)
                 lda = M

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -35,7 +35,7 @@ for (gemm, elt) in gemm_datatype_mappings
                                beta::$(elt), C::Ptr{$elt})
             # Convert our compile-time transpose marker to a char for BLAS
             convtrans(V::Val{false}) = 'N'
-            convtrans(V::Val{true})  = 'T'
+            convtrans(V::Val{true})  = 'C'
 
             if transA == Val(false)
                 lda = M

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -35,7 +35,7 @@ for (gemm, elt) in gemm_datatype_mappings
                                beta::$(elt), C::Ptr{$elt})
             # Convert our compile-time transpose marker to a char for BLAS
             convtrans(V::Val{false}) = 'N'
-            convtrans(V::Val{true})  = 'C'
+            convtrans(V::Val{true})  = $elt <: Complex ? 'C' : 'T'
 
             if transA == Val(false)
                 lda = M

--- a/src/impl/conv_direct.jl
+++ b/src/impl/conv_direct.jl
@@ -107,7 +107,7 @@ function conv_direct!(
                     kproj(kh, kernel_h, fk),
                     kproj(kd, kernel_d, fk),
                     c_in, c_out]
-            dotprod = muladd(x_val, w_val, dotprod)
+            dotprod = muladd(x_val, conj(w_val), dotprod)
         end
         y[w_idx, h_idx, d_idx, c_out, batch] = alpha*dotprod + beta*y[w_idx, h_idx, d_idx, c_out, batch]
     end
@@ -147,7 +147,7 @@ function conv_direct!(
                             kproj(kh, kernel_h, fk),
                             kproj(kd, kernel_d, fk),
                             c_in, c_out]
-                    dotprod = muladd(x_val, w_val, dotprod)
+                    dotprod = muladd(x_val, conj(w_val), dotprod)
                 end
             end
         end

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -51,7 +51,7 @@ function conv_im2col!(
         im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
         GC.@preserve col_slice w y begin
             col_ptr = pointer(col_slice)
-            w_ptr = pointer(w)
+            w_ptr = pointer(copy(conj(w)))
             y_ptr = pointer(y, (batch_idx - 1)*M*N + 1)
             gemm!(Val(false), Val(false), M, N, K, alpha, col_ptr, w_ptr, beta, y_ptr)
         end


### PR DESCRIPTION
This is a follow up of https://github.com/FluxML/NNlib.jl/pull/389
The question is whether the weights should be conjugated before they are multiplied by the input.
This is more text-book like (see e.g. https://dsp.stackexchange.com/questions/55388/for-complex-values-why-use-complex-conjugate-in-convolution).