### PR TITLE
Fix conv with groups when falling in direct backend

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -292,8 +292,8 @@ end
 for (front_name, backend) in (
     # This maps from public, front-facing name, to internal backend name
     :conv                   => :direct,
-    :∇conv_data             => :direct, 
-    :∇conv_filter           => :direct,
+    # :∇conv_data             => :direct, 
+    # :∇conv_filter           => :direct,
 )
 
     # We only define 3d conv primitives, we reshape lower down to get 1d and 2d convolution
@@ -327,6 +327,62 @@ for (front_name, backend) in (
             return out
         end
     end
+end
+
+# direct function forwarding definition
+function ∇conv_data!(out::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
+                     in2::AbstractArray{T2,N}, cdims::C; kwargs...) where {yT, T1, T2, N, C <: ConvDims}
+    if yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+        @warn string("Slow fallback implementation invoked for ", string(front_name), "!  ",
+                "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
+    end
+
+    dx_cs = Iterators.partition(1:size(out, 4),
+                channels_in(cdims) ÷ groupcount(cdims))
+    w_cs = Iterators.partition(1:size(in2, 5),
+                channels_out(cdims) ÷ groupcount(cdims))
+    dy_cs = Iterators.partition(1:size(in1, 4),
+                channels_out(cdims) ÷ groupcount(cdims))
+    cdims2 = basetype(C)(cdims,
+            G = 1,
+            C_in = channels_in(cdims) ÷ groupcount(cdims),
+            C_out = channels_out(cdims) ÷ groupcount(cdims))
+
+    Threads.@sync for (xc, yc, wc) in zip(dx_cs, dy_cs, w_cs)
+        dxv = @view out[ntuple(i -> i == 4 ? xc : Colon(), 5)...]
+        dyv = @view in1[ntuple(i -> i == 4 ? yc : Colon(), 5)...]
+        wv = @view in2[ntuple(i -> i == 5  ? wc : Colon(), 5)...]
+        Threads.@spawn ∇conv_data_direct!(dxv, dyv, wv, cdims2; kwargs...)
+    end
+
+    return out
+end
+
+function ∇conv_filter!(out::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
+                       in2::AbstractArray{T2,N}, cdims::C; kwargs...) where {yT, T1, T2, N, C <: ConvDims}
+    if yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+        @warn string("Slow fallback implementation invoked for ", string(front_name), "!  ",
+                "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
+    end
+    dw_cs = Iterators.partition(1:size(out, 5),
+                channels_out(cdims) ÷ groupcount(cdims))
+    dy_cs = Iterators.partition(1:size(in2, 4),
+                channels_out(cdims) ÷ groupcount(cdims))
+    x_cs = Iterators.partition(1:size(in1, 4),
+                channels_in(cdims) ÷ groupcount(cdims))
+    cdims2 = basetype(C)(cdims,
+            G = 1,
+            C_in = channels_in(cdims) ÷ groupcount(cdims),
+            C_out = channels_out(cdims) ÷ groupcount(cdims))
+
+    Threads.@sync for (wc, xc, yc) in zip(dw_cs, x_cs, dy_cs)
+        x = @view in1[ntuple(i -> i == 4 ? xc : Colon(), 5)...]
+        dy = @view in2[ntuple(i -> i == 4 ? yc : Colon(), 5)...]
+        dw = @view out[ntuple(i -> i == 5 ? yc : Colon(), 5)...]
+        Threads.@spawn ∇conv_filter_direct!(dw, x, dy, cdims2; kwargs...)
+    end
+
+    return out
 end
 
 for Dims in [:DenseConvDims, :DepthwiseConvDims, :PoolDims]

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -223,7 +223,6 @@ for (front_name, backend, signature) in (
 )
     # We only define 3d conv primitives, we reshape lower down to get 1d and 2d convolution
     @eval begin
-        # println($(Symbol(["$(i)" for i in "$(signature[5])"]...))...)
         function $(Symbol("$(front_name)!"))(
                         out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
                         in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -166,13 +166,16 @@ end
 
 # First, we will define mappings from the generic API names to our accelerated backend
 # implementations. For homogeneous-datatype 1, 2 and 3d convolutions, we default to using
-# im2col + GEMM.  Do so in a loop, here:
+# im2col + GEMM.
+# But we always support a fallback, non-accelerated path, where we use the direct, but
+# slow, implementations. These should not typically be used, hence the `@warn`,
 
 # These are the GEMM types we will accelerate with `im2col`
 const G = Union{[x[2] for x in gemm_datatype_mappings]...}
 
 for (front_name, backend, signature) in (
-    # This maps from public, front-facing name, to internal backend name
+    # This maps from public, front-facing name, to internal backend name, given the function signature and the where clause
+    # (frontend, backend, (out Array signature, in1 Array signature, in2 Array signature, (parametric Types)))
     (:conv, :im2col, ((:T, 5), (:T, 5), (:T, 5), :C, (:(T <: G), :(C <: ConvDims)))),
     (:conv, :direct, ((:yT, :N), (:T1, :N), (:T2, :N), :C, (:yT, :T1, :T2, :N, :(C <: ConvDims)))),
 )
@@ -213,7 +216,8 @@ end
 
 # im2col-accelerated function forwarding definition
 for (front_name, backend, signature) in (
-    # This maps from public, front-facing name, to internal backend name
+    # This maps from public, front-facing name, to internal backend name, given the function signature and the where clause
+    # (frontend, backend, (out Array signature, in1 Array signature, in2 Array signature, (parametric Types)))
     (:∇conv_data, :im2col, ((:T, 5), (:T, 5), (:T, 5), :C, (:(T <: G), :(C <: ConvDims)))),
     (:∇conv_data, :direct, ((:yT, :N), (:T1, :N), (:T2, :N), :C, (:yT, :T1, :T2, :N, :(C <: ConvDims)))),
 )
@@ -256,13 +260,13 @@ for (front_name, backend, signature) in (
 end
 
 for (front_name, backend, signature) in (
-    # This maps from public, front-facing name, to internal backend name
+    # This maps from public, front-facing name, to internal backend name, given the function signature and the where clause
+    # (frontend, backend, (out Array signature, in1 Array signature, in2 Array signature, (parametric Types)))
     (:∇conv_filter, :im2col, ((:T, 5), (:T, 5), (:T, 5), :C, (:(T <: G), :(C <: ConvDims)))),
     (:∇conv_filter, :direct, ((:yT, :N), (:T1, :N), (:T2, :N), :C, (:yT, :T1, :T2, :N, :(C <: ConvDims)))),
 )
     # We only define 3d conv primitives, we reshape lower down to get 1d and 2d convolution
     @eval begin
-        # println($(Symbol(["$(i)" for i in "$(signature[5])"]...))...)
         function $(Symbol("$(front_name)!"))(
                         out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
                         in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},
@@ -298,97 +302,36 @@ for (front_name, backend, signature) in (
 end
 
 
-for (front_name, backend) in (
-        # This maps from public, front-facing name, to internal backend name
-        :depthwiseconv          => :im2col,
-        :∇depthwiseconv_data    => :im2col,
-        :∇depthwiseconv_filter  => :im2col,
-    )
+for (front_name, backend, signature) in (
+    # This maps from public, front-facing name, to internal backend name, given the function signature and the where clause
+    # (frontend, backend, (out Array signature, in1 Array signature, in2 Array signature, (parametric Types)))
+    (:depthwiseconv, :im2col, ((:T, 5), (:T, 5), (:T, 5), :C, (:(T <: G), :(C <: ConvDims)))),
+    (:depthwiseconv, :direct, ((:yT, :N), (:T1, :N), (:T2, :N), :C, (:yT, :T1, :T2, :N, :(C <: ConvDims)))),
+    
+    (:∇depthwiseconv_data, :im2col, ((:T, 5), (:T, 5), (:T, 5), :C, (:(T <: G), :(C <: ConvDims)))),
+    (:∇depthwiseconv_data, :direct, ((:yT, :N), (:T1, :N), (:T2, :N), :C, (:yT, :T1, :T2, :N, :(C <: ConvDims)))),
+    
+    (:∇depthwiseconv_filter, :im2col, ((:T, 5), (:T, 5), (:T, 5), :C, (:(T <: G), :(C <: ConvDims)))),
+    (:∇depthwiseconv_filter, :direct, ((:yT, :N), (:T1, :N), (:T2, :N), :C, (:yT, :T1, :T2, :N, :(C <: ConvDims)))),
+)
 
     # We only define 3d conv primitives, we reshape lower down to get 1d and 2d convolution
     @eval begin
         # im2col-accelerated function forwarding definition
         function $(Symbol("$(front_name)!"))(
-                        out::AbstractArray{T,5}, in1::AbstractArray{T,5},
-                        in2::AbstractArray{T,5}, cdims::C; kwargs...) where {T <: $G, C <: ConvDims}
+                        out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
+                        in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},
+                        in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
+                        cdims::$(signature[4]),
+                        kwargs...) where {$(signature[5]...)}
+            if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+                @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
+                        "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
+            end
             $(Symbol("$(front_name)_$(backend)!"))(out, in1, in2, cdims; kwargs...)
         end
     end
 end
-
-# We always support a fallback, non-accelerated path, where we use the direct, but
-# slow, implementations.  These should not typically be used, hence the `@warn`,
-# but let's go ahead and define them first:
-for front_name in (:depthwiseconv, :∇depthwiseconv_data, :∇depthwiseconv_filter)
-    @eval begin
-        function $(Symbol("$(front_name)!"))(
-                        y::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
-                        in2::AbstractArray{T2,N}, cdims::ConvDims;
-                        kwargs...) where {yT, T1, T2, N}
-            if yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
-                @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
-                          "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
-            end
-            $(Symbol("$(front_name)_direct!"))(y, in1, in2, cdims; kwargs...)
-        end
-    end
-end
-
-# # direct function forwarding definition
-# function ∇conv_data!(out::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
-#                      in2::AbstractArray{T2,N}, cdims::C; kwargs...) where {yT, T1, T2, N, C <: ConvDims}
-#     if yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
-#         @warn string("Slow fallback implementation invoked for ", string(front_name), "!  ",
-#                 "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
-#     end
-
-#     dx_cs = Iterators.partition(1:size(out, 4),
-#                 channels_in(cdims) ÷ groupcount(cdims))
-#     w_cs = Iterators.partition(1:size(in2, 5),
-#                 channels_out(cdims) ÷ groupcount(cdims))
-#     dy_cs = Iterators.partition(1:size(in1, 4),
-#                 channels_out(cdims) ÷ groupcount(cdims))
-#     cdims2 = basetype(C)(cdims,
-#             G = 1,
-#             C_in = channels_in(cdims) ÷ groupcount(cdims),
-#             C_out = channels_out(cdims) ÷ groupcount(cdims))
-
-#     Threads.@sync for (xc, yc, wc) in zip(dx_cs, dy_cs, w_cs)
-#         dxv = @view out[ntuple(i -> i == 4 ? xc : Colon(), 5)...]
-#         dyv = @view in1[ntuple(i -> i == 4 ? yc : Colon(), 5)...]
-#         wv = @view in2[ntuple(i -> i == 5  ? wc : Colon(), 5)...]
-#         Threads.@spawn ∇conv_data_direct!(dxv, dyv, wv, cdims2; kwargs...)
-#     end
-
-#     return out
-# end
-
-# function ∇conv_filter!(out::AbstractArray{yT,N}, in1::AbstractArray{T1,N},
-#                        in2::AbstractArray{T2,N}, cdims::C; kwargs...) where {yT, T1, T2, N, C <: ConvDims}
-#     if yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
-#         @warn string("Slow fallback implementation invoked for ", string(front_name), "!  ",
-#                 "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
-#     end
-#     dw_cs = Iterators.partition(1:size(out, 5),
-#                 channels_out(cdims) ÷ groupcount(cdims))
-#     dy_cs = Iterators.partition(1:size(in2, 4),
-#                 channels_out(cdims) ÷ groupcount(cdims))
-#     x_cs = Iterators.partition(1:size(in1, 4),
-#                 channels_in(cdims) ÷ groupcount(cdims))
-#     cdims2 = basetype(C)(cdims,
-#             G = 1,
-#             C_in = channels_in(cdims) ÷ groupcount(cdims),
-#             C_out = channels_out(cdims) ÷ groupcount(cdims))
-
-#     Threads.@sync for (wc, xc, yc) in zip(dw_cs, x_cs, dy_cs)
-#         x = @view in1[ntuple(i -> i == 4 ? xc : Colon(), 5)...]
-#         dy = @view in2[ntuple(i -> i == 4 ? yc : Colon(), 5)...]
-#         dw = @view out[ntuple(i -> i == 5 ? yc : Colon(), 5)...]
-#         Threads.@spawn ∇conv_filter_direct!(dw, x, dy, cdims2; kwargs...)
-#     end
-
-#     return out
-# end
 
 for Dims in [:DenseConvDims, :DepthwiseConvDims, :PoolDims]
     @eval @non_differentiable $Dims(::Any...)

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -322,7 +322,7 @@ for (front_name, backend, signature) in (
                         out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
                         in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
-                        cdims::$(signature[4]),
+                        cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
             if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -183,7 +183,7 @@ for (front_name, backend, signature) in (
                         out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
                         in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
-                        cdims::$(signature[4]),
+                        cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
             if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
@@ -224,7 +224,7 @@ for (front_name, backend, signature) in (
                         out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
                         in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
-                        cdims::$(signature[4]),
+                        cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
             if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
@@ -267,7 +267,7 @@ for (front_name, backend, signature) in (
                         out::AbstractArray{$(signature[1][1]), $(signature[1][2])},
                         in1::AbstractArray{$(signature[2][1]), $(signature[1][2])},
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
-                        cdims::$(signature[4]),
+                        cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
             if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -725,6 +725,18 @@ end
     @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true)) == (12, 7, 16, 10)
 end
 
+# https://github.com/FluxML/NNlib.jl/pull/171
+@testset "conv_wrapper with groups - not equal types that trigger direct backend" begin
+    x = rand(Float32, 10, 10, 3, 8)
+    w = rand(Float64, 2, 2, 3, 4)
+    g = 2
+    @test size(conv(x, w); groups=g) == (9, 9, 16, 8)
+    @test size(conv(x, w; stride = (2, 2), pad = (2, 2), groups=g)) == (7, 7, 16, 8)
+    @test size(conv(x, w1; stride = (1, 2), pad = (2, 3), groups=g)) == (12, 7, 16, 8)
+    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), groups=g)) == (12, 7, 16, 8)
+    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true, groups=g)) == (12, 7, 16, 8)
+end
+
 @testset "depthwiseconv_wrapper" begin
     x = rand(10, 10, 3, 10)
     w = rand(2, 2, 3, 3)

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -725,7 +725,7 @@ end
     @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true)) == (12, 7, 16, 10)
 end
 
