### PR TITLE
Add `dropout`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.8.13"
+version = "0.8.14"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -40,6 +40,9 @@ for f in ACTIVATIONS
 end
 export sigmoid, hardsigmoid, logsigmoid, thresholdrelu # Aliases
 
+include("dropout.jl")
+export dropout, dropout!
+
 include("softmax.jl")
 export softmax, softmax!, ∇softmax, ∇softmax!, logsoftmax, 
     logsoftmax!, ∇logsoftmax, ∇logsoftmax!, logsumexp

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -6,6 +6,7 @@ using ChainRulesCore
 import ChainRulesCore: rrule
 using Base.Broadcast: broadcasted
 using Base.Threads
+using Random
 using Statistics
 using Statistics: mean
 using LinearAlgebra

--- a/src/dropout.jl
+++ b/src/dropout.jl
@@ -1,0 +1,152 @@
+using Random, ChainRulesCore
+
+"""
+    dropout([rng], A, p; dims=:)
+
+Returns an array in which each element of `A` is either replaced with zero,
+with probability `p`, or else multiplied by `1/(1-p)`.
+
+By default every element is treated independently.
+With `dims=1`, a choice is made for every value of the 1st index
+i.e. each row of a matrix is either zero or not.
+
+Optional first argument is the random number generator used.
+
+# Examples
+```
+julia> dropout(ones(2, 10), 1/5)
+2×10 Matrix{Float64}:
+ 1.25  1.25  0.0   1.25  1.25  1.25  1.25  1.25  1.25  1.25
+ 1.25  1.25  1.25  0.0   1.25  1.25  0.0   1.25  1.25  1.25
+
+julia> mean(dropout(ones(10^4, 5), 0.3), dims=1)
+1×5 Matrix{Float64}:
+ 0.996  1.00171  1.00629  0.998714  0.992429
+
+julia> dropout(ones(5, 5), 0.7, dims=1)  # whole row the same
+5×5 Matrix{Float64}:
+ 3.33333  3.33333  3.33333  3.33333  3.33333
+ 0.0      0.0      0.0      0.0      0.0
+ 0.0      0.0      0.0      0.0      0.0
+ 3.33333  3.33333  3.33333  3.33333  3.33333
+ 0.0      0.0      0.0      0.0      0.0
+
+julia> mean(dropout(ones(10^4, 5), 0.3, dims=1), dims=1)
+1×5 Matrix{Float64}:
+ 1.00571  1.00571  1.00571  1.00571  1.00571
+```
+"""
+dropout(A::AbstractArray, p::Real; dims = :) = dropout(_rng_from_array(A), A, p; dims)
+
+function dropout(rng::AbstractRNG, A::AbstractArray, p::Real; dims = :)
+    T = float(eltype(A))
+    0 <= p <= 1 || throw(ArgumentError("dropout expects a probability 0 <= p <= 1"))
+    if p > 0
+        dst = similar(A, T)
+        pT = convert(real(T), p)
+        _dropout!(rng, dst, A, pT, dims)
+    else
+        # Not so sure we want fast paths... this tries but doesn't guarantee type-stability,
+        # and the rrule does not have such a fast paths.
+        convert(AbstractArray{T}, A)
+    end
+end
+
+"""
+    dropout!(B, A, p; dims=:)
+
+This does exactly `B .= dropout(A, p; dims)`,
+or rather, it's the implementation of out-of-place [`dropout`](@ref).
+"""
+function dropout!(dst::AbstractArray, src::AbstractArray, p::Real; dims=:)
+    size(dst) == size(src) || throw(DimensionMismatch("dropout! expects output array the same size as input"))
+    0 <= p <= 1 || throw(ArgumentError("dropout expects a probability 0 <= p <= 1"))
+    if p > 0
+        rng = _rng_from_array(A)
+        pT = convert(real(eltype(dst)), p)
+        _dropout!(rng, dst, src, pT, dims)
+    else
+        copyto!(dst, src)
+    end
+end
+
+# This is the easy case in that we can safely use the output array for random numbers.
+function _dropout!(rng::AbstractRNG, dst::AbstractArray, src::AbstractArray, p::Real, dims::Colon)
+    val = convert(eltype(dst), 1/(1-p))
+    rand!(rng, dst)
+    # dst .= (dst.>p) .* val .* src  # hits a SIMD bug
+    _fast_broadcast!(dst, src) do q, x
+        (q>p) * val * x
+    end
+    dst
+end
+
+# For other dims, we we do need to allocate something.
+function _dropout!(rng::AbstractRNG, dst::AbstractArray, src::AbstractArray, p::Real, dims)
+    tmp = similar(dst, ntuple(d -> d in dims ? size(src,d) : 1, ndims(src)))
+    rand!(rng, tmp)
+    val = convert(eltype(dst), 1/(1-p))
+    # One-pass strategy:
+    # dst .= (tmp.>p) .* val .* src
+    # Two-pass strategy:
+    _fast_broadcast!(tmp) do q
+        (q>p) * val
+    end
+    dst .= tmp .* src
+end
+
+# The gradient needs to keep the random choices made, thus store at least a BitArray,
+# but the following way turns out to be faster & simpler:
+function ChainRulesCore.rrule(::typeof(dropout), rng::AbstractRNG, A::AbstractArray, p::Real; dims = :)
+    T = float(eltype(A))
+    val = convert(T, 1/(1-p))
+    keep = if dims isa Colon
+        similar(A, T) 
+    else
+        similar(A, T, ntuple(d -> d in dims ? size(A,d) : 1, ndims(A)))
+    end
+    rand!(rng, keep)
+    Y = @. (keep>p) * A * val
+    function dropout_back(Δ)
+        dY = unthunk(Δ)
+        dA = @. (keep>p) * dY * val
+        (NoTangent(), NoTangent(), dA, NoTangent())
+    end
+    return Y, dropout_back
+end
+
+"""
+    _fast_broadcast!(f, x, y, z...)
+
+This does `x .= f.(x, y, z...)`, but works around
+an issue with broadcasting that prevents SIMD in such cases.
+Can be removed once https://github.com/JuliaLang/julia/issues/43153 is fixed.
+
+Not intended for general use. Does not check sizes!
+"""
+function _fast_broadcast!(f::F, x::Array, yz...) where {F<:Function}
+    bc = Broadcast.instantiate(Broadcast.broadcasted(f, x, yz...))
+    @simd ivdep for I in eachindex(bc)
+        @inbounds x[I] = bc[I]
+    end
+    return x
+end
+function _fast_broadcast!(f::F, x::AbstractArray, yz...) where {F<:Function}
+    # CUDA does not suffer from this bug
+    broadcast!(f, x, x, yz...)
+end
+
+
+"""
+    _rng_from_array(x)
+
+Return the random number generator most appropriate for `x`:
+`CUDA.default_rng()` for `CuArray`,
+else `Random.default_rng()`
+"""
+_rng_from_array(::AbstractArray) = Random.default_rng()
+# _rng_from_array(::CuArray) = CUDA.default_rng()
+
+@non_differentiable _rng_from_array(::Any)
+
+

