### PR TITLE
Add fold and unfold

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -71,6 +71,8 @@ ConvDims
 depthwiseconv
 DepthwiseConvDims
 DenseConvDims
+unfold
+fold
 ```
 
 ## Upsampling

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -62,7 +62,6 @@ include("conv_bias_act.jl")
 export conv_bias_act, conv_bias_act!
 
 include("fold.jl")
-export unfold, unfold!, fold, fold!
 
 include("ctc.jl")
 export ctc_loss

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -61,6 +61,9 @@ export conv, conv!, ∇conv_data, ∇conv_data!, ∇conv_filter,
 include("conv_bias_act.jl")
 export conv_bias_act, conv_bias_act!
 
+include("fold.jl")
+export unfold, unfold!, fold, fold!
+
 include("ctc.jl")
 export ctc_loss
 

--- a/src/fold.jl
+++ b/src/fold.jl
@@ -1,0 +1,134 @@
+
+"""
+    unfold(x, kernel_size; stride = 1, pad = 0, dilation = 0)
+
+Places sliding windows of x into a container tensor of size (num_windows, window_size, batchsize).
+The window size is determined by the prod(spatial dims of kernel)*input_channels.
+The number of sliding windows will match those of convolution (conv) with the same kernel_size and arguments.
+"""
+function unfold(x::AbstractArray{T, N}, kernel_size::NTuple{K}; stride = 1, pad = 0, dilation = 1) where {T, K, N}
+    stride = expand(Val(N - 2), stride)
+    padding = expand(Val(N - 2), pad)
+    dilation = expand(Val(N - 2), dilation)
+    cdims = DenseConvDims(size(x), kernel_size; stride, padding, dilation)
+    return unfold(x, cdims)
+end
+
+"""
+    fold(y, output_size, kernel_size; stride = 1, pad = 0, dilation = 0)
+
+Accumulates sliding windows from the output of unfold into a container tensor of size `output_size`.
+An inverse to `unfold` can be obtained by using `fold` and accounting for scaling issues. 
+For example,
+
+```jldoctest
+julia> kernel_size, pad = (3, 3, 1, 1), 1
+
+julia> x = reshape(1:64, 8, 8, 1, 1) |> collect;
+
+julia> y = unfold(x, kernel_size; pad=pad);
+
+julia> size(y)
+(64, 9, 1)
+
+julia> z = fold(y, size(x), kernel_size; pad=pad);
+
+julia> d = fold(unfold(ones(eltype(x), size(x)...), kernel_size; pad=pad), size(x), kernel_size; pad=pad)
+8×8×1×1 Array{Int64, 4}:
+[:, :, 1, 1] =
+ 4  6  6  6  6  6  6  4
+ 6  9  9  9  9  9  9  6
+ 6  9  9  9  9  9  9  6
+ 6  9  9  9  9  9  9  6
+ 6  9  9  9  9  9  9  6
+ 6  9  9  9  9  9  9  6
+ 6  9  9  9  9  9  9  6
+ 4  6  6  6  6  6  6  4
+
+julia> x == z./d
+true
+```
+"""
+function fold(x::AbstractArray{T, 3}, output_size::NTuple{N}, kernel_size::NTuple{K}; stride = 1, pad = 0, dilation = 1) where {T, K, N}
+    stride = expand(Val(N - 2), stride)
+    padding = expand(Val(N - 2), pad)
+    dilation = expand(Val(N - 2), dilation)
+    cdims = DenseConvDims(output_size, kernel_size; stride, padding, dilation)
+    return fold(x, output_size, cdims)
+end
+
+# im2col_dims returns (numblocks, blocksize, threadnum) where thread dim is used as thread-local
+# workspace for multithreaded conv. Ultimately, we want to threadnum with batchsize.
+unfold_dims(cdims::DenseConvDims) = im2col_dims(cdims)[1:2]
+
+# auto-allocating versions
+function unfold(x::AbstractArray{T, N}, cdims::DenseConvDims) where {T, N}
+    y = similar(x, unfold_dims(cdims)..., size(x, N)) # (numblocks, blocksize, batchsize)
+    return unfold!(y, x, cdims)
+end
+
+function fold(y::AbstractArray{T, 3}, output_size::NTuple, cdims::DenseConvDims) where {T}
+    x = similar(y, output_size) 
+    return fold!(x, y, cdims)
+end
+
+# N < 5 -dimension in-place versions 
+function unfold!(y::AbstractArray{yT, 3}, x::AbstractArray{xT, N}, cdims::DenseConvDims) where {yT, xT, N}
+    unfold!(
+        y, 
+        insert_singleton_spatial_dimension(x, 5-N), 
+        insert_singleton_spatial_dimension(cdims, 5-N), 
+    )
+    return y
+end
+
+function fold!(x::AbstractArray{xT, N}, y::AbstractArray{yT, 3}, cdims::DenseConvDims) where {yT, xT, N}
+    fold!(
+        insert_singleton_spatial_dimension(x, 5-N), 
+        y,
+        insert_singleton_spatial_dimension(cdims, 5-N), 
+    )
+    return x
+end
+
+# 5-dimension in-place versions 
+function unfold!(y::AbstractArray{yT, 3}, x::AbstractArray{xT, 5}, cdims::DenseConvDims) where {yT, xT}
+    @threads for batch_idx in 1:size(x, 5)
+        y_slice = view(y, :, :, batch_idx)
+        im2col!(y_slice, view(x, :, :, :, :, batch_idx), cdims)
+    end
+    return y
+end
+
+function fold!(x::AbstractArray{xT, 5}, y::AbstractArray{yT, 3}, cdims::DenseConvDims) where {xT, yT}
+    @threads for batch_idx in 1:size(x, 5)
+        y_slice = view(y, :, :, batch_idx)
+        col2im!(view(x, :, :, :, :, batch_idx), y_slice, cdims)
+    end
+    return x
+end
+
+# reverse diff rules
+function rrule(::typeof(unfold), x, cdims)
+    function unfold_pullback(Δ)
+        return (
+            NoTangent(),
+            @thunk(fold(unthunk(Δ), size(x), cdims)),
+            NoTangent(),
+        )
+    end
+    return unfold(x, cdims), unfold_pullback
+end
+
+function rrule(::typeof(fold), x, output_size, cdims)
+    function fold_pullback(Δ)
+        return (
+            NoTangent(),
+            @thunk(unfold(unthunk(Δ), cdims)),
+            NoTangent(),
+            NoTangent(),
+        )
+    end
+    return fold(x, output_size, cdims), fold_pullback
+end
+

--- a/src/fold.jl
+++ b/src/fold.jl
@@ -17,12 +17,9 @@ and a potential inverse of `unfold`.
 The below example demonstrates that `unfold` uses the same sliding windows as `conv`.
 In general [`batched_mul`](@ref) + `unfold` should not be used to achieve convolution.
 ```jldoctest
