### PR TITLE
Reduce `lpnormpool` unnecessary conversion

### DIFF
--- a/src/pooling.jl
+++ b/src/pooling.jl
@@ -185,7 +185,7 @@ end
 
 
 """
-    lpnormpool(x, p::T, k::NTuple{N, Integer}; pad=0, stride=k)
+    lpnormpool(x, p::Real, k::NTuple{N, Integer}; pad=0, stride=k)
 
 Perform Lp pool operation with value of the Lp norm `p` and window size `k` on input tensor `x`, also known as LPPool in pytorch.
 This pooling operator from [Learned-Norm Pooling for Deep Feedforward and Recurrent Neural Networks](https://arxiv.org/abs/1311.1780).
@@ -201,13 +201,11 @@ For all elements `x` in a size `k` window, lpnormpool computes `(∑ᵢ xᵢ^p)^
 
 Thus `lpnormpool(x, 1, k) ./ prod(k) ≈ meanpool(x, k)` and `lpnormpool(x, 2, k).^2 ./ prod(k) ≈ meanpool(x.^2, k)`.
 """
-function lpnormpool(x, p::T, k::NTuple{N, Integer}; pad=0, stride=k) where {N,T<:Number}
-    (isinf(p) || p < 0) && error("p value of Lp norm pool expects `0 < p < Inf`, but p is $(p) now.")
-    (typeof(p) <: Integer) || (p = convert(eltype(x), p)) # p needn't convert only if typeof(p) <: Integer
-    pad = expand(Val(N), pad)
-    stride = expand(Val(N), stride)
-    pdims = PoolDims(x, k; padding=pad, stride=stride)
-    return lpnormpool(x, pdims; p=p)
+function lpnormpool(x, p::Real, k::NTuple{N, Integer}; pad=0, stride=k) where {N}
+    pow = p isa Integer ? p : convert(float(eltype(x)), p)
+    (isinf(pow) || pow < 0) && error("p value of Lp norm pool expects `0 < p < Inf`, but p is $(pow) now.")
+    pdims = PoolDims(x, k; padding=expand(Val(N), pad), stride=expand(Val(N), stride))
+    return lpnormpool(x, pdims; p=pow)
 end
 
 

--- a/src/pooling.jl
+++ b/src/pooling.jl
@@ -185,7 +185,7 @@ end
 
 
 """
-    lpnormpool(x, p::Number, k::NTuple{N, Integer}; pad=0, stride=k)
+    lpnormpool(x, p::T, k::NTuple{N, Integer}; pad=0, stride=k)
 
 Perform Lp pool operation with value of the Lp norm `p` and window size `k` on input tensor `x`, also known as LPPool in pytorch.
 This pooling operator from [Learned-Norm Pooling for Deep Feedforward and Recurrent Neural Networks](https://arxiv.org/abs/1311.1780).
@@ -201,8 +201,9 @@ For all elements `x` in a size `k` window, lpnormpool computes `(∑ᵢ xᵢ^p)^
 
 Thus `lpnormpool(x, 1, k) ./ prod(k) ≈ meanpool(x, k)` and `lpnormpool(x, 2, k).^2 ./ prod(k) ≈ meanpool(x.^2, k)`.
 """
-function lpnormpool(x, p::Number, k::NTuple{N, Integer}; pad=0, stride=k) where N
+function lpnormpool(x, p::T, k::NTuple{N, Integer}; pad=0, stride=k) where {N,T<:Number}
     (isinf(p) || p < 0) && error("p value of Lp norm pool expects `0 < p < Inf`, but p is $(p) now.")
+    (typeof(p) <: Integer) || (p = convert(eltype(x), p)) # p needn't convert only if typeof(p) <: Integer
     pad = expand(Val(N), pad)
     stride = expand(Val(N), stride)
     pdims = PoolDims(x, k; padding=pad, stride=stride)


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

---

I try to add type conversion. But I find `x^p (typeof(p) <: Integer)` is a little slower than `x^p (typeof(p) == Float32)`:

```julia
a = 1:4000000
b = convert(UnitRange{Float32}, a)

@time for i in a
    lpnormpool(ones(Float32, 4,1,1), i, (2,), stride=1)
end

@time for i in b
    lpnormpool(ones(Float32, 4,1,1), i, (2,), stride=1)
end
```

Result:

```text
9.858444 seconds (96.00 M allocations: 5.662 GiB, 2.62% gc time) # a
8.916446 seconds (96.00 M allocations: 5.603 GiB, 2.95% gc time) # b
```

I also change calling sequence:

```text
8.995194 seconds (96.00 M allocations: 5.603 GiB, 2.99% gc time) # b
9.866587 seconds (96.00 M allocations: 5.662 GiB, 2.73% gc time) # a
```

Does this mean `x^p (p::Integer)` is slower than when p is a float? or I make some mistakes when testing?