--- a/src/dropout.jl
+++ b/src/dropout.jl
@@ -1,12 +1,12 @@
 
 """
-    dropout([rng], A, p; dims=:)
+    dropout([rng], A, p; [dims])
 
 Returns an array in which each element of `A` is either replaced with zero,
 with probability `p`, or else multiplied by `1/(1-p)`.
 
 By default every element is treated independently.
-With `dims=1`, a choice is made for every value of the 1st index
+With keyword `dims=1`, a choice is made for every value of the 1st index
 i.e. each row of a matrix is either zero or not.
 
 Optional first argument is the random number generator used.
@@ -41,7 +41,7 @@ function dropout(rng::AbstractRNG, A::AbstractArray, p::Real; dims = :)
     T = float(eltype(A))
     0 <= p <= 1 || throw(ArgumentError("dropout expects a probability 0 <= p <= 1"))
     if p > 0
-        dst = similar(A, T)
+        dst = similar(A, T, size(A))
         pT = convert(real(T), p)
         _dropout!(rng, dst, A, pT, dims)
     else
@@ -105,7 +105,7 @@ function ChainRulesCore.rrule(::typeof(dropout), rng::AbstractRNG, A::AbstractAr
     T = float(real(eltype(A)))
     val = convert(T, 1/(1-p))
     keep = if dims isa Colon
-        similar(A, T) 
+        similar(A, T, size(A))
     else
         similar(A, T, ntuple(d -> d in dims ? size(A,d) : 1, ndims(A)))
     end

--- a/src/dropout.jl
+++ b/src/dropout.jl
@@ -57,11 +57,12 @@ end
 This does exactly `B .= dropout(A, p; dims)`,
 or rather, it's the implementation of out-of-place [`dropout`](@ref).
 """
