### PR TITLE
export `grid_sample`

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -79,6 +79,7 @@ include("gather.jl")
 include("scatter.jl")
 include("utils.jl")
 include("sampling.jl")
+export grid_sample
 include("functions.jl")
 
 ## Include implementations


### PR DESCRIPTION
The motivation is to include the nice `grid_sample` function in the docs (otherwise it is very difficult to find). 
Maybe there is also a way to do so without exporting it.