### PR TITLE
Slightly faster softplus

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -615,7 +615,7 @@ julia> softplus(16f0)
 16.0f0
 ```
 """
-softplus(x) = log1p(exp(-abs(x))) + max(x, 0)
+softplus(x) = log1p(exp(-abs(x))) + relu(x)
 
 """
     logcosh(x)


### PR DESCRIPTION
A few percent faster `softplus` using `relu(x)` instead of `max(x, 0)`. Ref. https://github.com/FluxML/NNlib.jl/pull/347.