-function dropout!(dst::AbstractArray, src::AbstractArray, p::Real; dims=:)
+dropout!(B::AbstractArray, A::AbstractArray, p::Real; dims = :) = dropout!(_rng_from_array(B), B, A, p; dims)
+
+function dropout!(rng::AbstractRNG, dst::AbstractArray, src::AbstractArray, p::Real; dims=:)
     size(dst) == size(src) || throw(DimensionMismatch("dropout! expects output array the same size as input"))
     0 <= p <= 1 || throw(ArgumentError("dropout expects a probability 0 <= p <= 1"))
     if p > 0
-        rng = _rng_from_array(A)
         pT = convert(real(eltype(dst)), p)
         _dropout!(rng, dst, src, pT, dims)
     else

--- a/test/dropout.jl
+++ b/test/dropout.jl
@@ -15,8 +15,10 @@ using Zygote, StableRNGs, ChainRulesCore
     @test size(@inferred dropout(rng, x1, 0.1)) == (3, 4)
     @test size(@inferred dropout(rng, x1, 0.1; dims=2)) == (3, 4)
 
-    x2 = Diagonal(randn(Float32, 10))
-    @test dropout(x2, 0.3) isa Matrix{Float32}  # does not infer, but that's OK?
+    x2 = Diagonal(randn(Float32, 10))  # Just to check it runs on weird matrices.
+    if VERSION > v"1.8-"  # on 1.6 this makes a sparse array.
+        @test dropout(x2, 0.3) isa Matrix{Float32}  # does not infer, but that's OK?
+    end
 
     # Values
     @test dropout(x1, 0) == x1

--- a/test/dropout.jl
+++ b/test/dropout.jl
@@ -58,9 +58,17 @@ using Zygote, StableRNGs, ChainRulesCore
         @test Zygote.hessian_reverse(f1, [1.0,2.0,3.0]) == zeros(3, 3)
     end
 
+    # Bang
+    y1 = fill!(similar(x1), NaN)
+    @test dropout!(y1, x1, 0.0) == x1
+    @test y1 == x1
+    @test dropout!(rng, y1, x1, 1) == zero(x1)
+    @test y1 == zero(x1)
+
     # Errors
     @test_throws ArgumentError dropout(x1, -1)
     @test_throws ArgumentError dropout(x1, 2)
+    @test_throws ArgumentError dropout!(y1, x1, 3)
 end
 
 @testset "dropout + CUDA" begin

--- a/test/dropout.jl
+++ b/test/dropout.jl
@@ -16,6 +16,11 @@ using Zygote, StableRNGs, ChainRulesCore
     @test size(@inferred dropout(rng, x1, 0.1; dims=2)) == (3, 4)
 
     # Values
