### PR TITLE
Change libblas to libblastrampoline

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -10,7 +10,9 @@ using Statistics
 using Statistics: mean
 using LinearAlgebra
 using LinearAlgebra: BlasFloat, Transpose, Adjoint, AdjOrTransAbsMat
-using LinearAlgebra.BLAS: libblas, BlasInt, @blasfunc
+using LinearAlgebra.BLAS: BlasInt, @blasfunc
+
+const libblas = Base.libblas_name
 
 const IntOrIntTuple = Union{Integer, NTuple{N,<:Integer} where N}
 const Numeric = Union{AbstractArray{<:T}, T} where {T<:Number}

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -12,7 +12,7 @@ using LinearAlgebra
 using LinearAlgebra: BlasFloat, Transpose, Adjoint, AdjOrTransAbsMat
 using LinearAlgebra.BLAS: BlasInt, @blasfunc
 
-const libblas = Base.libblas_name
+const libblas = "libblastrampoline"
 
 const IntOrIntTuple = Union{Integer, NTuple{N,<:Integer} where N}
 const Numeric = Union{AbstractArray{<:T}, T} where {T<:Number}

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -12,7 +12,7 @@ using LinearAlgebra
 using LinearAlgebra: BlasFloat, Transpose, Adjoint, AdjOrTransAbsMat
 using LinearAlgebra.BLAS: BlasInt, @blasfunc
 
-const libblas = "libblastrampoline"
+const libblas = Base.libblas_name
 
 const IntOrIntTuple = Union{Integer, NTuple{N,<:Integer} where N}
 const Numeric = Union{AbstractArray{<:T}, T} where {T<:Number}

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -4,7 +4,7 @@
 using LinearAlgebra
 using LinearAlgebra.BLAS: BlasInt, @blasfunc
 
-if VERSION >= v"1.7-"
+@static if VERSION >= v"1.7-"
     using LinearAlgebra.BLAS: libblastrampoline
     const libblas = libblastrampoline
 else

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -4,12 +4,7 @@
 using LinearAlgebra
 using LinearAlgebra.BLAS: BlasInt, @blasfunc
 
-@static if VERSION >= v"1.7-"
-    using LinearAlgebra.BLAS: libblastrampoline
-    const libblas = libblastrampoline
-else
-    using LinearAlgebra.BLAS: libblas
-end
+const libblas = Base.libblas_name
 
 using Compat: get_num_threads, set_num_threads # needs Compat 3.13, for any Julia < 1.6
 

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -1,9 +1,6 @@
 ## Low level gemm! call with pointers
 ## Borrowed from Knet.jl, adapted for compile-time constants
 
-using LinearAlgebra
-using LinearAlgebra.BLAS: BlasInt, @blasfunc
-
 using Compat: get_num_threads, set_num_threads # needs Compat 3.13, for any Julia < 1.6
 
 """

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -2,7 +2,14 @@
 ## Borrowed from Knet.jl, adapted for compile-time constants
 
 using LinearAlgebra
-using LinearAlgebra.BLAS: libblastrampoline, BlasInt, @blasfunc
+using LinearAlgebra.BLAS: BlasInt, @blasfunc
+
+if VERSION >= v"1.7-"
+    using LinearAlgebra.BLAS: libblastrampoline
+    libblas = libblastrampoline
+else
+    using LinearAlgebra.BLAS: libblas
+end
 
 using Compat: get_num_threads, set_num_threads # needs Compat 3.13, for any Julia < 1.6
 
@@ -48,7 +55,7 @@ for (gemm, elt) in gemm_datatype_mappings
                 ldb = N
             end
             ldc = M
-            ccall((@blasfunc($(gemm)), libblastrampoline), Nothing,
+            ccall((@blasfunc($(gemm)), libblas), Nothing,
                   (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                    Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
                    Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},
@@ -106,7 +113,7 @@ for (gemm, elt) in gemm_datatype_mappings
                         ptrBk = ptrB + (k-1) * strB * sizeof($elt)
                         ptrCk = ptrC + (k-1) * strC * sizeof($elt)
 
-                        ccall((@blasfunc($(gemm)), libblastrampoline), Nothing,
+                        ccall((@blasfunc($(gemm)), libblas), Nothing,
                               (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                                Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
                                Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},
@@ -128,7 +135,7 @@ for (gemm, elt) in gemm_datatype_mappings
                     ptrBk = ptrB + (k-1) * strB * sizeof($elt)
                     ptrCk = ptrC + (k-1) * strC * sizeof($elt)
 
-                    ccall((@blasfunc($(gemm)), libblastrampoline), Nothing,
+                    ccall((@blasfunc($(gemm)), libblas), Nothing,
                           (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                            Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
                            Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -6,7 +6,7 @@ using LinearAlgebra.BLAS: BlasInt, @blasfunc
 
 if VERSION >= v"1.7-"
     using LinearAlgebra.BLAS: libblastrampoline
-    libblas = libblastrampoline
+    const libblas = libblastrampoline
 else
     using LinearAlgebra.BLAS: libblas
 end

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -2,7 +2,7 @@
 ## Borrowed from Knet.jl, adapted for compile-time constants
 
 using LinearAlgebra
-using LinearAlgebra.BLAS: libblas, BlasInt, @blasfunc
+using LinearAlgebra.BLAS: libblastrampoline, BlasInt, @blasfunc
 
 using Compat: get_num_threads, set_num_threads # needs Compat 3.13, for any Julia < 1.6
 
@@ -48,7 +48,7 @@ for (gemm, elt) in gemm_datatype_mappings
                 ldb = N
             end
             ldc = M
-            ccall((@blasfunc($(gemm)), libblas), Nothing,
+            ccall((@blasfunc($(gemm)), libblastrampoline), Nothing,
                   (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                    Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
                    Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},
@@ -106,7 +106,7 @@ for (gemm, elt) in gemm_datatype_mappings
                         ptrBk = ptrB + (k-1) * strB * sizeof($elt)
                         ptrCk = ptrC + (k-1) * strC * sizeof($elt)
 
-                        ccall((@blasfunc($(gemm)), libblas), Nothing,
+                        ccall((@blasfunc($(gemm)), libblastrampoline), Nothing,
                               (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                                Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
                                Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},
@@ -128,7 +128,7 @@ for (gemm, elt) in gemm_datatype_mappings
                     ptrBk = ptrB + (k-1) * strB * sizeof($elt)
                     ptrCk = ptrC + (k-1) * strC * sizeof($elt)
 
-                    ccall((@blasfunc($(gemm)), libblas), Nothing,
+                    ccall((@blasfunc($(gemm)), libblastrampoline), Nothing,
                           (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                            Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
                            Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -4,8 +4,6 @@
 using LinearAlgebra
 using LinearAlgebra.BLAS: BlasInt, @blasfunc
 
-const libblas = Base.libblas_name
-
 using Compat: get_num_threads, set_num_threads # needs Compat 3.13, for any Julia < 1.6
 
 """


### PR DESCRIPTION
Xref https://github.com/JuliaLang/julia/pull/44360, `libblas` is not used anymore for Julia v1.9 and above, and `libblastrampoline` is instead. Causing errors for CI on Julia master including places like https://github.com/FluxML/Metalhead.jl/pull/125#issuecomment-1055716157