-julia> x = [100; 2; 3; 40; 5; 6; 700;;;];  # 1D data, 1 channel, batch of 1
+julia> x = reshape([100 2 3 40 5 6 700], 7, 1, 1);  # 1D data, 1 channel, batch of 1
 
-julia> size(x)
-(7, 1, 1)
-
-julia> w = [1;0;-1;;;];  # 1D conv kernel of length 3
+julia> w = reshape([1 0 -1], 3, 1, 1);  # 1D conv kernel of length 3
 
 julia> kws = (pad=1, stride=2, flipped=true);  # use same args for conv and unfold
 
@@ -71,7 +68,7 @@ See also [`unfold`](@ref).
 
 # Example
 ```jldoctest
-julia> x = [100; 2; 3; 40; 5; 6; 700;;;];  # 1D data, 1 channel, batch of 1
+julia> x = reshape([100 2 3 40 5 6 700], 7, 1, 1);  # 1D data, 1 channel, batch of 1
 
 julia> y = unfold(x, (3,1,1))  # sliding window of size 3
 5×3×1 Array{Int64, 3}:

--- a/src/fold.jl
+++ b/src/fold.jl
@@ -1,21 +1,22 @@
 
 """
-    unfold(x, kernel_size; stride = 1, pad = 0, dilation = 0)
+    unfold(x, kernel_size; stride = 1, pad = 0, dilation = 0, flipped = false)
 
 Places sliding windows of x into a container tensor of size (num_windows, window_size, batchsize).
 The window size is determined by the prod(spatial dims of kernel)*input_channels.
 The number of sliding windows will match those of convolution (conv) with the same kernel_size and arguments.
+Uses NNlib.im2col! as backend.
 """
-function unfold(x::AbstractArray{T, N}, kernel_size::NTuple{K}; stride = 1, pad = 0, dilation = 1) where {T, K, N}
+function unfold(x::AbstractArray{T, N}, kernel_size::NTuple{K}; stride = 1, pad = 0, dilation = 1, flipped = false) where {T, K, N}
     stride = expand(Val(N - 2), stride)
     padding = expand(Val(N - 2), pad)
     dilation = expand(Val(N - 2), dilation)
-    cdims = DenseConvDims(size(x), kernel_size; stride, padding, dilation)
+    cdims = DenseConvDims(size(x), kernel_size; stride, padding, dilation, flipkernel=flipped)
     return unfold(x, cdims)
 end
 
 """
-    fold(y, output_size, kernel_size; stride = 1, pad = 0, dilation = 0)
+    fold(y, output_size, kernel_size; stride = 1, pad = 0, dilation = 0, flipped = false)
 
 Accumulates sliding windows from the output of unfold into a container tensor of size `output_size`.
 An inverse to `unfold` can be obtained by using `fold` and accounting for scaling issues. 
@@ -48,12 +49,13 @@ julia> d = fold(unfold(ones(eltype(x), size(x)...), kernel_size; pad=pad), size(
 julia> x == z./d
 true
 ```