-# https://github.com/FluxML/NNlib.jl/pull/171
+# https://github.com/FluxML/NNlib.jl/issues/369
 @testset "conv_wrapper with groups - not equal types that trigger direct backend" begin
     x = rand(Float32, 10, 10, 32, 8)
     w = rand(Float64, 2, 2, 16, 4)

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -727,14 +727,13 @@ end
 
 # https://github.com/FluxML/NNlib.jl/pull/171
 @testset "conv_wrapper with groups - not equal types that trigger direct backend" begin
-    x = rand(Float32, 10, 10, 3, 8)
-    w = rand(Float64, 2, 2, 3, 4)
+    x = rand(Float32, 10, 10, 32, 8)
+    w = rand(Float64, 2, 2, 16, 4)
     g = 2
-    @test size(conv(x, w); groups=g) == (9, 9, 16, 8)
-    @test size(conv(x, w; stride = (2, 2), pad = (2, 2), groups=g)) == (7, 7, 16, 8)
-    @test size(conv(x, w1; stride = (1, 2), pad = (2, 3), groups=g)) == (12, 7, 16, 8)
-    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), groups=g)) == (12, 7, 16, 8)
-    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true, groups=g)) == (12, 7, 16, 8)
+    @test size(conv(x, w; groups=g)) == (9, 9, 4, 8)
+    @test size(conv(x, w; stride = (2, 2), pad = (2, 2), groups=g)) == (7, 7, 4, 8)
+    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), groups=g)) == (12, 7, 4, 8)
+    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true, groups=g)) == (12, 7, 4, 8)
 end
 
 @testset "depthwiseconv_wrapper" begin

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -730,10 +730,10 @@ end
     x = rand(Float32, 10, 10, 32, 8)
     w = rand(Float64, 2, 2, 16, 4)
     g = 2