+    @test dropout(x1, 0) == x1
+    @test dropout(x1.+0im, 0) == x1
+    @test dropout(x1, 1) == zero.(x1)
+    @test dropout(x1.+im, 1) == zero.(x1)
+
     d45 = dropout(trues(100, 100, 100), 0.45)
     @test mean(d45) ≈ 1 atol=1e-2
     dpi2 = dropout(fill(pi, 1000), 0.2)
@@ -23,20 +28,69 @@ using Zygote, StableRNGs, ChainRulesCore
     d33 = dropout(fill(3, 10, 1000), 0.3, dims=2)
     @test sort(unique(vec(d33))) ≈ [0, 3/(1-0.3)]
 
+    # Complex -- not worth too much optimisation, but should work!
+    x2 = [1.0+0im,2.0+1im,3.0+3im]  # from Flux's tests
+    @test dropout(x2, 0.5) isa Vector{ComplexF64}
+    @test dropout(x2, 0.5; dims=1) isa Vector{ComplexF64}
+
     # Gradient rule
     y, back = rrule(dropout, rng, hcat(trues(1000), falses(1000)), 0.45)
     dx = back(fill(3, 1000, 2))[3]
     @test !all(iszero, dx[:,2])  # this is why we save the random choices
     @test sort(unique(vec(dx))) ≈ [0, 3/(1-0.45)]
 
+    y2, back2 = rrule(dropout, rng, x2, 0.5)
+    @test y2 isa Vector{ComplexF64}
+    @test back2(one.(y2))[3] isa Vector{ComplexF64}
+
     @testset "Zygote" begin
         @test Zygote.gradient(x -> sum(dropout(x, 0.3)), x1)[1] isa Matrix{Float32}
         @test Zygote.gradient(x -> sum(dropout(rng, x, 0.3)), x1)[1] isa Matrix{Float32}
         @test Zygote.gradient(x -> sum(dropout(x, 0.3, dims=1)), x1)[1] isa Matrix{Float32}
 
+        # p=0 & p=1
+        @test Zygote.gradient(x -> sum(dropout(x, 0)), x1)[1] == ones(3,4)
+        @test Zygote.gradient(x -> sum(dropout(x, 1)), x1)[1] == zeros(3,4)
+
+        # Second order
         f1(x) = sum(dropout(x, 0.5))
         @test_broken Zygote.hessian(f1, [1.0,2.0,3.0]) == zeros(3, 3)  # forward over reverse
         @test Zygote.hessian_reverse(f1, [1.0,2.0,3.0]) == zeros(3, 3)
     end
+
+    # Errors
+    @test_throws ArgumentError dropout(x1, -1)
+    @test_throws ArgumentError dropout(x1, 2)
 end
 
+@testset "dropout + CUDA" begin
+    # Basics
+    x1 = CUDA.randn(3, 4)
+    @test size(@inferred dropout(x1, 0.1)) == (3, 4)
+    @test size(@inferred dropout(x1, 0.2; dims=2)) == (3, 4)
+    @test size(@inferred dropout(x1, 0.3; dims=(1,2))) == (3, 4)
+
+    rng =  CUDA.default_rng()
+    @test size(@inferred dropout(rng, x1, 0.1)) == (3, 4)
+    @test size(@inferred dropout(rng, x1, 0.1; dims=2)) == (3, 4)
+
+    # Values
+    d45 = dropout(CUDA.ones(100, 100, 100), 0.45)
+    @test mean(d45) ≈ 1 atol=1e-2
+    dpi2 = dropout(CUDA.fill(1f0 * pi, 1000), 0.2)
+    @test sort(unique(Array(dpi2))) ≈ [0, 5pi/4]
+    d33 = dropout(CUDA.fill(3f0, 10, 1000), 0.3, dims=2)
+    @test sort(unique(vec(Array(d33)))) ≈ [0, 3/(1-0.3)]
+
+    # Gradient rule
+    y, back = rrule(dropout, rng, hcat(CUDA.ones(1000), CUDA.zeros(1000)), 0.45)
+    dx = back(CUDA.fill(3f0, 1000, 2))[3]
+    @test !all(iszero, dx[:,2])  # this is why we save the random choices
+    @test sort(unique(vec(Array(dx)))) ≈ [0, 3/(1-0.45)]
+
+    @testset "Zygote" begin
+        @test Zygote.gradient(x -> sum(dropout(x, 0.3)), x1)[1] isa CuArray{Float32}
+        @test Zygote.gradient(x -> sum(dropout(rng, x, 0.3)), x1)[1] isa CuArray{Float32}
+        @test Zygote.gradient(x -> sum(dropout(x, 0.3, dims=1)), x1)[1] isa CuArray{Float32}
+    end
+end

