### PR TITLE
Widen activation broadcast rules

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -877,7 +877,7 @@ for (f, dfdx) in UNARY_ACTS
 
     pullback = Symbol(:broadcasted_, f, :_pullback)
     @eval function rrule(::typeof(broadcasted),
-                         ::typeof($f), x::Numeric)
+                         ::typeof($f), x::Union{Numeric, Broadcast.Broadcasted})
         Ω = $f.(x)
         function $pullback(dΩ)
             x_thunk = InplaceableThunk(
@@ -908,7 +908,7 @@ for (f, dfdx1, dfdx2) in BINARY_ACTS
     pullback = Symbol(:broadcasted_, f, :_pullback_2arg)
     @eval function rrule(::typeof(broadcasted),
                          ::typeof($f), 
-                         x1::Numeric, x2::Number)
+                         x1::Union{Numeric, Broadcast.Broadcasted}, x2::Number)
         Ω = $f.(x1, x2)
         ## Allowing x2::Array would allow size(Ω) != size(x1), which is not handled here:
         $pullback(dΩ) = (NoTangent(), NoTangent(), @.(dΩ * $dfdx1), NO_ACT_GRAD)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -319,6 +319,14 @@ has_rule(a) = rrule(a, 1f0) === nothing ? "(no rule)" : ""
     end
 end
 
+using Base.Broadcast: broadcasted
+
+@testset "lazy broadcasting" begin
+    # ChainRules returns a Broadcasted, check these rules accept it
+    @test rrule(broadcasted, relu, rrule(broadcasted, +, [1,2], 3)[1]) != nothing
+    @test rrule(broadcasted, leakyrelu, rrule(broadcasted, +, [1,2], 3)[1], 0.2) != nothing
+end
+
 @testset "Gradient correctness" begin
     
     local rng = StableRNG(17)


### PR DESCRIPTION
In something like `relu.(x .+ b)`, the broadcast rule for `.+` in Zygote always makes an array, but the rule in ChainRules makes a `Broadcasted` to permit fusion. In that case the rule for `relu.(x::Numeric)` here won't currently be called; so this PR widens its signature. As suggested here: https://github.com/FluxML/NNlib.jl/issues/432#issuecomment-1214444303