-    @test size(conv(x, w; groups=g)) == (9, 9, 4, 8)
-    @test size(conv(x, w; stride = (2, 2), pad = (2, 2), groups=g)) == (7, 7, 4, 8)
-    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), groups=g)) == (12, 7, 4, 8)
-    @test size(conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true, groups=g)) == (12, 7, 4, 8)
+    @test conv(x, w; groups=g) ≈ conv(x, Float32.(w); groups=g)
+    @test conv(x, w; stride = (2, 2), pad = (2, 2), groups=g) ≈ conv(x, w; stride = (2, 2), pad = (2, 2), groups=g)
+    @test conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), groups=g) ≈ conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), groups=g)
+    @test conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true, groups=g) ≈ conv(x, w; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true, groups=g)
 end
 
 @testset "depthwiseconv_wrapper" begin


### PR DESCRIPTION
Fixing https://github.com/FluxML/NNlib.jl/issues/369.

When the convolution filter type is not the same as the input array, **conv** uses the _direct_ backend
Probably this backed was not updated when grouped convolution was added to **conv**, which led to some false warnings about dimension mismatches given that the **check_dimension** function changed as well.

This PR adds the same logic used in _im2col_ backend to the _direct_ backed, so grouped convolutions also works for the _direct_ backend.

### What has changed
Now for both _conv_ and _depthwiseconv_ (and their forwarding definitions), we have the functions definitions of both im2col and direct backend in a for-loop.

The idea is that future features or corrections will always be implemented for both backends avoiding the problem that happened in https://github.com/FluxML/NNlib.jl/issues/369.

For this, the loop needs a new element, where we had the frontend and backend, we now have the frontend, backend, and signature. This signature is used for the parametric types of the AbstractArray that are used for the functions since there are some type restrictions for the im2col backend.

### PR Checklist

- [X] Tests are added
- [X] Documentation, if applicable