--- a/test/dropout.jl
+++ b/test/dropout.jl
@@ -1,0 +1,42 @@
+using NNlib, Test, Statistics, Random
+using Zygote, StableRNGs, ChainRulesCore
+
+@testset "dropout" begin
+    # Basics
+    x1 = randn(Float32, 3, 4)
+    @test size(@inferred dropout(x1, 0.1)) == (3, 4)
+    @test size(@inferred dropout(x1, 0.2; dims=2)) == (3, 4)
+    @test size(@inferred dropout(x1, 0.3; dims=(1,2))) == (3, 4)
+    @test eltype(dropout(x1, 0.1)) == Float32
+    @test eltype(dropout(x1, 0.1; dims=1)) == Float32
+    @test eltype(dropout(x1, 0.1; dims=(1,2))) == Float32
+
+    rng =  Random.default_rng()
+    @test size(@inferred dropout(rng, x1, 0.1)) == (3, 4)
+    @test size(@inferred dropout(rng, x1, 0.1; dims=2)) == (3, 4)
+
+    # Values
+    d45 = dropout(trues(100, 100, 100), 0.45)
+    @test mean(d45) ≈ 1 atol=1e-2
+    dpi2 = dropout(fill(pi, 1000), 0.2)
+    @test sort(unique(dpi2)) ≈ [0, 5pi/4]
+    d33 = dropout(fill(3, 10, 1000), 0.3, dims=2)
+    @test sort(unique(vec(d33))) ≈ [0, 3/(1-0.3)]
+
+    # Gradient rule
+    y, back = rrule(dropout, rng, hcat(trues(1000), falses(1000)), 0.45)
+    dx = back(fill(3, 1000, 2))[3]
+    @test !all(iszero, dx[:,2])  # this is why we save the random choices
+    @test sort(unique(vec(dx))) ≈ [0, 3/(1-0.45)]
+
+    @testset "Zygote" begin
+        @test Zygote.gradient(x -> sum(dropout(x, 0.3)), x1)[1] isa Matrix{Float32}
+        @test Zygote.gradient(x -> sum(dropout(rng, x, 0.3)), x1)[1] isa Matrix{Float32}
+        @test Zygote.gradient(x -> sum(dropout(x, 0.3, dims=1)), x1)[1] isa Matrix{Float32}
+
+        f1(x) = sum(dropout(x, 0.5))
+        @test_broken Zygote.hessian(f1, [1.0,2.0,3.0]) == zeros(3, 3)  # forward over reverse
+        @test Zygote.hessian_reverse(f1, [1.0,2.0,3.0]) == zeros(3, 3)
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,10 @@ include("test_utils.jl")
         include("ctc.jl")
     end
 
+    @testset "Dropout" begin
+        include("dropout.jl")
+    end
+
     @testset "Fold/Unfold" begin
         include("fold.jl")
     end


### PR DESCRIPTION
This adds a `dropout` function.

At least on CPU, this should be about twice as fast as the one in Flux, and use less memory. There are some Flux PRs, but the code is messy, and I got lost & started from scratch.

It's not quite the fastest variant. The gradient can be faster if we believe that every zero in the output comes from the mask, never from the input. That may not be a terrible assumption -- if you don't have a `relu` before it, zeros are rare; if you do, then the gradient associated to a zero will be discarded anyway. But... perhaps it's best to be correct.

<details>