+Uses NNlib.col2im! as backend.
 """
-function fold(x::AbstractArray{T, 3}, output_size::NTuple{N}, kernel_size::NTuple{K}; stride = 1, pad = 0, dilation = 1) where {T, K, N}
+function fold(x::AbstractArray{T, 3}, output_size::NTuple{N}, kernel_size::NTuple{K}; stride = 1, pad = 0, dilation = 1, flipped = false) where {T, K, N}
     stride = expand(Val(N - 2), stride)
     padding = expand(Val(N - 2), pad)
     dilation = expand(Val(N - 2), dilation)
-    cdims = DenseConvDims(output_size, kernel_size; stride, padding, dilation)
+    cdims = DenseConvDims(output_size, kernel_size; stride, padding, dilation, flipkernel=flipped)
     return fold(x, output_size, cdims)
 end
 
@@ -109,26 +111,26 @@ function fold!(x::AbstractArray{xT, 5}, y::AbstractArray{yT, 3}, cdims::DenseCon
 end
 
 # reverse diff rules
-function rrule(::typeof(unfold), x, cdims)
+function rrule(::typeof(unfold), x, cdims::DenseConvDims; kw...)
     function unfold_pullback(Δ)
         return (
             NoTangent(),
-            @thunk(fold(unthunk(Δ), size(x), cdims)),
+            fold(unthunk(Δ), size(x), cdims; kw...),
             NoTangent(),
         )
     end
-    return unfold(x, cdims), unfold_pullback
+    return unfold(x, cdims; kw...), unfold_pullback
 end
 
-function rrule(::typeof(fold), x, output_size, cdims)
+function rrule(::typeof(fold), x, output_size, cdims::DenseConvDims; kw...)
     function fold_pullback(Δ)
         return (
             NoTangent(),
-            @thunk(unfold(unthunk(Δ), cdims)),
+            unfold(unthunk(Δ), cdims; kw...),
             NoTangent(),
             NoTangent(),
         )
     end
-    return fold(x, output_size, cdims), fold_pullback
+    return fold(x, output_size, cdims; kw...), fold_pullback
 end
 

--- a/src/fold.jl
+++ b/src/fold.jl
@@ -23,7 +23,7 @@ julia> w = reshape([1 0 -1], 3, 1, 1);  # 1D conv kernel of length 3
 
 julia> kws = (pad=1, stride=2, flipped=true);  # use same args for conv and unfold
 
-julia> z = unfold(x, size(w); kws...) 
+julia> z = NNlib.unfold(x, size(w); kws...) 
 4×3×1 Array{Int64, 3}:
 [:, :, 1] =
   0  100   2
@@ -70,7 +70,7 @@ See also [`unfold`](@ref).
 ```jldoctest
 julia> x = reshape([100 2 3 40 5 6 700], 7, 1, 1);  # 1D data, 1 channel, batch of 1
 
-julia> y = unfold(x, (3,1,1))  # sliding window of size 3
+julia> y = NNlib.unfold(x, (3,1,1))  # sliding window of size 3
 5×3×1 Array{Int64, 3}:
 [:, :, 1] =
  100   2    3
@@ -79,7 +79,7 @@ julia> y = unfold(x, (3,1,1))  # sliding window of size 3
   40   5    6
    5   6  700
 
-julia> z = fold(y, size(x), (3,1,1))  # sum of contributions in y. 100 appears once, 40 three times
+julia> z = NNlib.fold(y, size(x), (3,1,1))  # sum of contributions in y. 100 appears once, 40 three times
 7×1×1 Array{Int64, 3}:
 [:, :, 1] =
  100
@@ -90,7 +90,7 @@ julia> z = fold(y, size(x), (3,1,1))  # sum of contributions in y. 100 appears o
   12
  700
 
-julia> divisor = fold(unfold(ones(size(x)...), (3,1,1)), size(x), (3,1,1))
+julia> divisor = NNlib.fold(NNlib.unfold(ones(size(x)...), (3,1,1)), size(x), (3,1,1))
 7×1×1 Array{Float64, 3}:
 [:, :, 1] =
  1.0

--- a/src/fold.jl
+++ b/src/fold.jl
@@ -23,7 +23,7 @@ An inverse to `unfold` can be obtained by using `fold` and accounting for scalin
 For example,
 
 ```jldoctest
-julia> kernel_size, pad = (3, 3, 1, 1), 1
+julia> kernel_size, pad = (3, 3, 1, 1), 1;
 
 julia> x = reshape(1:64, 8, 8, 1, 1) |> collect;
 
@@ -48,6 +48,7 @@ julia> d = fold(unfold(ones(eltype(x), size(x)...), kernel_size; pad=pad), size(
 
 julia> x == z./d
 true
+
 ```
 Uses NNlib.col2im! as backend.
 """

