### PR TITLE
Trigger tagbot on issue comments

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,8 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:  # https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249
+    types:
+      - created
 jobs:
   TagBot:
     runs-on: ubuntu-latest

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"


### PR DESCRIPTION
See https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249

We don't want it running every hour to check if a new version of NNlib was released. Environment-friendly and efficient.

> **Warning**
> This should be merged after a new release (triggered here - https://github.com/FluxML/NNlib.jl/commit/a5e51ab634eac8f2a748312b8f3d872a8c0d3ffe#commitcomment-87743155) is created by the TagBot in the next run. Should happen roughly in the next 20 minutes.

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