I can put a gist of these variations somewhere. But local benchmarks are:

```julia
let x = randn(Float32, 100, 100)
    @btime dropout($x, 0.3) # Flux
    @btime mydropout($x, 0.3)  # sans mask -- this PR
    @btime mydropout2($x, 0.3)  # with mask
end;
  # min 10.375 μs, mean 19.879 μs (13 allocations, 78.45 KiB)
  # min 5.292 μs, mean 10.736 μs (2 allocations, 39.11 KiB)
  # min 12.958 μs, mean 17.476 μs (5 allocations, 44.67 KiB)

let x = randn(Float32, 100, 100)
    @btime gradient(x -> sum(dropout(x, 0.3)), $x) # Flux
    @btime gradient(x -> sum(mydropout(x, 0.3)), $x)  # sans mask... but sadly wrong answers
    @btime gradient(x -> sum(mydropout2(x, 0.3)), $x)  # with boolean mask
    @btime gradient(x -> sum(mydropout3(x, 0.3)), $x)  # keep random numbers -- this PR
end;
  # min 28.292 μs, mean 49.702 μs (70 allocations, 158.55 KiB)
  # min 12.500 μs, mean 22.952 μs (20 allocations, 78.70 KiB)
  # min 26.916 μs, mean 37.291 μs (37 allocations, 84.69 KiB)
  # min 13.208 μs, mean 26.490 μs (23 allocations, 117.92 KiB)


let x = randn(Float32, 100, 100)
    @btime dropout($x, 0.3; dims=1)
    @btime mydropout($x, 0.3; dims=1)
    @btime mydropout2($x, 0.3; dims=1)
end;
  # min 1.363 μs, mean 5.047 μs (3 allocations, 39.59 KiB)
  # min 1.346 μs, mean 6.003 μs (3 allocations, 39.59 KiB)
  # min 1.675 μs, mean 5.735 μs (5 allocations, 39.72 KiB)

let x = randn(Float32, 100, 100)
    @btime gradient(x -> sum(dropout(x, 0.3; dims=1)), $x)
    @btime gradient(x -> sum(mydropout(x, 0.3; dims=1)), $x)
    @btime gradient(x -> sum(mydropout2(x, 0.3; dims=1)), $x)
    @btime gradient(x -> sum(mydropout3(x, 0.3; dims=1)), $x)
    @btime gradient(x -> sum(mydropout4(x, 0.3; dims=1)), $x)  # changed to same strategy as dims=:
end;
  # min 25.458 μs, mean 47.425 μs (108 allocations, 122.16 KiB)
  # min 8.722 μs, mean 17.797 μs (21 allocations, 79.19 KiB)
  # min 13.709 μs, mean 24.887 μs (33 allocations, 79.61 KiB)
  # min 8.680 μs, mean 18.442 μs (21 allocations, 79.19 KiB)
  # min 9.916 μs, mean 22.267 μs (21 allocations, 79.25 KiB)  # slightly slower, but simpler
```

</details>

Edit: timing things on the GPU, at first the `dims=:` case seemed slow, but now it's not...

<details>