--- a/test/fold.jl
+++ b/test/fold.jl
@@ -3,26 +3,26 @@ using NNlib, Test
 @testset "unfold wrapper" begin
     x = rand(rng, 16, 16, 3, 10)
     w = rand(rng, 5, 5, 3, 2)
-    @test size(unfold(x, size(w))) == (144, 75, 10)
-    @test size(unfold(x, size(w); pad=2)) == (256, 75, 10)
-    @test size(unfold(x, size(w); stride=2)) == (36, 75, 10)
-    @test size(unfold(x, size(w); dilation=2)) == (64, 75, 10)
+    @test size(NNlib.unfold(x, size(w))) == (144, 75, 10)
+    @test size(NNlib.unfold(x, size(w); pad=2)) == (256, 75, 10)
+    @test size(NNlib.unfold(x, size(w); stride=2)) == (36, 75, 10)
+    @test size(NNlib.unfold(x, size(w); dilation=2)) == (64, 75, 10)
 end
 
 @testset "Inverses: spatial_rank=$spatial_rank" for spatial_rank in (1, 2, 3)
     x = rand(rng, repeat([8], spatial_rank)..., 3, 2)
     w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
     cdims = DenseConvDims(x, w; padding=1)
-    y = unfold(x, cdims)
-    z = fold(y, size(x), cdims)
-    divisor = fold(unfold(ones(eltype(x), size(x)...), cdims), size(x), cdims)
+    y = NNlib.unfold(x, cdims)
+    z = NNlib.fold(y, size(x), cdims)
+    divisor = NNlib.fold(NNlib.unfold(ones(eltype(x), size(x)...), cdims), size(x), cdims)
     @test isapprox(z ./ divisor, x, rtol=1.0e-7)
 
     # introduce stride
     cdims = DenseConvDims(x, w; padding=1, stride=2)
-    y = unfold(x, cdims)
-    z = fold(y, size(x), cdims)
-    divisor = fold(unfold(ones(eltype(x), size(x)...), cdims), size(x), cdims)
+    y = NNlib.unfold(x, cdims)
+    z = NNlib.fold(y, size(x), cdims)
+    divisor = NNlib.fold(NNlib.unfold(ones(eltype(x), size(x)...), cdims), size(x), cdims)
     @test isapprox(z ./ divisor, x, rtol=1.0e-7)
 end
 
