### PR TITLE
make BatchedAdjOrTrans return correct BroadcastStyle

### DIFF
--- a/src/batched/batchedadjtrans.jl
+++ b/src/batched/batchedadjtrans.jl
@@ -102,3 +102,5 @@ end
 
 adapt_structure(to, x::BatchedAdjoint) = BatchedAdjoint(adapt(to, parent(x)))
 adapt_structure(to, x::BatchedTranspose) = BatchedTranspose(adapt(to, parent(x)))
+
+Broadcast.BroadcastStyle(::Type{<:BatchedAdjOrTrans{T, S}}) where {T, S} = Broadcast.BroadcastStyle(S)


### PR DESCRIPTION
This make `batch_transpose` or `batch_adjoint` over gpu array broadcastable.

without this patch:

```julia
julia> using NNlib, CUDA

julia> x = cu(randn(3,4,1));

julia> CUDA.allowscalar(false)

julia> batched_transpose(x) + batched_transpose(x)  
ERROR: Scalar indexing is disallowed.
Invocation of getindex resulted in scalar indexing of a GPU array.
This is typically caused by calling an iterating implementation of a method.
Such implementations *do not* execute on the GPU, but very slowly on the CPU,
and therefore are only permitted from the REPL for prototyping purposes.
If you did intend to index this array, annotate the caller with @allowscalar.
Stacktrace:                                                
[...]
```

with this patch:

```julia
julia> using NNlib, CUDA

julia> x = cu(randn(3,4,1));

julia> CUDA.allowscalar(false)    

julia> batched_transpose(x) + batched_transpose(x)
4×3×1 CuArray{Float32, 3, CUDA.Mem.DeviceBuffer}:
[:, :, 1] =
 0.804003  -1.25596    1.6399
 2.09514    0.652395   2.89468
 0.938654   1.72338   -4.85532
 0.247084   0.30947   -2.44189

```