```julia
# ] add https://github.com/mcabbott/NNlib.jl/tree/dropout

using NNlib, CUDA, BenchmarkTools, Zygote, Flux, ChainRulesCore, Random

NNlib._rng_from_array(::CuArray) = CUDA.default_rng()

NNlib.dropout(cu(ones(3,5)), 0.3)
NNlib.dropout(cu(ones(3,5)), 0.4; dims=1)

Flux.dropout(cu(ones(3,5)), 0.3)
Flux.dropout(cu(ones(3,5)), 0.4; dims=1)

# To try out the copy-the-RNG idea, only for gradients:

@eval Base.copy(r::CUDA.RNG) = $(Expr(:new, CUDA.RNG, :(r.seed), :(r.counter)))

using NNlib: _fast_broadcast!

mydropout6(args...; kw...) = dropout(args...; kw...)  # same forward as this PR
function ChainRulesCore.rrule(::typeof(mydropout6), rng::AbstractRNG, x::AbstractArray, p::Real; dims = :)
    dup_rng = copy(rng)   # save for backward pass
    y = dropout(dup_rng, x, p; dims)  # for other dims, could re-use buffer...
    val = convert(eltype(y), 1/(1-p))
    function back6(Δ)
        dims isa Colon || error("will be wrong")
        dx = rand!(dup_rng, similar(y))
        _fast_broadcast!(dx, unthunk(Δ)) do q, dy
            (q>p) * val * dy
        end
        (NoTangent(), NoTangent(), dx, NoTangent())
    end
    y, back6
end

ChainRulesCore.@non_differentiable CUDA.default_rng()

mydropout6(CUDA.default_rng(), cu(ones(3,5)), 0.3)
gradient(x -> sum(mydropout6(CUDA.default_rng(), x, 0.3)), cu(ones(3,5)))


##### Forward times & allocations

julia> let x = CUDA.rand(100, 1000)
           @btime CUDA.@sync Flux.dropout($x, 0.3)
           @btime CUDA.@sync NNlib.dropout($x, 0.3)
           println()
           @btime CUDA.@sync Flux.dropout($x, 0.3; dims=1)
           @btime CUDA.@sync NNlib.dropout($x, 0.3; dims=1)
       end;
  49.163 μs (94 allocations: 4.27 KiB)
  29.623 μs (48 allocations: 2.31 KiB)

  43.097 μs (85 allocations: 4.05 KiB)
  42.857 μs (85 allocations: 3.98 KiB)

# one pass strategy, for the last:
  39.118 μs (88 allocations: 5.33 KiB)


# First run?
  # 49.339 μs (94 allocations: 4.27 KiB)
  # 261.194 μs (41 allocations: 392.56 KiB)  # awful

  # 42.835 μs (85 allocations: 4.05 KiB)
  # 47.702 μs (77 allocations: 4.05 KiB)

julia> let x = CUDA.rand(1000, 10_000)
           CUDA.@time Flux.dropout(x, 0.3)
           CUDA.@time NNlib.dropout(x, 0.3)
           println()
           CUDA.@time Flux.dropout(x, 0.3; dims=1)
           CUDA.@time NNlib.dropout(x, 0.3; dims=1)
       end;
  0.000415 seconds (94 CPU allocations: 4.266 KiB) (2 GPU allocations: 76.294 MiB, 5.40% memmgmt time)
  0.000269 seconds (48 CPU allocations: 2.312 KiB) (1 GPU allocation: 38.147 MiB, 2.50% memmgmt time)

  0.000185 seconds (86 CPU allocations: 4.062 KiB) (2 GPU allocations: 38.151 MiB, 6.87% memmgmt time)
  0.000186 seconds (86 CPU allocations: 4.000 KiB) (2 GPU allocations: 38.151 MiB, 4.62% memmgmt time)

# one pass:
  0.000214 seconds (88 CPU allocations: 5.328 KiB) (2 GPU allocations: 38.151 MiB, 3.88% memmgmt time)

# Earlier:
  # 0.000474 seconds (94 CPU allocations: 4.266 KiB) (2 GPU allocations: 76.294 MiB, 2.89% memmgmt time)
  # 0.046926 seconds (41 CPU allocations: 38.149 MiB) (1 GPU allocation: 38.147 MiB, 0.02% memmgmt time)

  # 0.000227 seconds (86 CPU allocations: 4.062 KiB) (2 GPU allocations: 38.151 MiB, 12.16% memmgmt time)
  # 0.000235 seconds (78 CPU allocations: 7.641 KiB) (2 GPU allocations: 38.151 MiB, 4.83% memmgmt time)


##### Gradient times & allocations

julia> let x = CUDA.randn(100, 1000), rng = CUDA.default_rng()
           @btime CUDA.@sync gradient(x -> sum(Flux.dropout(x, 0.3)), $x)
           @btime CUDA.@sync gradient(x -> sum(NNlib.dropout(x, 0.3)), $x)
           @btime CUDA.@sync gradient(x -> sum(mydropout6($rng, x, 0.3)), $x)
           println()
           @btime CUDA.@sync gradient(x -> sum(Flux.dropout(x, 0.3; dims=1)), $x)
           @btime CUDA.@sync gradient(x -> sum(NNlib.dropout(x, 0.3; dims=1)), $x)
       end;
  225.455 μs (364 allocations: 16.27 KiB)
  133.620 μs (242 allocations: 11.19 KiB)
  146.186 μs (258 allocations: 12.05 KiB)

  342.355 μs (509 allocations: 22.77 KiB)
  165.137 μs (284 allocations: 12.70 KiB)


# First try, without mydropout6
  # 194.412 μs (364 allocations: 16.27 KiB)
  # 318.048 μs (235 allocations: 401.44 KiB)  # bad, but not because of alloc

  # 259.827 μs (509 allocations: 22.77 KiB)
  # 150.939 μs (276 allocations: 12.77 KiB)  # great



julia> let x = CUDA.randn(1000, 10_000), rng = CUDA.default_rng()
           CUDA.@time gradient(x -> sum(Flux.dropout(x, 0.3)), x)
           CUDA.@time gradient(x -> sum(NNlib.dropout(x, 0.3)), x)
           CUDA.@time gradient(x -> sum(mydropout6(rng, x, 0.3)), x)
           println()
           CUDA.@time gradient(x -> sum(Flux.dropout(x, 0.3; dims=1)), x)
           CUDA.@time gradient(x -> sum(NNlib.dropout(x, 0.3; dims=1)), x)
       end;
  0.116546 seconds (61.41 k CPU allocations: 2.759 MiB, 26.81% gc time) (7 GPU allocations: 190.735 MiB, 8.33% memmgmt time)
  0.078563 seconds (52.12 k CPU allocations: 2.933 MiB) (6 GPU allocations: 152.589 MiB, 0.07% memmgmt time)
  0.078514 seconds (42.42 k CPU allocations: 2.552 MiB) (5 GPU allocations: 114.442 MiB, 0.07% memmgmt time)

  0.090443 seconds (54.14 k CPU allocations: 2.910 MiB) (8 GPU allocations: 152.596 MiB, 0.07% memmgmt time)
  0.083492 seconds (44.09 k CPU allocations: 2.394 MiB) (6 GPU allocations: 114.445 MiB, 0.07% memmgmt time)

# First try, without mydropout6
  # 0.070830 seconds (35.09 k CPU allocations: 1.953 MiB) (7 GPU allocations: 190.735 MiB, 0.10% memmgmt time)
  # 0.149181 seconds (52.21 k CPU allocations: 41.074 MiB, 14.75% gc time) (6 GPU allocations: 152.589 MiB, 0.18% memmgmt time)

  # 0.087902 seconds (54.21 k CPU allocations: 2.912 MiB) (8 GPU allocations: 152.596 MiB, 0.07% memmgmt time)
  # 0.082117 seconds (44.14 k CPU allocations: 2.399 MiB) (6 GPU allocations: 114.445 MiB, 0.06% memmgmt time)


##### CPU, on cyclops

julia> let x = rand(100, 1000)
           @btime Flux.dropout($x, 0.3)
           @btime NNlib.dropout($x, 0.3)
           println()
           @btime Flux.dropout($x, 0.3; dims=1)
           @btime CUDA.@sync NNlib.dropout($x, 0.3; dims=1)
       end;
  491.842 μs (13 allocations: 1.53 MiB)
  297.053 μs (2 allocations: 781.30 KiB)

  139.822 μs (3 allocations: 782.17 KiB)
  143.676 μs (3 allocations: 782.17 KiB)

# one pass strategy, for the last:
  143.043 μs (3 allocations: 782.17 KiB)
```

</details>