@@ -30,11 +30,11 @@ end
     x = rand(rng, repeat([5], spatial_rank)..., 3, 2)
     w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
     cdims = DenseConvDims(x, w)
-    gradtest(x -> unfold(x, cdims), x)
-    test_rrule(unfold, x, cdims)
+    gradtest(x -> NNlib.unfold(x, cdims), x)
+    test_rrule(NNlib.unfold, x, cdims)
     
-    y = unfold(x, cdims)
-    gradtest(y -> fold(y, size(x), cdims), y)
-    test_rrule(fold, y, size(x), cdims)
+    y = NNlib.unfold(x, cdims)
+    gradtest(y -> NNlib.fold(y, size(x), cdims), y)
+    test_rrule(NNlib.fold, y, size(x), cdims)
 end
 

--- a/test/fold.jl
+++ b/test/fold.jl
@@ -30,9 +30,11 @@ end
     x = rand(rng, repeat([5], spatial_rank)..., 3, 2)
     w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
     cdims = DenseConvDims(x, w)
-    gradtest(x -> sum(unfold(x, cdims)), x)
+    gradtest(x -> unfold(x, cdims), x)
+    test_rrule(unfold, x, cdims)
     
     y = unfold(x, cdims)
-    gradtest(y -> sum(fold(y, size(x), cdims)), y)
+    gradtest(y -> fold(y, size(x), cdims), y)
+    test_rrule(fold, y, size(x), cdims)
 end
 

--- a/test/fold.jl
+++ b/test/fold.jl
@@ -1,0 +1,38 @@
+using NNlib, Test
+
+@testset "unfold wrapper" begin
+    x = rand(rng, 16, 16, 3, 10)
+    w = rand(rng, 5, 5, 3, 2)
+    @test size(unfold(x, size(w))) == (144, 75, 10)
+    @test size(unfold(x, size(w); pad=2)) == (256, 75, 10)
+    @test size(unfold(x, size(w); stride=2)) == (36, 75, 10)
+    @test size(unfold(x, size(w); dilation=2)) == (64, 75, 10)
+end
+
+@testset "Inverses: spatial_rank=$spatial_rank" for spatial_rank in (1, 2, 3)
+    x = rand(rng, repeat([8], spatial_rank)..., 3, 2)
+    w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
+    cdims = DenseConvDims(x, w; padding=1)
+    y = unfold(x, cdims)
+    z = fold(y, size(x), cdims)
+    divisor = fold(unfold(ones(eltype(x), size(x)...), cdims), size(x), cdims)
+    @test isapprox(z ./ divisor, x, rtol=1.0e-7)
+
+    # introduce stride
+    cdims = DenseConvDims(x, w; padding=1, stride=2)
+    y = unfold(x, cdims)
+    z = fold(y, size(x), cdims)
+    divisor = fold(unfold(ones(eltype(x), size(x)...), cdims), size(x), cdims)
+    @test isapprox(z ./ divisor, x, rtol=1.0e-7)
+end
+
+@testset "AutoDiff: spatial_rank=$spatial_rank" for spatial_rank in (1, 2, 3)
+    x = rand(rng, repeat([5], spatial_rank)..., 3, 2)
+    w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
+    cdims = DenseConvDims(x, w)
+    gradtest(x -> sum(unfold(x, cdims)), x)
+    
+    y = unfold(x, cdims)
+    gradtest(y -> sum(fold(y, size(x), cdims)), y)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,10 @@ include("test_utils.jl")
         include("ctc.jl")
     end
 
+    @testset "Fold/Unfold" begin
+        include("fold.jl")
+    end
+
     @testset "Inference" begin
         include("inference.jl")
     end


### PR DESCRIPTION
Added `fold` / `unfold` operators for [pytorch feature parity](https://github.com/FluxML/Flux.jl/issues/1431). These are useful for nonlocal operators in convnets. I tried to follow a similar style as `conv` and `meanpool`, and similar argument structuring as [pytorch's fold/unfold](https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html#torch.nn.Unfold). 

I initially looked at pull #303 but ended up writing things a little differently.

I have not had the chance to test on GPU yet, but can give it a go soon.

Feedback is greatly appreciated!

### PR Checklist

- [x] Tests are added (autodiff, wrapper, fold/unfold as inverses)
- [x] Documentation (of wrapper functions only)
