### PR TITLE
Fixup docs for fold and unfold

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -71,8 +71,8 @@ ConvDims
 depthwiseconv
 DepthwiseConvDims
 DenseConvDims
-unfold
-fold
+NNlib.unfold
+NNlib.fold
 ```
 
 ## Upsampling


### PR DESCRIPTION
Documenter reports missing docstrings because these were included sans prefix despite not being exported.

### PR Checklist

- [N/A] Tests are added
- [x] Documentation, if applicable
