### PR TITLE
Avoid `Rational` in activation function gradients

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,8 @@ steps:
     agents:
       queue: "juliagpu"
       cuda: "*"
+    env:
+      NNLIB_TEST_CUDA: true
     timeout_in_minutes: 60
 
   # - label: "GPU julia nightly"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -256,7 +256,7 @@ julia> extrema(rrelu.(fill(-10f0, 1000)))
 (-3.3316886f0, -1.2548422f0)
 ```
 """
-function rrelu(x::T, l=1//8, u=1//3) where T<:Number
+function rrelu(x::T, l=oftf(x,1/8), u=oftf(x,1/3)) where T<:Number
     a = (u - l) * rand(float(T)) + l
     return leakyrelu(x, a)
 end
@@ -404,7 +404,7 @@ julia> hardswish.(-5:5)'
 """
 @inline hardswish(x) = x * hardσ(x)
 
-deriv_hardswish(x) = ifelse(x < -3, oftf(x,0), ifelse(x > 3, oftf(x,1), x/3 + 1//2))
+deriv_hardswish(x) = ifelse(x < -3, oftf(x,0), ifelse(x > 3, oftf(x,1), x/3 + oftf(x,1/2)))
 
 """
     lisht(x) = x * tanh(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,83 +7,84 @@ using Zygote: gradient
 using StableRNGs
 using CUDA
 
-if VERSION < v"1.6"
-    @info "skipping doctests, on Julia $VERSION"
-else
-    using Documenter
-    DocMeta.setdocmeta!(NNlib, :DocTestSetup, :(using NNlib, UnicodePlots); recursive=true)
-    @testset "Doctests" begin
-        doctest(NNlib, manual=false)
-    end
-end
-
 const rng = StableRNG(123)
-
 include("test_utils.jl")
 
-@testset "Activation Functions" begin
-    include("activations.jl")
-end
-
-@testset "Batched Multiplication" begin
-    include("batchedmul.jl")
-end
-
-@testset "Convolution" begin
-    include("conv.jl")
-    include("conv_bias_act.jl")
-end
-
-@testset "Inference" begin
-    include("inference.jl")
-end
-
-@testset "Pooling" begin
-    include("pooling.jl")
-end
-
-@testset "Padding" begin
-    include("padding.jl")
-end
-
-@testset "Softmax" begin
-    include("softmax.jl")
-end
-
-@testset "Upsampling" begin
-    include("upsample.jl")
-end
-
-@testset "Gather" begin
-    include("gather.jl")
-end
-
-@testset "Scatter" begin
-    include("scatter.jl")
-end
-
-@testset "Utilities" begin
-    include("utils.jl")
-end
-
-@testset "Grid Sampling" begin
-    include("sampling.jl")
-end
-
-@testset "Functions" begin
-    include("functions.jl")
-end
-
-if VERSION >= v"1.6" && CUDA.functional()
-    if get(ENV, "NNLIB_TEST_CUDA", "false") == "true"
-        import Pkg
-        using NNlibCUDA
-        @testset "CUDA" begin
-            Pkg.test("NNlibCUDA")
+@testset verbose=true "NNlib.jl" begin
+    if CUDA.functional()
+        if get(ENV, "NNLIB_TEST_CUDA", "false") == "true"
+            import Pkg
+            using NNlibCUDA
+            @testset "CUDA" begin
+                Pkg.test("NNlibCUDA")
+            end
+        else
+            @info "Skipping CUDA tests, set NNLIB_TEST_CUDA=true to run them"
         end
     else
-        @info "Skipping CUDA tests, set NNLIB_TEST_CUDA=true to run them"
+        @info "Insufficient version or CUDA not found; Skipping CUDA tests"
     end
-else
-    @info "Insufficient version or CUDA not found; Skipping CUDA tests"
+
+    if VERSION < v"1.6"
+        @info "skipping doctests, on Julia $VERSION"
+    else
+        using Documenter
+        DocMeta.setdocmeta!(NNlib, :DocTestSetup, :(using NNlib, UnicodePlots); recursive=true)
+        @testset "Doctests" begin
+            doctest(NNlib, manual=false)
+        end
+    end
+
+    @testset "Activation Functions" begin
+        include("activations.jl")
+    end
+
+    @testset "Batched Multiplication" begin
+        include("batchedmul.jl")
+    end
+
+    @testset "Convolution" begin
+        include("conv.jl")
+        include("conv_bias_act.jl")
+    end
+
+    @testset "Inference" begin
+        include("inference.jl")
+    end
+
+    @testset "Pooling" begin
+        include("pooling.jl")
+    end
+
+    @testset "Padding" begin
+        include("padding.jl")
+    end
+
+    @testset "Softmax" begin
+        include("softmax.jl")
+    end
+
+    @testset "Upsampling" begin
+        include("upsample.jl")
+    end
+
+    @testset "Gather" begin
+        include("gather.jl")
+    end
+
+    @testset "Scatter" begin
+        include("scatter.jl")
+    end
+
+    @testset "Utilities" begin
+        include("utils.jl")
+    end
+
+    @testset "Grid Sampling" begin
+        include("sampling.jl")
+    end
+
+    @testset "Functions" begin
+        include("functions.jl")
+    end
 end


### PR DESCRIPTION
This avoids using rational numbers in some activation function gradients, as that causes problems on GPU. 

Closes #398, closes #400.