### PR TITLE
Avoid `maximum` in `softmax`

### DIFF
--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -17,7 +17,7 @@ See also [`logsoftmax`](@ref).
 
 # Examples
 
-```jldoctest softmax; filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?
+```jldoctest; filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?"
 julia> softmax([1, 2, 3])
 3-element Vector{Float64}:
  0.09003057317038046

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -20,7 +20,7 @@ See also [`logsoftmax`](@ref).
 ```jldoctest
 julia> softmax([1, 2, 3])
 3-element Vector{Float64}:
- 0.09003057317038046
+ 0.09003057317038045
  0.24472847105479764
  0.6652409557748218
 
@@ -64,7 +64,8 @@ function softmax!(out::AbstractArray{T}, x::AbstractArray; dims = 1) where {T}
     else
         @fastmath @. out = ifelse(isequal(max_,Inf), ifelse(isequal(x,Inf), 1, 0), exp(x - max_))
     end
-    out ./= sum!(max_, out)
+    tmp = dims isa Colon ? sum(out) : sum!(max_, out)
+    out ./= tmp
 end
 
 function ∇softmax_data(dy::AbstractArray{T}, y::AbstractArray{S}; dims = 1) where {T,S}

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -58,7 +58,7 @@ softmax(x::AbstractArray{T}; dims = 1) where {T} = softmax!(similar(x, float(T))
 softmax!(x::AbstractArray; dims = 1) = softmax!(x, x; dims)
 
 function softmax!(out::AbstractArray{T}, x::AbstractArray; dims = 1) where {T}
-    max_ = @fastmath reduce(max, x; dims, init = T(-Inf))
+    max_ = fast_maximum(x; dims)
     if all(isfinite, max_)
         @fastmath out .= exp.(x .- max_)
     else
@@ -76,7 +76,7 @@ function ∇softmax_data(dy::AbstractArray{T}, y::AbstractArray{S}; dims = 1) wh
         # This path is faster, only safe for 1st derivatives though.
         # Was previously `∇softmax!(dx, dy, x, y; dims)` to allow CUDA overloads,
         # but that was slow: https://github.com/FluxML/NNlibCUDA.jl/issues/30
-        out = similar(y, promote_type(T,S))
+        out = similar(y, promote_type(T,S))  # sure to be mutable
         out .= dy .* y
         out .= out .- y .* sum(out; dims)
     end
@@ -91,6 +91,7 @@ end
 within_grad() = false
 rrule(::typeof(within_grad)) = true, _ -> (NoTangent(),)
 
+fast_maximum(x::AbstractArray{T}; dims) where {T} = @fastmath reduce(max, x; dims, init = float(T)(-Inf))
 
 """
     logsoftmax(x; dims = 1)
@@ -110,13 +111,14 @@ logsoftmax(x::AbstractArray{T}; dims = 1) where {T} = logsoftmax!(similar(x, flo
 logsoftmax!(x::AbstractArray; dims = 1) = logsoftmax!(x, x; dims)
 
 function logsoftmax!(out::AbstractArray{T}, x::AbstractArray; dims = 1) where {T}
-    max_ = maximum(x; dims)
+    max_ = fast_maximum(x; dims)
     if all(isfinite, max_)
         out .= x .- max_
     else
         @. out = ifelse(isequal(max_,Inf), ifelse(isequal(x,Inf), 0, -Inf), x - max_)
     end
-    @fastmath log_ = log.(sum(exp, out; dims))
+    tmp = dims isa Colon ? sum(out) : sum!(max_, out)
+    @fastmath log_ = log.(tmp)
     out .-= log_
 end
 

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -17,10 +17,10 @@ See also [`logsoftmax`](@ref).
 
 # Examples
 
-```jldoctest
+```jldoctest; filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?
 julia> softmax([1, 2, 3])
 3-element Vector{Float64}:
- 0.09003057317038045
+ 0.09003057317038046
  0.24472847105479764
  0.6652409557748218
 

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -117,8 +117,7 @@ function logsoftmax!(out::AbstractArray{T}, x::AbstractArray; dims = 1) where {T
     else
         @. out = ifelse(isequal(max_,Inf), ifelse(isequal(x,Inf), 0, -Inf), x - max_)
     end
-    tmp = dims isa Colon ? sum(out) : sum!(max_, out)
-    @fastmath log_ = log.(tmp)
+    @fastmath log_ = log.(sum(exp, out; dims))
     out .-= log_
 end
 

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -58,13 +58,13 @@ softmax(x::AbstractArray{T}; dims = 1) where {T} = softmax!(similar(x, float(T))
 softmax!(x::AbstractArray; dims = 1) = softmax!(x, x; dims)
 
 function softmax!(out::AbstractArray{T}, x::AbstractArray; dims = 1) where {T}
-    max_ = maximum(x; dims)
+    max_ = @fastmath reduce(max, x; dims, init = T(-Inf))
     if all(isfinite, max_)
         @fastmath out .= exp.(x .- max_)
     else
         @fastmath @. out = ifelse(isequal(max_,Inf), ifelse(isequal(x,Inf), 1, 0), exp(x - max_))
     end
-    out ./= sum(out; dims)
+    out ./= sum!(max_, out)
 end
 
 function ∇softmax_data(dy::AbstractArray{T}, y::AbstractArray{S}; dims = 1) where {T,S}

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -17,7 +17,7 @@ See also [`logsoftmax`](@ref).
 
 # Examples
 
-```jldoctest; filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?
+```jldoctest softmax; filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?
 julia> softmax([1, 2, 3])
 3-element Vector{Float64}:
  0.09003057317038046


### PR DESCRIPTION
I think `max` is very careful about NaN & signed zero, and hence `maximum` is surprisingly slow. This uses the `@fastmath` version: 
```
julia> let x = randn(Float32, 100, 1000)
         @btime softmax($x)
         @btime _softmax($x)  # this PR
       end;
  min 1.344 ms, mean 1.422 ms (7 allocations, 398.91 KiB)
  min 647.875 μs, mean 707.579 μs (3 allocations, 394.73 KiB)
```