### PR TITLE
Merge NNlibCUDA as subpackage

### DIFF
--- a/ext/NNlibCUDA/.buildkite/pipeline.yml
+++ b/ext/NNlibCUDA/.buildkite/pipeline.yml
@@ -1,0 +1,20 @@
+steps:
+  - label: "GPU integration with julia v1.6"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.6" 
+      - JuliaCI/julia-test#v1: ~
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    timeout_in_minutes: 60
+
+  - label: "GPU integration with julia v1"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.8"
+      - JuliaCI/julia-test#v1: ~
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    timeout_in_minutes: 60

--- a/ext/NNlibCUDA/.github/workflows/compathelper.yml
+++ b/ext/NNlibCUDA/.github/workflows/compathelper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 * * * *'
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.2.0]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/ext/NNlibCUDA/.github/workflows/tagbot.yml
+++ b/ext/NNlibCUDA/.github/workflows/tagbot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/ext/NNlibCUDA/.gitignore
+++ b/ext/NNlibCUDA/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/ext/NNlibCUDA/LICENSE.md
+++ b/ext/NNlibCUDA/LICENSE.md
@@ -1,0 +1,23 @@
+The NNlibCUDA.jl package is licensed under the MIT "Expat" License:
+
+> Copyright (c) 2021-22: Julia Computing, INc., Dhairya Gandhi and Contributors
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/ext/NNlibCUDA/Project.toml
+++ b/ext/NNlibCUDA/Project.toml
@@ -1,0 +1,29 @@
+name = "NNlibCUDA"
+uuid = "a00861dc-f156-4864-bf3c-e6376f28a68d"
+version = "0.2.7"
+
+[deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
+
+[compat]
+Adapt = "3.3"
+cuDNN = "1"
+CUDA = "4"
+NNlib = "0.8.15"
+julia = "1.6"
+
+[extras]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[targets]
+test = ["CUDA", "ChainRulesCore", "ForwardDiff", "Test", "Zygote"]

--- a/ext/NNlibCUDA/README.md
+++ b/ext/NNlibCUDA/README.md
@@ -1,0 +1,5 @@
+# NNlibCUDA.jl
+
+This is a glue package which extends functions from [NNlib.jl](https://github.com/FluxML/NNlib.jl) to work with [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl). It should be loaded automatically when using [Flux.jl](https://github.com/FluxML/Flux.jl), but not when using NNlib.jl by itself.
+
+Julia gpu kernels are in `src/`, while wrappers around `cudnn` are in `src/cudnn/`.

--- a/ext/NNlibCUDA/src/NNlibCUDA.jl
+++ b/ext/NNlibCUDA/src/NNlibCUDA.jl
@@ -1,0 +1,26 @@
+module NNlibCUDA
+
+using NNlib
+using CUDA, cuDNN
+using Random, Statistics
+
+const IntOrIntTuple = Union{Integer, NTuple{N,<:Integer} where N}
+
+include("upsample.jl")
+include("sampling.jl")
+include("activations.jl")
+include("batchedadjtrans.jl")
+include("batchedmul.jl")
+include("ctc.jl")
+include("fold.jl")
+include("scatter.jl")
+include("gather.jl")
+include("utils.jl")
+include("cudnn/cudnn.jl")
+include("cudnn/conv.jl")
+include("cudnn/pooling.jl")
+include("cudnn/softmax.jl")
+include("cudnn/activations.jl")
+include("cudnn/batchnorm.jl")
+
+end # module

--- a/ext/NNlibCUDA/src/activations.jl
+++ b/ext/NNlibCUDA/src/activations.jl
@@ -1,0 +1,24 @@
+# Activation functions
+
+# Some of activation functions need a wrapper for GPU support
+# https://github.com/JuliaGPU/CuArrays.jl/issues/614
+
+# @cufunc softplus(x::Real) = ifelse(x > 0, x + log1p(exp(-x)), log1p(exp(x)))
+
+# @cufunc logσ(x::Real) = -softplus(-x)
+
+# @cufunc function gelu(x::Real)
+#     p = oftype(x / 1, π)
+#     λ = oftype(x / 1, √(2 / p))
+#     α = oftype(x / 1, 0.044715)
+#     h = oftype(x / 1, 0.5)
+#     h * x * (one(x) + tanh(λ * (x + α * x^3)))
+# end
+
+# @cufunc lisht(x::Real) = x * tanh(x)
+
+# @cufunc logcosh(x::Real) = x + softplus(-2x) - log(oftype(x, 2))
+
+# @cufunc mish(x::Real) = x * tanh(softplus(x))
+
+# @cufunc tanhshrink(x::Real) = x - tanh(x)

--- a/ext/NNlibCUDA/src/batchedadjtrans.jl
+++ b/ext/NNlibCUDA/src/batchedadjtrans.jl
@@ -1,0 +1,17 @@
+using NNlib: BatchedAdjoint, BatchedTranspose, BatchedAdjOrTrans
+using Adapt
+using Adapt: WrappedArray
+
+const CuBatchedAdjoint{T} = BatchedAdjoint{T, <: CuArray{T}}
+const CuBatchedTranspose{T} = BatchedTranspose{T, <: CuArray{T}}
+const CuBatchedAdjOrTrans{T} = Union{CuBatchedAdjoint{T}, CuBatchedTranspose{T}}
+const WrappedCuBatchedAdjOrTrans{T, N} = WrappedArray{T, N, CuBatchedAdjOrTrans{T}, CuBatchedAdjOrTrans{T}}
+
+
+Base.print_array(io::IO, b::Union{CuBatchedAdjOrTrans, WrappedCuBatchedAdjOrTrans}) = Base.print_array(io, adapt(Array, b))
+Base._show_nonempty(io::IO, b::Union{CuBatchedAdjOrTrans, WrappedCuBatchedAdjOrTrans}, prefix::String) = Base._show_nonempty(io, adapt(Array, b), prefix)
+Base.show_vector(io::IO, b::Union{CuBatchedAdjOrTrans, WrappedCuBatchedAdjOrTrans}, opn, cls) = Base.show_vector(io, adapt(Array, b), opn, cls)
+
+Base.convert(::Type{T}, b::Union{CuBatchedAdjOrTrans, WrappedCuBatchedAdjOrTrans}) where {T<:Array} = Base.convert(T, adapt(Array, b))
+Base.Array{T, N}(b::Union{CuBatchedAdjOrTrans, WrappedCuBatchedAdjOrTrans}) where {T, N} = Array{T, N}(adapt(Array, b))
+Base.collect(b::Union{CuBatchedAdjOrTrans, WrappedCuBatchedAdjOrTrans}) = collect(adapt(Array, b))

--- a/ext/NNlibCUDA/src/batchedmul.jl
+++ b/ext/NNlibCUDA/src/batchedmul.jl
@@ -1,0 +1,7 @@
+# Batched matrix multiplication
+# 1st argument is produced by NNlib.storage_type(A)
+NNlib._batched_gemm!(::Type{<:CuArray}, transA::Char, transB::Char, α::Number, A, B, β::Number, C) =
+     CUBLAS.gemm_strided_batched!(transA, transB, α, A, B, β, C)
+
+Base.unsafe_convert(::Type{CuPtr{T}}, A::NNlib.BatchedAdjOrTrans{T}) where {T} =
+    Base.unsafe_convert(CuPtr{T}, parent(A))

--- a/ext/NNlibCUDA/src/ctc.jl
+++ b/ext/NNlibCUDA/src/ctc.jl
@@ -1,0 +1,232 @@
+# CTC loss moved from Flux.jl to NNlib + NNlibCUDA
+
+import NNlib: ctc_loss, ctc_alpha, ∇ctc_loss
+
+## GPU implementation
+
+# a port of the GPU kernels from Baidu's C++ warp-ctc package,
+# which itself is Copyright 2015-2016 Baidu USA LLC
+# and available under the Apache 2.0 license
+#
+# Apache 2.0 license: https://www.apache.org/licenses/LICENSE-2.0
+# GitHub: https://github.com/baidu-research/warp-ctc/
+# paper: https://arxiv.org/pdf/1512.02595.pdf
+
+const MAX_THREADS = 256
+
+function log_plus_f(p1, p2)
+  isinf(p1) && return p2
+  isinf(p2) && return p1
+  if p1 < p2
+    p1, p2 = p2, p1
+  end
+  return p1 + log(1+exp(p2 - p1))
+end
+
+function count_repeats(A)
+  repeats = 0
+  for (i,elem) in enumerate(A)
+    if i > 1 && A[i] == A[i-1]
+      repeats += 1
+    end
+  end
+  return repeats
+end
+
+function compute_alpha_kernel(probs, labelSize, uttLength, repeats, labelsWithoutBlanks, labelsWithBlanks, alpha, blankLabel)
+
+  tid = threadIdx().x
+  L = labelSize
+  T = uttLength
+  S = length(labelsWithBlanks)
+
+  if L + repeats > T
+    return nothing
+  end
+  labels = labelsWithBlanks
+
+  # Corner-case checking
+  start = (L + repeats <= T) ? 0 : 1
+  last = S > 1 ? 2 : 1
+
+  # Fill in first column (time step)
+  i = tid
+  while i <= last - start
+    alpha[start+i, 1] = probs[labels[start+i], 1]
+    i += blockDim().x
+  end
+  sync_threads()
+
+  # Fill in coefficients for each time step
+  for t=2:T
+    # Corner-case checking
+    if tid == 1 && !(1 < S - 2*(T-t) - 1)
+      if start == 0
+        alpha[1, t] = alpha[1, t-1] + probs[blankLabel, t]
+      elseif start == 1
+        alpha[1, t] = alpha[1, t-1]
+      end
+    end
+    sync_threads()
+
+    # Fill in coefficients for each label class in the target output sequence;
+    # each thread will process the calculations for one class
+    idx = tid+1
+    while idx <= S
+      prevSum = log_plus_f(alpha[idx, t-1], alpha[idx-1, t-1])
+      if labels[idx] != blankLabel && idx != 2 && labels[idx] != labels[idx-2]
+        prevSum = log_plus_f(prevSum, alpha[idx-2, t-1])
+      end
+      if idx < S - 2*(T-t) - 1
+        alpha[idx, t] = -Inf32
+      else
+        alpha[idx, t] = prevSum + probs[labels[idx], t]
+      end
+      idx += blockDim().x
+    end
+    sync_threads()
+  end
+  return nothing
+end
+
+function compute_beta_and_grad_kernel(probs, labelSize, uttLength,
+                  repeatsInLabel, labelsWithBlanks,
+                  alphas, beta, output, accum,
+                  grad, blankLabel, loss)
+
+  tid = threadIdx().x
+  L = labelSize
+  T = uttLength
+  S = 2*L + 1
+  repeats = repeatsInLabel
+  labels = labelsWithBlanks
+
+  if (L+repeats) > T
+    return nothing
+  end
+
+  # Corner-case checking
+  start = S > 1 ? S-2 : 0
+  last = L + repeats < T ? S : S-1
+  sync_threads()
+  i = tid
+
+  # Calculate coefficients for last column (time step)
+  # then determine alpha and beta product
+  while i <= last - start
+    beta[i+start, T] = 0
+    output[i+start, T] = beta[i+start, T] + alphas[i+start, T]
+    i += blockDim().x
+  end
+  sync_threads()
+
+  # Fill in `accum` for last column (time step)
+  if tid == 1
+    for i=1:S
+      labelIdx = labels[i]
+      accum[labelIdx, T] = log_plus_f(accum[labelIdx, T], output[i, T])
+    end
+  end
+  sync_threads()
+
+  # Fill in `grad` for last column (time step)
+  idx = tid
+  while idx <= size(grad, 1)
+    s = -Inf32
+    for i=1:S
+      s = log_plus_f(s, output[i, T])
+    end
+
+    # ∂L/∂a (where a is activation before logsoftmax)
+    grad[idx, T] = exp(probs[idx, T]) - exp(accum[idx, T] - s)
+    idx += blockDim().x
+  end
+  sync_threads()
+
+  # Fill in the rest of the coefficients
+  t = T-1
+  while t >= 1
+    if t < T
+      idx = tid
+      while idx <= S
+        nextSum = probs[labels[idx], t+1] + beta[idx, t+1]
+        if idx < S
+          nextSum = log_plus_f(nextSum,
+            probs[labels[idx+1], t+1] + beta[idx+1, t+1])
+        end
+        if labels[idx] != blankLabel && idx != S-1 && labels[idx] != labels[idx+2]
+          nextSum = log_plus_f(nextSum,
+            probs[labels[idx+2], t+1] + beta[idx + 2, t+1])
+        end
+        if idx > 2*t
+          beta[idx, t] = -Inf32
+        else
+          beta[idx, t] = nextSum
+        end
+        idx += blockDim().x
+      end
+      sync_threads()
+      idx = tid
+      while idx <= S
+        output[idx, t] = alphas[idx, t] + beta[idx, t]
+        idx += blockDim().x
+      end
+      sync_threads()
+    end
+    sync_threads()
+
+    # Calculate accumulated alpha-beta products for each label class for
+    # each time step; used in calculating gradients
+    if tid == 1
+      for i=1:S
+        labelIdx = labels[i]
+        accum[labelIdx, t] = log_plus_f(accum[labelIdx, t], output[i, t])
+      end
+    end
+    sync_threads()
+    idx = tid
+
+    # Calculate gradients
+    while idx <= size(grad, 1)
+
+      # ∂L/∂a (where a is activation before logsoftmax)
+      grad[idx, t] = exp(probs[idx, t]) - exp(accum[idx, t] + loss)
+      idx += blockDim().x
+    end
+    sync_threads()
+    t -= 1
+    sync_threads()
+  end
+  return nothing
+end
+
+function ctc_alpha(ŷ::CuArray, y)
+  ŷ = logsoftmax(ŷ)
+  blank = size(ŷ, 1)
+  ycu = cu(y)
+  z′ = CUDA.fill(blank, 2 * length(y) + 1)
+  z′[eachindex(y) .* 2] .= ycu
+  T = size(ŷ, 2)
+  U′ = 2*length(y) + 1
+  alphas = CUDA.fill(log(zero(eltype(ŷ))), U′,T)
+  nRepeats = count_repeats(CUDA.adapt(Array, y))
+  nThreads = min(U′, MAX_THREADS)
+  @cuda blocks=1 threads=nThreads compute_alpha_kernel(ŷ, length(y), T, nRepeats, ycu, z′, alphas, blank)
+  return (loss=-1 * logsumexp(alphas[end-1:end]), alpha=alphas, z′=z′, yhat=ŷ, nRepeats=nRepeats)
+end
+
+ctc_loss(ŷ::CuArray, y) = ctc_alpha(ŷ::CuArray, y).loss
+
+function ∇ctc_loss(ŷ::CuArray, y, out)
+  loss, alphas, z′, ŷ, nRepeats = out
+  U′, T = size(alphas)
+  blank = size(ŷ, 1)
+  typed_zero = zero(eltype(ŷ))
+  betas = CUDA.fill(log(typed_zero), U′, T)
+  output = CUDA.fill(log(typed_zero), U′, T)
+  nThreads = min(U′, MAX_THREADS)
+  grads = CUDA.fill(log(typed_zero), size(ŷ))
+  accum = CUDA.fill(log(typed_zero), size(ŷ))
+  @cuda blocks=1 threads=nThreads compute_beta_and_grad_kernel(ŷ, length(y), T, nRepeats, CuArray(z′), alphas, betas, output, accum, grads, blank, loss)
+  return grads
+end

--- a/ext/NNlibCUDA/src/cudnn/activations.jl
+++ b/ext/NNlibCUDA/src/cudnn/activations.jl
@@ -1,0 +1,40 @@
+
+# Activation
+
+using Base.Broadcast
+using cuDNN: cudnnActivationForward!, cudnnOpTensor!,
+             CUDNN_ACTIVATION_TANH, CUDNN_ACTIVATION_SIGMOID, CUDNN_ACTIVATION_ELU,
+             CUDNN_ACTIVATION_RELU, CUDNN_ACTIVATION_CLIPPED_RELU, CUDNN_OP_TENSOR_MAX,
+             CUDNN_ACTIVATION_IDENTITY
+
+for (f, op) in [
+    CUDA.tanh       => (src,dst)->cudnnActivationForward!(dst, src, mode=CUDNN_ACTIVATION_TANH),
+    NNlib.σ         => (src,dst)->cudnnActivationForward!(dst, src, mode=CUDNN_ACTIVATION_SIGMOID),
+    NNlib.elu       => (src,dst)->cudnnActivationForward!(dst, src, mode=CUDNN_ACTIVATION_ELU),
+    NNlib.relu      => (src,dst)->cudnnActivationForward!(dst, src, mode=CUDNN_ACTIVATION_RELU),
+    # NNlib.relu6     => (src,dst)->cudnnActivationForward!(dst, src, mode=CUDNN_ACTIVATION_CLIPPED_RELU, coef=6.0),
+    # NNlib.leakyrelu => (src,dst)->cudnnOpTensor!(dst, src, src; op=CUDNN_OP_TENSOR_MAX, alpha1=0.01),
+    ]
+
+    @eval begin
+        # in-place
+        function Base.materialize!(dst::DenseCuArray{<:CUDNNFloat},
+                                   bc::Broadcast.Broadcasted{<:Any,<:Any,typeof($f),<:Tuple{DenseCuArray{<:CUDNNFloat}}})
+            $op(bc.args[1], dst)
+            return dst
+        end
+
+        # out of place
+        function Base.materialize(bc::Broadcast.Broadcasted{<:Any,<:Any,typeof($f),<:Tuple{DenseCuArray{<:CUDNNFloat}}})
+            ElType = Broadcast.combine_eltypes(bc.f, bc.args)
+            dst = similar(bc, ElType)
+            $op(bc.args[1], dst)
+            return dst
+        end
+    end
+end
+
+# CUDNN_ACTIVATION_IDENTITY does not work with cudnnActivationForward
+# FIXME: put this optimization in GPUArrays' `copyto!` (like Base.Broadcast's `copyto!`)
+Base.broadcasted(::typeof(identity), x::DenseCuArray{T}) where {T<:CUDNNFloat} = x
+

--- a/ext/NNlibCUDA/src/cudnn/batchnorm.jl
+++ b/ext/NNlibCUDA/src/cudnn/batchnorm.jl
@@ -1,0 +1,155 @@
+using cuDNN: CUDNN_BN_MIN_EPSILON, cudnnBatchNormalizationBackward,
+             cudnnBatchNormalizationForwardInference, CUDNN_BATCHNORM_SPATIAL,
+             cudnnBatchNormalizationForwardTraining
+
+
+# TODO: replace with new cudnn normalization interface
+# https://github.com/JuliaGPU/CUDA.jl/blob/master/lib/cudnn/normalization.jl
+
+mutable struct BNCache
+  mean
+  ivar
+end
+
+BNCache() = BNCache(nothing, nothing)
+
+@inline _wsize(x::AbstractArray{<:Any,N}) where N = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
+
+function batchnorm(g::Nothing, b::Nothing, x::DenseCuArray,
+                   running_mean, running_var, momentum; kws...)
+  affine_sz = _wsize(x)
+  g = fill!(similar(x, affine_sz), 1)
+  b = fill!(similar(x, affine_sz), 0)
+  return batchnorm(g, b, x, running_mean, running_var, momentum; kws...)
+end
+
+# NOTE: CuDNN supports only 4D and 5D Tensors for BatchNorm Operations
+# so reshape a 2D Tensor into 4D
+function batchnorm(g::DenseCuArray{T}, b::DenseCuArray{T}, x::DenseCuArray{T,2},
+                   running_mean, running_var, momentum; kws...) where T<:CUDNNFloat
+  x = reshape(x, 1, 1, size(x, 1), size(x, 2))
+  y = batchnorm(g, b, x, running_mean, running_var, momentum; kws...)
+  return dropdims(y, dims = (1, 2))
+end
+
+function batchnorm(g::DenseCuArray{T}, b::DenseCuArray{T}, x::Union{DenseCuArray{T,4},DenseCuArray{T,5}},
+                   running_mean, running_var, momentum; kws...) where T<:CUDNNFloat
+  cudnnBNForward!(similar(x), g, b, x, running_mean, running_var, momentum; kws...)
+end
+
+function cudnnBNForward!(y::DenseCuArray{T}, g::DenseCuArray{T}, b::DenseCuArray{T}, x::DenseCuArray{T},
+                        running_mean, running_var, momentum;
+                        cache = nothing,
+                        alpha = T(1), beta = T(0),
+                        eps = T(1e-5),
+                        training = true,
+                        affine = true,
+                        track_stats = true) where T<:CUDNNFloat
+  dims = _wsize(x)
+  if eps < CUDNN_BN_MIN_EPSILON
+    @warn "eps $eps is too small for CuDNN, setting to CUDNN_BN_MIN_EPSILON=$CUDNN_BN_MIN_EPSILON"
+    eps = CUDNN_BN_MIN_EPSILON
+  end
+
+  if running_mean === nothing || running_var === nothing
+    running_mean !== running_var && throw(ArgumentError("both or neither of running_mean and running_var must be nothing"))
+    if track_stats || !training
+      running_mean = fill!(similar(x, dims), 0)
+      running_var = fill!(similar(x, dims), 1)
+    end
+  end
+
+  xd = cudnnTensorDescriptor(x)
+  yd = cudnnTensorDescriptor(y)
+  gd = cudnnTensorDescriptor(CUDNN_TENSOR_NCHW, cudnnDataType(T), Cint(length(dims)), dim4(dims,Val(CUDNN_TENSOR_NCHW)))
+
+  if training
+    if !track_stats
+      running_mean = CU_NULL
+      running_var = CU_NULL
+    end
+
+    if cache !== nothing
+      mean = fill!(similar(x, dims), 0)
+      ivar = fill!(similar(x, dims), 1)
+    else
+      mean = CU_NULL
+      ivar = CU_NULL
+    end
+
+    cudnnBatchNormalizationForwardTraining(handle(), CUDNN_BATCHNORM_SPATIAL, scalingParameter(T, alpha), scalingParameter(T, beta), xd, x, yd, y, gd, g, b, momentum, running_mean, running_var, eps, mean, ivar)
+
+    if cache !== nothing
+      cache.mean = mean
+      cache.ivar = ivar
+    end
+  else
+    cudnnBatchNormalizationForwardInference(handle(), CUDNN_BATCHNORM_SPATIAL, scalingParameter(T, alpha), scalingParameter(T, beta), xd, x, yd, y, gd, g, b, running_mean, running_var, eps)
+  end
+  return y
+end
+
+function ∇batchnorm(g::Nothing, b::Nothing, x::DenseCuArray, dy::DenseCuArray,
+                    running_mean, running_var, momentum; kws...)
+  affine_sz = _wsize(x)
+  g = fill!(similar(x, affine_sz), 1)
+  b = fill!(similar(x, affine_sz), 0)
+  return ∇batchnorm(g, b, x, dy, running_mean, running_var, momentum; kws...)
+end
+
+function ∇batchnorm(g::DenseCuArray{T}, b::DenseCuArray{T}, x::DenseCuArray{T, 2}, dy::DenseCuArray{T, 2},
+            running_mean, running_var, momentum;
+            kws...) where T<:CUDNNFloat
+  dg, db, dx = ∇batchnorm(g, b, reshape(x, 1, 1, size(x, 1), size(x, 2)), reshape(dy, 1, 1, size(dy, 1),
+                          size(dy, 2)), running_mean, running_var, momentum; kws...)
+  (dg, db, dropdims(dx, dims = (1, 2)))
+end
+
+
+function ∇batchnorm(g::DenseCuArray{T}, b::DenseCuArray{T}, x::DenseCuArray{T}, dy::DenseCuArray{T},
+                    running_mean, running_var, momentum;
+                    affine=true, kws...) where T<:CUDNNFloat
+  dg = similar(g)
+  db = similar(b)
+  dx = similar(x)
+  cudnnBNBackward!(dg, g, db, dx, x, dy, running_mean, running_var, T(momentum); kws...)
+  if affine
+    (dg, db, dx)
+  else
+    # cuDNN always calculates dg and db, therefore we just have to drop them
+    (nothing, nothing, dx)
+  end
+end
+
+function cudnnBNBackward!(dg::DenseCuArray{T}, g::DenseCuArray{T}, db::DenseCuArray{T},
+                          dx::DenseCuArray{T}, x::DenseCuArray{T}, dy::DenseCuArray{T},
+                          running_mean, running_var,
+                          momentum; cache = nothing, eps = T(1e-5),
+                          alpha = T(1), beta = T(0),
+                          dalpha = T(1), dbeta = T(0), training = true,
+                          track_stats = true) where T<:CUDNNFloat
+  if !track_stats
+    running_mean = CU_NULL
+    running_var = CU_NULL
+  end
+
+  xd = cudnnTensorDescriptor(x)
+  dyd = cudnnTensorDescriptor(dy)
+  dxd = cudnnTensorDescriptor(dx)
+  gd = cudnnTensorDescriptor(CUDNN_TENSOR_NCHW, cudnnDataType(T), Cint(length(_wsize(x))), dim4(_wsize(x),Val(CUDNN_TENSOR_NCHW)))
+  if cache !== nothing
+    @debug "fetching mean and ivar from the cache"
+    mean, ivar = cache.mean, cache.ivar
+  else
+    mean, ivar = CU_NULL, CU_NULL
+  end
+
+  if eps < CUDNN_BN_MIN_EPSILON
+    @warn "eps $eps is too small for CuDNN, setting to CUDNN_BN_MIN_EPSILON=$CUDNN_BN_MIN_EPSILON"
+    eps = CUDNN_BN_MIN_EPSILON
+  end
+
+  cudnnBatchNormalizationBackward(handle(), CUDNN_BATCHNORM_SPATIAL,
+        scalingParameter(T, alpha), scalingParameter(T, beta), scalingParameter(T, dalpha), scalingParameter(T, dbeta),
+        xd, x, dyd, dy, dxd, dx, gd, g, dg, db, eps, mean, ivar)
+end

--- a/ext/NNlibCUDA/src/cudnn/conv.jl
+++ b/ext/NNlibCUDA/src/cudnn/conv.jl
@@ -1,0 +1,130 @@
+
+using NNlib: DenseConvDims
+import NNlib: conv!, ∇conv_filter!, ∇conv_data!, conv_bias_act!
+
+using cuDNN: scalingParameter, CUDNN_CONVOLUTION, convdims,
+             cudnnConvolutionDescriptor, cudnnConvolutionBwdDataAlgoPerf,
+             cudnnConvolutionForward!, cudnnConvolutionBwdFilterAlgoPerf,
+             cudnnConvolutionBackwardData, cudnnConvolutionBackwardFilter,
+             cudnnConvolutionBackwardBias
+
+const CUDNNFloat = Union{Float16,Float32,Float64}
+
+function cudnnConvolutionDescriptorAndPaddedInput(cdims::DenseConvDims, x::DenseCuArray{T}) where T
+    # The main purpose of this function is to catch asymmetric padding which cudnn does not support
+    # If we find asymmetric padding we'll make a copy of x which is manually padded so that we can
+    # call cudnn with symmetric padding.
+    pad = NNlib.padding(cdims)
+    sdims = NNlib.spatial_dims(cdims)
+    all(i -> pad[i] .== pad[i+1], 1:2:2sdims) && return (cudnnConvolutionDescriptor(cdims, x), x, identity)
+
+    # Naive implementation, is there a faster way?
+    # How much we need to pad x manually: The absolute difference between pad_left and pad_right, pad_top
+    # and pad_bottom etc. respectively. We keep the sign here though because we use it below to figure out
+    # which side of x to pad. Oh, and we use a CartesianIndex as we will mainly use this to index in x
+    pad_manual = CartesianIndex(ntuple(i -> i > sdims ? 0 : pad[2(i-1)+1] - pad[2(i-1)+2], ndims(x)))
+
+    # How much we can let cudnn pad: The smallest padding amount between pad_left and pad_right, pad_top
+    # and pad_bottom etc. respectively
+    pad_cudnn = ntuple(i -> min(pad[2(i-1)+1], pad[2(i-1)+2]), sdims)
+
+    x_padded_size = ntuple(i -> i <= sdims ? size(x, i) + abs(pad_manual[i]) : size(x ,i), ndims(x))
+    x_padded = similar(x, x_padded_size)
+    fill!(x_padded, 0)
+    # This is a bit yucky, but we are basically figuring out where in x_padded we shall insert x
+    # Haven't benchmarked if this has any advantages over a more readable solution, e.g. writing dim
+    # by dim to an array in a loop
+    xIs = CartesianIndices(x)
+    xI_first = first(xIs)
+    xI_last = last(xIs)
+    xIs_pad = max(xI_first, xI_first + pad_manual) : max(xI_last, xI_last + pad_manual)
+    x_padded[xIs_pad] = x
+
+    return cudnnConvolutionDescriptor(cdims, x_padded, pad_cudnn), x_padded, _x -> _x[xIs_pad]
+end
+
+function cudnnConvolutionDescriptor(cdims::DenseConvDims, x::DenseCuArray{T}, pad = nnlibPadding(cdims)) where T
+    mode=(NNlib.flipkernel(cdims) ? CUDNN_CROSS_CORRELATION : CUDNN_CONVOLUTION)
+    cudnnConvolutionDescriptor(convdims(pad, size(x),0),
+                               convdims(NNlib.stride(cdims),size(x),1),
+                               convdims(NNlib.dilation(cdims),size(x),1),
+                               mode,
+                               cudnnDataType(T),
+                               math_mode(),
+                               CUDNN_DEFAULT_REORDER,
+                               Cint(NNlib.groupcount(cdims)))
+end
+
+function conv!(y::DenseCuArray{T}, x::DenseCuArray{T}, w::DenseCuArray{T}, cdims::DenseConvDims;
+               alpha=1, beta=0, algo=-1) where T<:CUDNNFloat
+    if cudnnversion() < v"6"
+        all(x -> x == 1, dilation(cdims)) || error("Only dilation = 1 is supported in cuDNN version < 6")
+    end
+    if algo != -1
+        @warn "algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
+    end
+    d, x, _ = cudnnConvolutionDescriptorAndPaddedInput(cdims, x)
+    cudnnConvolutionForward!(y, w, x, d; alpha, beta, z=y)
+end
+
+function conv_bias_act!(y::DenseCuArray{T}, x::DenseCuArray{T}, w::DenseCuArray{T},
+                        cdims::DenseConvDims, bias::DenseCuArray{T}, σ=identity;
+                        z::DenseCuArray{T}=y, alpha=1, beta=0, algo=-1) where T<:CUDNNFloat
+    if cudnnversion() < v"6"
+        all(x -> x == 1, dilation(cdims)) || error("Only dilation = 1 is supported in cuDNN version < 6")
+    end
+    if algo != -1
+        @warn "The algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
+    end
+    d, x, _ = cudnnConvolutionDescriptorAndPaddedInput(cdims, x)
+    # only relu and identity are supported by cudnnConvolutionForward!
+    activation = (σ == NNlib.relu ? CUDNN_ACTIVATION_RELU : CUDNN_ACTIVATION_IDENTITY)
+    cudnnConvolutionForward!(y, w, x, d; z, bias, activation, alpha, beta)
+    if activation === CUDNN_ACTIVATION_IDENTITY && σ ∉ (nothing, identity)
+        y = σ.(y)
+    end
+    return y
+end
+
+function ∇conv_data!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, w::DenseCuArray{T},
+                     cdims::DenseConvDims; alpha=1, beta=0, algo=-1) where T<:CUDNNFloat
+    if cudnnversion() < v"6"
+        all(x -> x == 1, dilation(cdims)) || error("Only dilation = 1 is supported in cuDNN version < 6")
+    end
+    if algo != -1
+        @warn "The algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
+    end
+    alpha, beta = scalingParameter(T,alpha), scalingParameter(T,beta);
+    convDesc, dx, depad = cudnnConvolutionDescriptorAndPaddedInput(cdims, dx)
+    xDesc, yDesc, wDesc = cudnnTensorDescriptor(dx), cudnnTensorDescriptor(dy), cudnnFilterDescriptor(w)
+    p = cudnnConvolutionBwdDataAlgoPerf(wDesc, w, yDesc, dy, convDesc, xDesc, dx, beta!=0)
+    with_workspace(p.memory) do workspace
+        cudnnConvolutionBackwardData(handle(), alpha, wDesc, w, yDesc, dy, convDesc, p.algo, workspace, sizeof(workspace), beta, xDesc, dx)
+    end
+    return depad(dx)
+end
+
+function ∇conv_filter!(dw::DenseCuArray{T}, x::DenseCuArray{T}, dy::DenseCuArray{T},
+                       cdims::DenseConvDims; alpha=1, beta=0, algo=-1) where T<:CUDNNFloat
+    if cudnnversion() < v"6"
+        all(x -> x == 1, dilation(cdims)) || error("Only dilation = 1 is supported in cuDNN version < 6")
+    end
+    if algo != -1
+        @warn "The algo option has been deprecated, the fastest algo is computed automatically" maxlog=1
+    end
+    alpha, beta = scalingParameter(T,alpha), scalingParameter(T,beta);
+    convDesc, x, _ = cudnnConvolutionDescriptorAndPaddedInput(cdims, x)
+    xDesc, yDesc, wDesc = cudnnTensorDescriptor(x), cudnnTensorDescriptor(dy), cudnnFilterDescriptor(dw)
+    p = cudnnConvolutionBwdFilterAlgoPerf(xDesc, x, yDesc, dy, convDesc, wDesc, dw, beta!=0);
+    with_workspace(p.memory) do workspace
+        cudnnConvolutionBackwardFilter(handle(), alpha, xDesc, x, yDesc, dy, convDesc, p.algo, workspace, sizeof(workspace), beta, wDesc, dw);
+    end
+    return dw
+end
+
+function ∇conv_bias!(db::DenseCuArray{T}, dy::DenseCuArray{T}; alpha=1, beta=0) where T<:CUDNNFloat
+    alpha,beta = scalingParameter(T,alpha), scalingParameter(T,beta)
+    bDesc, yDesc = cudnnTensorDescriptor.((db,dy))
+    cudnnConvolutionBackwardBias(handle(), alpha, yDesc, dy, beta, bDesc, db)
+    return db
+end

--- a/ext/NNlibCUDA/src/cudnn/cudnn.jl
+++ b/ext/NNlibCUDA/src/cudnn/cudnn.jl
@@ -1,0 +1,13 @@
+using cuDNN: handle, with_workspace, cudnnTensorDescriptor, cudnnFilterDescriptor,
+             cudnnDataType, math_mode, CUDNN_DEFAULT_REORDER, CUDNN_CROSS_CORRELATION,
+             CUDNN_NOT_PROPAGATE_NAN, CUDNN_TENSOR_NCHW, dim4
+
+cudnnversion() = cuDNN.version()
+
+function nnlibPadding(dims)
+    pd = NNlib.padding(dims)
+    if !all(pd[1:2:end] .== pd[2:2:end])
+        @warn "cuDNN does not support asymmetric padding; defaulting to symmetric choice" maxlog=1
+    end
+    return pd[1:2:end]
+end

--- a/ext/NNlibCUDA/src/cudnn/pooling.jl
+++ b/ext/NNlibCUDA/src/cudnn/pooling.jl
@@ -1,0 +1,73 @@
+using cuDNN: cudnnPoolingMode_t, CUDNN_POOLING_MAX,
+             CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,
+             cudnnPoolingForward!, pooldims, cudnnPoolingBackward
+
+import NNlib: maxpool!, ∇maxpool!, meanpool!, ∇meanpool!
+import cuDNN: cudnnPoolingDescriptor
+
+function cudnnPoolingDescriptor(pdims::PoolDims, x::DenseCuArray{T}, mode::cudnnPoolingMode_t) where T
+    window, padding, stride = NNlib.kernel_size(pdims), nnlibPadding(pdims), NNlib.stride(pdims)
+    nanOpt = CUDNN_NOT_PROPAGATE_NAN
+    cudnnPoolingDescriptor(mode, nanOpt, Cint(ndims(x)-2), pooldims(window,size(x)), pooldims(padding,size(x)), pooldims(stride,size(x)))
+end
+
+function maxpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
+    d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_MAX)
+    cudnnPoolingForward!(y, x, d)
+end
+
+function ∇maxpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
+    xDesc, yDesc = cudnnTensorDescriptor.((x, y))
+    d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_MAX)
+    alpha, beta = scalingParameter(T,1), scalingParameter(T,0)
+    cudnnPoolingBackward(handle(), d, alpha, yDesc, y, yDesc, dy, xDesc, x, beta, xDesc, dx)
+    return dx
+end
+
+function meanpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
+    d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
+    cudnnPoolingForward!(y, x, d)
+end
+
+function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
+    xDesc, yDesc = cudnnTensorDescriptor.((x, y))
+    d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
+    alpha, beta = scalingParameter(T,1), scalingParameter(T,0)
+    cudnnPoolingBackward(handle(), d, alpha, yDesc, y, yDesc, dy, xDesc, x, beta, xDesc, dx)
+    return dx
+end
+
+### Since CUDA.jl does not support 1D pooling, we have to convert to 2d
+
+add1d(x) = reshape(x, 1, size(x)...)
+
+function fix_pooldims_1d(pdims::PoolDims{1,K,S,P,D}) where {K,S,P,D}
+    PoolDims{2, K + 1, S + 1, P + 2, D + 1}((1, NNlib.input_size(pdims)...),
+                                            (1, NNlib.kernel_size(pdims)...),
+                                            NNlib.channels_in(pdims),
+                                            (1, NNlib.stride(pdims)...),
+                                            (0, 0, NNlib.padding(pdims)...),
+                                            (1, NNlib.dilation(pdims)...))
+end
+
+function maxpool!(y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
+    maxpool!(add1d(y), add1d(x), fix_pooldims_1d(pdims))
+    return y
+end
+
+function meanpool!(y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
+    meanpool!(add1d(y), add1d(x), fix_pooldims_1d(pdims))
+    return y
+end
+
+function ∇maxpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
+    ∇maxpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims))
+    return dx
+end
+
+function ∇meanpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
+    ∇meanpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims))
+    return dx
+end
+
+

--- a/ext/NNlibCUDA/src/cudnn/softmax.jl
+++ b/ext/NNlibCUDA/src/cudnn/softmax.jl
@@ -1,0 +1,102 @@
+import NNlib: softmax, softmax!, ∇softmax, ∇softmax!,
+              logsoftmax, logsoftmax!, ∇logsoftmax, ∇logsoftmax!
+
+using cuDNN: CUDNN_SOFTMAX_LOG, CUDNN_SOFTMAX_MODE_CHANNEL,
+             CUDNN_SOFTMAX_FAST, CUDNN_SOFTMAX_ACCURATE, cudnnSoftmaxForward!,
+             cudnnSoftmaxBackward
+
+# Softmax
+
+# @denizyuret: do not do inplace operations with softmax/logsoftmax when (1) cpu version is not, (2) one can use softmax!
+function softmax(x::T; dims=1) where {T<:DenseCuArray}
+    softmax!(similar(x), x; dims)
+end
+
+function ∇softmax(dy::T, x::T, y::T; dims=1) where {T<:DenseCuArray}
+    ∇softmax!(similar(x), dy, x, y; dims)
+end
+
+function logsoftmax(x::T; dims=1) where {T<:DenseCuArray}
+    logsoftmax!(similar(x), x; dims)
+end
+
+function ∇logsoftmax(dy::T, x::T, y::T; dims=1) where {T<:DenseCuArray}
+    ∇logsoftmax!(similar(x), dy, x, y; dims)
+end
+
+# @denizyuret: backup implementations for unsupported/slow size/dims combinations:
+function _softmax!(y::T, x::T; dims) where {T<:DenseCuArray}
+    y .= exp.(x .- maximum(x; dims))
+    y ./= sum(y; dims)
+end
+
+function _∇softmax!(dx::T, dy::T, x::T, y::T; dims) where {T<:DenseCuArray}
+    dx .= y .* (dy .- sum(dy .* y; dims))
+end
+
+function _logsoftmax!(y::T, x::T; dims) where {T<:DenseCuArray}
+    y .= x .- maximum(x; dims)
+    y .-= log.(sum(exp.(y); dims))
+end
+
+function _∇logsoftmax!(dx::T, dy::T, x::T, y::T; dims) where {T<:DenseCuArray}
+    dx .= dy .- sum(dy; dims) .* exp.(y)
+end
+
+# Trick by @norci to use cudnn for softmax dims args that are contiguous:
+# If dims=(dmin:dmax) then CUDNN_SOFTMAX_MODE_CHANNEL does the trick with reshape
+#    (1, prod(size(x)[1:dmin-1]), prod(size(x)[dmin:dmax]), :)
+# softmaxdims returns nothing when the backup implementation should be used.
+
+function softmaxdims(x, dims)
+    dims === Colon() && return (1, 1, length(x), 1)
+    mind,maxd = minimum(dims),maximum(dims)
+    all(i in dims for i in mind:maxd) || return nothing # cannot handle if not contiguous
+    stride = dimsize = 1
+    for i in 1:(mind-1); stride *= size(x,i); end # Using size(x,i) assumes trailing dims = 1, robust to maxd > ndims(x)
+    for i in mind:maxd; dimsize *= size(x,i); end
+    batchsize = length(x)÷(stride*dimsize)
+    # Here is a region where cudnn is slower, so we go with the backup:
+    batchsize == 1 && 64 <= stride <= 4096 && 64 <= dimsize <= 4096 && return nothing
+    return (1, stride, dimsize, batchsize)
+end
+
+# Determine softmax algo based on math_mode
+
+softmaxalgo() = (CUDA.math_mode()===CUDA.FAST_MATH ? CUDNN_SOFTMAX_FAST : CUDNN_SOFTMAX_ACCURATE)
+
+# Main implementations:
+
+function softmax!(y::T, x::T = y; dims=1) where {T<:DenseCuArray}
+    s = softmaxdims(x, dims)
+    s === nothing && return _softmax!(y, x; dims)
+    cudnnSoftmaxForward!(reshape(y,s), reshape(x,s); mode = CUDNN_SOFTMAX_MODE_CHANNEL, algo = softmaxalgo())
+    return y
+end
+
+function ∇softmax!(dx::T, dy::T, x::T, y::T; dims=1) where {R,T<:DenseCuArray{R}}
+    s = softmaxdims(x, dims)
+    s === nothing && return _∇softmax!(dx, dy, x, y; dims)
+    xDesc = cudnnTensorDescriptor(reshape(x,s))
+    alpha, beta = scalingParameter(R,1), scalingParameter(R,0)
+    cudnnSoftmaxBackward(handle(), softmaxalgo(), CUDNN_SOFTMAX_MODE_CHANNEL,
+                         alpha, xDesc, y, xDesc, dy, beta, xDesc, dx)
+    return dx
+end
+
+function logsoftmax!(y::T, x::T = y; dims=1) where {T<:DenseCuArray}
+    s = softmaxdims(x, dims)
+    s === nothing && return _logsoftmax!(y, x; dims)
+    cudnnSoftmaxForward!(reshape(y,s), reshape(x,s); mode = CUDNN_SOFTMAX_MODE_CHANNEL, algo = CUDNN_SOFTMAX_LOG)
+    return y
+end
+
+function ∇logsoftmax!(dx::T, dy::T, x::T, y::T; dims=1) where {R,T<:DenseCuArray{R}}
+    s = softmaxdims(x, dims)
+    s === nothing && return _∇logsoftmax!(dx, dy, x, y; dims)
+    xDesc = cudnnTensorDescriptor(reshape(x,s))
+    alpha, beta = scalingParameter(R,1), scalingParameter(R,0)
+    cudnnSoftmaxBackward(handle(), CUDNN_SOFTMAX_LOG, CUDNN_SOFTMAX_MODE_CHANNEL,
+                         alpha, xDesc, y, xDesc, dy, beta, xDesc, dx)
+    return dx
+end

--- a/ext/NNlibCUDA/src/fold.jl
+++ b/ext/NNlibCUDA/src/fold.jl
@@ -1,0 +1,111 @@
+
+function unfold_kernel!(col::AbstractArray{T}, x, col_size, input_size, output_size, kernel_size, flipkernel, stride, pad_lo, dilation, max_idx) where {T}
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        i, kw, kh, kd, c, b = CartesianIndices(col_size)[index].I # col indices
+        w, h, d = CartesianIndices(output_size)[i].I # x indices
+
+        # project 
+        w, h, d = @. ((w, h, d) - 1)*stride - pad_lo + 1 + ((kw, kh, kd) - 1)*dilation
+
+        if !flipkernel
+            kw, kh, kd = kernel_size .- (kw, kh, kd) .+ 1
+        end
+
+        # check out of bounds
+        if !all(checkindex.(Bool, UnitRange.(1, input_size), (w, h, d)))
+            col[i, kw, kh, kd, c, b] = T(0)
+            return nothing
+        end
+        
+        xval::T = x[w, h, d, c, b]
+        col[i, kw, kh, kd, c, b] = xval
+    end
+
+    return nothing
+end
+
+function fold_kernel!(x::AbstractArray{T}, col, col_size, input_size, output_size, kernel_size, flipkernel, stride, pad_lo, dilation, max_idx) where {T}
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        i, kw, kh, kd, c, b = CartesianIndices(col_size)[index].I # col indices
+        w, h, d = CartesianIndices(output_size)[i].I # x indices
+
+        # project 
+        w, h, d = @. ((w, h, d) - 1)*stride - pad_lo + 1 + ((kw, kh, kd) - 1)*dilation
+
+        # check out of bounds
+        if !all(checkindex.(Bool, UnitRange.(1, input_size), (w, h, d)))
+            return nothing
+        end
+
+        if !flipkernel
+            kw, kh, kd = kernel_size .- (kw, kh, kd) .+ 1
+        end
+        
+        cval::T = col[i, kw, kh, kd, c, b]
+        CUDA.@atomic x[w, h, d, c, b] += cval
+    end
+
+    return nothing
+end
+
+function NNlib.unfold!(col::AnyCuArray{cT,3}, x::AnyCuArray{xT,5}, cdims::NNlib.DenseConvDims) where {cT, xT}
+    if NNlib.spatial_dims(cdims) != 3
+        throw(DimensionMismatch("unfold!() only accepts 3d convoluitional inputs"))
+    end
+
+    input_size = NNlib.input_size(cdims)
+    C_in = NNlib.channels_in(cdims)
+    kernel_size = NNlib.kernel_size(cdims)
+    pad_w_lo, pad_w_hi, pad_h_lo, pad_h_hi, pad_d_lo, pad_d_hi = NNlib.padding(cdims)
+    pad_lo = (pad_w_lo, pad_h_lo, pad_d_lo)
+    dilation = NNlib.dilation(cdims)
+    stride = NNlib.stride(cdims)
+    output_size = NNlib.output_size(cdims)
+    flipkernel = NNlib.flipkernel(cdims) 
+
+    col_reshaped = reshape(col, (prod(output_size), kernel_size..., C_in, :))
+
+    max_idx = prod(size(col))
+    args = col_reshaped, x, size(col_reshaped), input_size, output_size, kernel_size, flipkernel, stride, pad_lo, dilation, max_idx
+    kernel = @cuda launch=false unfold_kernel!(args...)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(max_idx, config.threads)
+    blocks = cld(max_idx, threads)
+    kernel(args...; threads=threads, blocks=blocks)
+    return col
+end
+
+function NNlib.fold!(x::AnyCuArray{xT,5}, col::AnyCuArray{cT,3}, cdims::NNlib.DenseConvDims) where {xT, cT}
+    if NNlib.spatial_dims(cdims) != 3
+        throw(DimensionMismatch("fold!() only accepts 3d convoluitional inputs"))
+    end
+
+    # going to accumulate into x
+    fill!(x, xT(0))
+
+    input_size = NNlib.input_size(cdims)
+    C_in = NNlib.channels_in(cdims)
+    kernel_size = NNlib.kernel_size(cdims)
+    pad_w_lo, pad_w_hi, pad_h_lo, pad_h_hi, pad_d_lo, pad_d_hi = NNlib.padding(cdims)
+    pad_lo = (pad_w_lo, pad_h_lo, pad_d_lo)
+    dilation = NNlib.dilation(cdims)
+    stride = NNlib.stride(cdims)
+    output_size = NNlib.output_size(cdims)
+    flipkernel = NNlib.flipkernel(cdims) 
+
+    col_reshaped = reshape(col, (prod(output_size), kernel_size..., C_in, :))
+
+    max_idx = prod(size(col))
+    args = x, col_reshaped, size(col_reshaped), input_size, output_size, kernel_size, flipkernel, stride, pad_lo, dilation, max_idx
+    kernel = @cuda launch=false fold_kernel!(args...)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(max_idx, config.threads)
+    blocks = cld(max_idx, threads)
+    kernel(args...; threads=threads, blocks=blocks)
+    return x
+end
+

--- a/ext/NNlibCUDA/src/gather.jl
+++ b/ext/NNlibCUDA/src/gather.jl
@@ -1,0 +1,65 @@
+function gather_check_dims(X::AbstractArray{Tx,Nx}, 
+                           Y::AbstractArray{Ty,Ny},
+                           idx::AbstractArray{Tidx,Nidx}) where
+                           {Tx,Ty,Tidx<:IntOrIntTuple,Nx,Ny,Nidx}
+    M = NNlib.typelength(Tidx)
+    dims = gather_check_dims(Nx, Ny, M, Nidx)
+    size(X)[1:dims] == size(Y)[1:dims] || throw(ArgumentError("Incompatible input shapes."))
+    size(Y)[dims+1:end] == size(idx) || throw(ArgumentError("Incompatible input shapes."))
+    return dims
+end
+
+function gather_check_dims(X::AbstractArray{Tx,Nx}, 
+                           Y::AbstractArray{Ty,Ny},
+                           idx::AbstractArray{CartesianIndex{M},Nidx}) where
+                           {Tx,Ty,Nx,Ny,M,Nidx}
+    dims = gather_check_dims(Nx, Ny, M, Nidx)
+    size(X)[1:dims] == size(Y)[1:dims] || throw(ArgumentError("Incompatible input shapes."))
+    size(Y)[dims+1:end] == size(idx) || throw(ArgumentError("Incompatible input shapes."))
+    return dims
+end
+
+function gather_check_dims(Nx, Ny, M, Nidx)
+    @assert Nx - M == Ny - Nidx "Incompatible input shapes of (dst, src, idx) = ($Nx, $Ny, $Nidx)."
+    dims = Nx - M
+    dims < 0 && throw(ArgumentError("dims must be non-negative but got dims=$dims."))
+    return dims
+end
+
+function gather_kernel!(dst, src, idx, max_idx, max_dims_idx, dims_size)
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        j, k = divrem(index-1, max_dims_idx)
+        dims_i = CartesianIndices(dims_size)[k+1]
+        dst[index] = src[dims_i, idx[j+1]...]
+    end
+    return nothing
+end
+
+function gather_kernel!(dst, src, idx::CUDA.CuDeviceArray{<:CartesianIndex}, max_idx, max_dims_idx, dims_size)
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        j, k = divrem(index-1, max_dims_idx)
+        dims_i = CartesianIndices(dims_size)[k+1]
+        li = Base._to_linear_index(src, Tuple(dims_i)..., Tuple(idx[j+1])...)
+        dst[index] = src[li]
+    end
+    return nothing
+end
+
+function NNlib.gather!(dst::AnyCuArray, src::AnyCuArray, idx::AnyCuArray)
+    dims = gather_check_dims(src, dst, idx)
+    dims_size = size(src)[1:dims]
+    max_dims_idx = prod(dims_size)
+    max_idx = max_dims_idx * length(idx)
+    args = dst, src, idx, max_idx, max_dims_idx, dims_size
+
+    kernel = @cuda launch=false gather_kernel!(args...)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(max_idx, config.threads)
+    blocks = cld(max_idx, threads)
+    kernel(args...; threads=threads, blocks=blocks)
+    return dst
+end

--- a/ext/NNlibCUDA/src/sampling.jl
+++ b/ext/NNlibCUDA/src/sampling.jl
@@ -1,0 +1,61 @@
+@inline function NNlib._safe_add!(dx::CuDeviceArray{T, 4}, value, ix, iy, c, n) where T
+    @inbounds CUDA.@atomic dx[ix, iy, c, n] += value
+end
+
+function grid_sample_kernel!(n_elem, output, input, grid, padding_mode)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+    if index < n_elem
+        iW, iH, iC, _ = size(input)
+        _, gW, gH, _ = size(grid)
+
+        w = index % gW + 1
+        h = (index ÷ gW) % gH + 1
+        n = index ÷ (gW * gH) + 1
+        NNlib._grid_sample_kernel!(output, input, grid, padding_mode, w, h, n, iW, iH, iC)
+    end
+    nothing
+end
+
+function ∇grid_sample_kernel!(n_elem, dx, dgrid, Δ, input, grid, padding_mode)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+    if index < n_elem
+        iW, iH, iC, _ = size(input)
+        _, gW, gH, _ = size(grid)
+
+        w = index % gW + 1
+        h = (index ÷ gW) % gH + 1
+        n = index ÷ (gW * gH) + 1
+        NNlib._∇grid_sample_kernel!(dx, dgrid, Δ, input, grid, padding_mode, w, h, n, iW, iH, iC)
+    end
+    nothing
+end
+
+function NNlib.grid_sample(x::CuArray{T, 4}, grid::CuArray{V, 4}; padding_mode = :zeros) where {T, V}
+    pad = Val(padding_mode)
+    _, _, xC, xN = size(x)
+    _, gW, gH, _ = size(grid)
+    n_elem = gW * gH * xN
+    y = similar(x, T, (gW, gH, xC, xN))
+
+    kernel = @cuda launch=false grid_sample_kernel!(n_elem, y, x, grid, pad)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(n_elem, config.threads)
+    blocks = cld(n_elem, threads)
+    kernel(n_elem, y, x, grid, pad; threads=threads, blocks=blocks)
+    y
+end
+
+function NNlib.∇grid_sample(Δ::CuArray{T, 4}, x::CuArray{T, 4}, grid::CuArray{V, 4}; padding_mode = :zeros) where {T, V}
+    pad = Val(padding_mode)
+    xN = size(x, 4)
+    _, gW, gH, _ = size(grid)
+    n_elem = gW * gH * xN
+    dx, dgrid = CUDA.zeros(T, size(x)), similar(grid)
+
+    kernel = @cuda launch=false ∇grid_sample_kernel!(n_elem, dx, dgrid, Δ, x, grid, pad)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(n_elem, config.threads)
+    blocks = cld(n_elem, threads)
+    kernel(n_elem, dx, dgrid, Δ, x, grid, pad; threads=threads, blocks=blocks)
+    dx, dgrid
+end

--- a/ext/NNlibCUDA/src/scatter.jl
+++ b/ext/NNlibCUDA/src/scatter.jl
@@ -1,0 +1,188 @@
+# supported op: +, -, *, /, max, min, &, |, mean
+
+function scatter_kernel!(op::OP, dst, src, idx) where OP
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= length(idx)
+        CUDA.@atomic dst[idx[index]...] = op(dst[idx[index]...], src[index])
+    end
+    return nothing
+end
+
+function scatter_kernel!(op::OP, dst, src, idx::CUDA.CuDeviceArray{<:CartesianIndex}) where OP
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= length(idx)
+        li = Base._to_linear_index(dst, Tuple(idx[index])...)
+        CUDA.@atomic dst[li] = op(dst[li], src[index])
+    end
+    return nothing
+end
+
+function scatter_kernel!(op::OP, dst, src, idx, max_idx, max_dims_idx, dims_size) where OP
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        j, k = divrem(index-1, max_dims_idx)
+        dims_i = CartesianIndices(dims_size)[k+1]
+        CUDA.@atomic dst[Tuple(dims_i)..., idx[j+1]...] = op(dst[Tuple(dims_i)..., idx[j+1]...], src[index])
+    end
+    return nothing
+end
+
+function scatter_kernel!(op::OP, dst, src, idx::CUDA.CuDeviceArray{<:CartesianIndex}, 
+            max_idx, max_dims_idx, dims_size) where OP
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        j, k = divrem(index-1, max_dims_idx)
+        dims_i = CartesianIndices(dims_size)[k+1]
+        li = Base._to_linear_index(dst, Tuple(dims_i)..., Tuple(idx[j+1])...)
+        CUDA.@atomic dst[li] = op(dst[li], src[index])
+    end
+    return nothing
+end
+
+function NNlib.scatter!(op::OP, dst::AnyCuArray, src::AnyCuArray, idx::AnyCuArray) where OP
+    dims = NNlib.scatter_dims(dst, src, idx)
+    args = if dims == 0
+        max_idx = length(idx)
+        op, dst, src, idx
+    else
+        dims_size = size(dst)[1:dims]
+        max_dims_idx = prod(dims_size)
+        max_idx = max_dims_idx * length(idx)
+        op, dst, src, idx, max_idx, max_dims_idx, dims_size
+    end
+
+    kernel = @cuda launch=false scatter_kernel!(args...)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(max_idx, config.threads)
+    blocks = cld(max_idx, threads)
+    kernel(args...; threads=threads, blocks=blocks)
+    return dst
+end
+
+function NNlib.scatter!(op::typeof(mean), dst::AnyCuArray, src::AnyCuArray, idx::AnyCuArray)
+    Ns = NNlib.scatter!(+, zero(dst), one.(src), idx)
+    dst_ = NNlib.scatter!(+, zero(dst), src, idx)
+    dst .+= NNlib.safe_div.(dst_, Ns)
+    return dst
+end
+
+
+## Gradients
+
+function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx, 
+                rev_idx, max_idx, T::Type{TT})  where {OP,TT}
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        cart_j = CartesianIndices(idx)[index]
+        # get aggregating indeices, which is to be aggregated together, and itself index
+        inds = rev_idx[idx[cart_j]...]
+        # multiply all values to be aggregated but not itself
+        x = one(T)
+        for k in inds
+            x *= src[k]
+        end
+        x /= src[cart_j]
+        # apply `op` on `Δsrc[i, k]` and `x`
+        Δsrc[cart_j] = op(Δsrc[cart_j], x)
+    end
+    return nothing
+end
+
+function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx::CUDA.CuDeviceArray{<:CartesianIndex}, 
+                rev_idx, max_idx, T::Type{TT}) where {OP,TT}
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        cart_j = CartesianIndices(idx)[index]
+        # get aggregating indeices, which is to be aggregated together, and itself index
+        inds = rev_idx[Tuple(idx[cart_j])...]
+        # multiply all values to be aggregated but not itself
+        x = one(T)
+        for k in inds
+            x *= src[k]
+        end
+        x /= src[cart_j]
+        # apply `op` on `Δsrc[i, k]` and `x`
+        Δsrc[cart_j] = op(Δsrc[cart_j], x)
+    end
+    return nothing
+end
+
+function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx, 
+            rev_idx, pre_cart_idx, max_dims_idx, max_idx, T::Type{TT}) where {OP,TT}
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        i, j = fldmod1(index, max_dims_idx)
+        cart_i = CartesianIndices(idx)[i]
+        cart_j = pre_cart_idx[j]
+        # get aggregating indeices, which is to be aggregated together, and itself index
+        inds = rev_idx[idx[cart_i]...]
+        # multiply all values to be aggregated but not itself
+        x = one(T)
+        for k in inds
+            jk = Base._to_linear_index(src, Tuple(cart_j)..., Tuple(k)...)
+            x *= src[jk]
+        end
+        x /= src[index]
+        # apply `op` on `Δsrc[i, k]` and `x`
+        Δsrc[index] = op(Δsrc[index], x)
+    end
+    return nothing
+end
+
+function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx::CUDA.CuDeviceArray{<:CartesianIndex},
+                rev_idx, pre_cart_idx, max_dims_idx, max_idx, T::Type{TT}) where {OP,TT}
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        i, j = fldmod1(index, max_dims_idx)
+        cart_i = CartesianIndices(idx)[i]
+        cart_j = pre_cart_idx[j]
+        # get aggregating indeices, which is to be aggregated together, and itself index
+        inds = rev_idx[Tuple(idx[cart_i])...]
+        # multiply all values to be aggregated but not itself
+        x = one(T)
+        for k in inds
+            jk = Base._to_linear_index(src, Tuple(cart_j)..., Tuple(k)...)
+            x *= src[jk]
+        end
+        x /= src[index]
+        # apply `op` on `Δsrc[i, k]` and `x`
+        Δsrc[index] = op(Δsrc[index], x)
+    end
+    return nothing
+end
+
+function NNlib.∇scatter_src(op::Union{typeof(*),typeof(/)}, Δ, dst,
+                            src::AnyCuArray{Tsrc,Nsrc}, 
+                            idx::AnyCuArray{Tidx,Nidx}) where {Tsrc,Tidx,Nsrc,Nidx}
+    dims = Nsrc - Nidx
+    Δsrc = NNlib.modify_src(op, NNlib.gather(Δ, idx), src)
+    rev_idx = NNlib.reverse_indices(idx)
+    rev_idx = CuArray(map(CUDA.cudaconvert, rev_idx))
+    
+    if dims == 0
+        max_idx = length(idx)
+        args = op, Δsrc, src, idx, rev_idx, max_idx, Tsrc
+    else
+        pre_cart_idx = CartesianIndices(axes(src)[1:dims])
+        max_dims_idx = length(pre_cart_idx)
+        max_idx = max_dims_idx * length(idx)
+        args = op, Δsrc, src, idx, rev_idx, pre_cart_idx, max_dims_idx, max_idx, Tsrc
+    end
+
+    kernel = @cuda launch=false ∇scatter_src_kernel!(args...)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(max_idx, config.threads)
+    blocks = cld(max_idx, threads)
+    kernel(args...; threads=threads, blocks=blocks)
+
+    CUDA.unsafe_free!(rev_idx)
+    return Δsrc
+end

--- a/ext/NNlibCUDA/src/upsample.jl
+++ b/ext/NNlibCUDA/src/upsample.jl
@@ -1,0 +1,361 @@
+#
+# Upsampling
+#
+
+# GPU based bilinear upsampling including its gradient
+#
+# Based on the Caffe2 implementation at:
+# The code is a translation from the following files:
+# - https://github.com/pytorch/pytorch/blob/v1.8.0-rc1/caffe2/operators/upsample_op.cu
+# - https://github.com/pytorch/pytorch/blob/v1.8.0-rc1/caffe2/core/common_gpu.h
+#
+# Copyright (c) 2016-2021 Facebook Inc.
+# Copyright (c) 2015 Google Inc.
+# Copyright (c) 2015 Yangqing Jia
+# Copyright 2019-2020 Kakao Brain
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+#    conditions and the following disclaimer in the documentation and/or other materials
+#    provided with the distribution.
+#
+# 3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America and
+#    IDIAP Research Institute nor the names of its contributors may be used to endorse or
+#    promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Forward and backward pass have been tested to produce the same output
+# as pytorch with align_corners=True - it works modulo bit noise.
+# pytorch's default is align_corners=False, because otherwise the gradients depend on the
+# image size, which should be avoided -> this should be considered here as well
+
+@inline function compute_source_index(ratio::T, dst_index, align_corners) where T
+    if align_corners
+        return ratio*dst_index
+    else
+        src_idx = ratio * (dst_index + T(0.5)) - T(0.5)
+        return max(zero(T), src_idx)
+    end
+end
+
+function NNlib.upsample_linear_kernel!(y::CuArray{T,N}, x::CuArray{T,N}; align_corners=true) where {T,N}
+    out_size = prod(size(y)[1:N-2])
+
+    if align_corners
+        ratios = ntuple(i -> T((size(x,i)-1) / (size(y,i)-1)), N-2)
+    else
+        ratios = ntuple(i -> T(size(x,i) / size(y,i)), N-2)
+    end
+
+    kernel = @cuda launch=false upsample_linear_cuda_kernel!(out_size, ratios..., x, y, align_corners)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = Base.min(out_size, config.threads)
+    blocks = cld(out_size, threads)
+    kernel(out_size, ratios..., x, y, align_corners; threads=threads, blocks=blocks)
+    return y
+end
+
+function NNlib.∇upsample_linear_kernel!(dx::CuArray{T,N}, Δ::CuArray{T,N}; align_corners=true) where {T,N}
+    in_size = prod(size(Δ)[1:N-2])
+
+    if align_corners
+        ratios = ntuple(i -> T((size(dx,i)-1) / (size(Δ,i)-1)), N-2)  # reversed compared to forward pass
+    else
+        ratios = ntuple(i -> T(size(dx,i) / size(Δ,i)), N-2)
+    end
+
+    kernel = @cuda launch=false ∇upsample_linear_cuda_kernel!(in_size, ratios..., Δ, dx, align_corners)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = Base.min(in_size, config.threads)
+    blocks = cld(in_size, threads)
+    kernel(in_size, ratios..., Δ, dx, align_corners; threads=threads, blocks=blocks)
+    return dx
+end
+
+
+###########
+# linear
+###########
+function upsample_linear_cuda_kernel!(n_elem, rwidth, x::CuDeviceArray{<:Any, 3}, y::CuDeviceArray{<:Any, 3}, align_corners)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+
+    if index < n_elem
+        in_w, channels, batchsize = size(x)
+        out_w, _, _ = size(y)
+
+        ow = index % out_w
+
+        # real_index = rwidth*ow
+        real_index = compute_source_index(rwidth, ow, align_corners)
+        iw0 = Base.floor(Int, real_index)
+        offset = (iw0 < in_w-1) ? 1 : 0
+        iw1 = iw0 + offset + 1
+        w1lambda = real_index - iw0
+        w0lambda = 1 - w1lambda
+        iw0 += 1
+
+        @inbounds for n in 1:batchsize
+            for c in 1:channels
+                val = (w0lambda * x[iw0, c, n]  + # w0 * i00
+                       w1lambda * x[iw1, c, n])   # w1 * i01
+                y[ow+1, c, n] = val
+            end
+        end
+    end
+    return nothing
+end
+
+# Δ is the gradient backpropagated from downstream layers
+function ∇upsample_linear_cuda_kernel!(n_elem, rwidth, Δ::CuDeviceArray{<:Any, 3}, dx::CuDeviceArray{<:Any, 3}, align_corners)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+
+    if index < n_elem
+        in_width, channels, batchsize = size(Δ)
+        out_width, _, _ = size(dx)
+
+        iw = index % in_width
+
+        # real_index_w = rwidth * iw
+        real_index_w = compute_source_index(rwidth, iw, align_corners)
+        ow0 = Base.floor(Int, real_index_w)
+        offset = (ow0 < out_width - 1) ? 1 : 0
+        ow1 = ow0 + offset + 1
+        w1lambda = real_index_w - ow0
+        w0lambda = 1 - w1lambda
+        ow0 += 1
+
+        @inbounds for n in 1:batchsize
+            for c in 1:channels
+                val = Δ[iw+1, c, n]
+                CUDA.@atomic dx[ow0, c, n] += w0lambda * val
+                CUDA.@atomic dx[ow1, c, n] += w1lambda * val
+            end
+        end
+    end # if
+    return nothing
+end
+
+
+###########
+# bilinear
+###########
+function upsample_linear_cuda_kernel!(n_elem, rwidth, rheight, x::CuDeviceArray{<:Any, 4}, y::CuDeviceArray{<:Any, 4}, align_corners)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+
+    if index < n_elem
+        in_w, in_h, channels, batchsize = size(x)
+        out_w, out_h, _, _ = size(y)
+
+        ow = index % out_w
+        oh = index ÷ out_w
+
+        # real_index = rheight*oh
+        real_index = compute_source_index(rheight, oh, align_corners)
+        ih0 = Base.floor(Int, real_index)
+        offset = (ih0 < in_h-1) ? 1 : 0
+        ih1 = ih0 + offset + 1
+        h1lambda = real_index - ih0
+        h0lambda = 1 - h1lambda
+        ih0 += 1
+
+        # real_index = rwidth*ow
+        real_index = compute_source_index(rwidth, ow, align_corners)
+        iw0 = Base.floor(Int, real_index)
+        offset = (iw0 < in_w-1) ? 1 : 0
+        iw1 = iw0 + offset + 1
+        w1lambda = real_index - iw0
+        w0lambda = 1 - w1lambda
+        iw0 += 1
+
+        @inbounds for n in 1:batchsize
+            for c in 1:channels
+                val = h0lambda * (w0lambda * x[iw0, ih0, c, n]  + # h0 * w0 * i00
+                                  w1lambda * x[iw1, ih0, c, n]) + # h0 * w1 * i01
+                      h1lambda * (w0lambda * x[iw0, ih1, c, n]  + # h1 * w0 * i10
+                                  w1lambda * x[iw1, ih1, c, n])   # h1 * w1 * i11
+                y[ow+1, oh+1, c, n] = val
+            end
+        end
+    end
+    return nothing
+end
+
+# Δ is the gradient backpropagated from downstream layers
+function ∇upsample_linear_cuda_kernel!(n_elem, rwidth, rheight, Δ::CuDeviceArray{<:Any, 4}, dx::CuDeviceArray{<:Any, 4}, align_corners)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+
+    if index < n_elem
+        in_width, in_height, channels, batchsize = size(Δ)
+        out_width, out_height, _, _ = size(dx)
+
+        iw = index % in_width
+        ih = index ÷ in_width
+
+        # Compute Y axis lambdas
+        # real_index_h = rheight*ih
+        real_index_h = compute_source_index(rheight, ih, align_corners)
+        oh0 = Base.floor(Int, real_index_h)
+        offset = (oh0 < out_height-1) ? 1 : 0
+        oh1 = oh0 + offset + 1
+        h1lambda = real_index_h - oh0
+        h0lambda = 1 - h1lambda
+        oh0 += 1
+
+        # # Compute X axis lambdas
+        # real_index_w = rwidth * iw
+        real_index_w = compute_source_index(rwidth, iw, align_corners)
+        ow0 = Base.floor(Int, real_index_w)
+        offset = (ow0 < out_width - 1) ? 1 : 0
+        ow1 = ow0 + offset + 1
+        w1lambda = real_index_w - ow0
+        w0lambda = 1 - w1lambda
+        ow0 += 1
+
+        @inbounds for n in 1:batchsize
+            for c in 1:channels
+                val = Δ[iw+1, ih+1, c, n]
+                CUDA.@atomic dx[ow0, oh0, c, n] += h0lambda * w0lambda * val
+                CUDA.@atomic dx[ow1, oh0, c, n] += h0lambda * w1lambda * val
+                CUDA.@atomic dx[ow0, oh1, c, n] += h1lambda * w0lambda * val
+                CUDA.@atomic dx[ow1, oh1, c, n] += h1lambda * w1lambda * val
+            end
+        end
+    end # if
+    return nothing
+end
+
+
+###########
+# trilinear
+###########
+function upsample_linear_cuda_kernel!(n_elem, rwidth, rheight, rdepth, x::CuDeviceArray{<:Any, 5}, y::CuDeviceArray{<:Any, 5}, align_corners)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+
+    if index < n_elem
+        in_w, in_h, in_d, channels, batchsize = size(x)
+        out_w, out_h, out_d, _, _ = size(y)
+
+        ow = (index % (out_w * out_h)) % out_w
+        oh = (index % (out_w * out_h)) ÷ out_w
+        od = index ÷ (out_w * out_h)
+
+        # real_index = rwidth*ow
+        real_index = compute_source_index(rwidth, ow, align_corners)
+        iw0 = Base.floor(Int, real_index)
+        offset = (iw0 < in_w-1) ? 1 : 0
+        iw1 = iw0 + offset + 1
+        w1lambda = real_index - iw0
+        w0lambda = 1 - w1lambda
+        iw0 += 1
+
+        # real_index = rheight*oh
+        real_index = compute_source_index(rheight, oh, align_corners)
+        ih0 = Base.floor(Int, real_index)
+        offset = (ih0 < in_h-1) ? 1 : 0
+        ih1 = ih0 + offset + 1
+        h1lambda = real_index - ih0
+        h0lambda = 1 - h1lambda
+        ih0 += 1
+
+        # real_index = rdepth*od
+        real_index = compute_source_index(rdepth, od, align_corners)
+        id0 = Base.floor(Int, real_index)
+        offset = (id0 < in_d-1) ? 1 : 0
+        id1 = id0 + offset + 1
+        d1lambda = real_index - id0
+        d0lambda = 1 - d1lambda
+        id0 += 1
+
+        @inbounds for n in 1:batchsize
+            for c in 1:channels
+                val = d0lambda *
+                         (h0lambda *
+                           (w0lambda * x[iw0, ih0, id0, c, n]  +
+                            w1lambda * x[iw1, ih0, id0, c, n]) +
+                          h1lambda *
+                           (w0lambda * x[iw0, ih1, id0, c, n]   +
+                            w1lambda * x[iw1, ih1, id0, c, n])) +
+                      d1lambda *
+                         (h0lambda *
+                           (w0lambda * x[iw0, ih0, id1, c, n]  +
+                            w1lambda * x[iw1, ih0, id1, c, n]) +
+                          h1lambda *
+                           (w0lambda * x[iw0, ih1, id1, c, n] +
+                            w1lambda * x[iw1, ih1, id1, c, n]))
+
+                y[ow+1, oh+1, od+1, c, n] = val
+            end
+        end
+    end
+    return nothing
+end
+
+# Δ is the gradient backpropagated from downstream layers
+function ∇upsample_linear_cuda_kernel!(n_elem, rwidth, rheight, rdepth, Δ::CuDeviceArray{<:Any, 5}, dx::CuDeviceArray{<:Any, 5}, align_corners)
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+
+    if index < n_elem
+        in_width, in_height, in_depth, channels, batchsize = size(Δ)
+        out_width, out_height, out_depth, _, _ = size(dx)
+
+        iw = (index % (in_height * in_width)) % in_width
+        ih = (index % (in_height * in_width)) ÷ in_width
+        id = index ÷  (in_height * in_width)
+
+        real_index_w = compute_source_index(rwidth, iw, align_corners)
+        ow0 = Base.floor(Int, real_index_w)
+        offset = (ow0 < out_width - 1) ? 1 : 0
+        ow1 = ow0 + offset + 1
+        w1lambda = real_index_w - ow0
+        w0lambda = 1 - w1lambda
+        ow0 += 1
+
+        real_index_h = compute_source_index(rheight, ih, align_corners)
+        oh0 = Base.floor(Int, real_index_h)
+        offset = (oh0 < out_height-1) ? 1 : 0
+        oh1 = oh0 + offset + 1
+        h1lambda = real_index_h - oh0
+        h0lambda = 1 - h1lambda
+        oh0 += 1
+
+        real_index_d = compute_source_index(rdepth, id, align_corners)
+        od0 = Base.floor(Int, real_index_d)
+        offset = (od0 < out_depth-1) ? 1 : 0
+        od1 = od0 + offset + 1
+        d1lambda = real_index_d - od0
+        d0lambda = 1 - d1lambda
+        od0 += 1
+
+        @inbounds for n in 1:batchsize
+            for c in 1:channels
+                val = Δ[iw+1, ih+1, id+1, c, n]
+                CUDA.@atomic dx[ow0, oh0, od0, c, n] += w0lambda * h0lambda * d0lambda * val
+                CUDA.@atomic dx[ow1, oh0, od0, c, n] += w1lambda * h0lambda * d0lambda * val
+                CUDA.@atomic dx[ow0, oh1, od0, c, n] += w0lambda * h1lambda * d0lambda * val
+                CUDA.@atomic dx[ow1, oh1, od0, c, n] += w1lambda * h1lambda * d0lambda * val
+
+                CUDA.@atomic dx[ow0, oh0, od1, c, n] += w0lambda * h0lambda * d1lambda * val
+                CUDA.@atomic dx[ow1, oh0, od1, c, n] += w1lambda * h0lambda * d1lambda * val
+                CUDA.@atomic dx[ow0, oh1, od1, c, n] += w0lambda * h1lambda * d1lambda * val
+                CUDA.@atomic dx[ow1, oh1, od1, c, n] += w1lambda * h1lambda * d1lambda * val
+            end
+        end
+    end # if
+    return nothing
+end

--- a/ext/NNlibCUDA/src/utils.jl
+++ b/ext/NNlibCUDA/src/utils.jl
@@ -1,0 +1,36 @@
+NNlib._rng_from_array(::CuArray) = CUDA.default_rng()
+
+NNlib._rng_compat_array(rng::CUDA.RNG, A::CuArray) = nothing
+NNlib._rng_compat_array(rng::AbstractRNG, A::CuArray) = throw(ArgumentError(
+    "cannot use rng::$(typeof(rng)) with array::CuArray, only CUDA's own RNG type works"))
+
+function divide_kernel!(xs, ys, max_idx)
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        xs[index] = xs[index] / ys[index]
+    end
+    return nothing
+end
+
+function divide_kernel!(xs, counts, max_idx, max_dims_idx, dims_size)
+    index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+    @inbounds if index <= max_idx
+        j, k = divrem(index-1, max_dims_idx)
+        dims_i = Tuple(CartesianIndices(dims_size)[k+1])
+        CUDA.@atomic xs[dims_i..., j+1] = xs[dims_i..., j+1] / counts[j+1]
+    end
+    return nothing
+end
+
+function NNlib.reverse_indices(idx::AnyCuArray{<:Any,N}) where N
+    max_dims = NNlib.maximum_dims(idx)
+    T = CartesianIndex{N}
+    rev = Array{Vector{T}}(undef, max_dims...)
+    for i in eachindex(rev)
+        rev[i] = T[]
+    end
+    NNlib.reverse_indices!(rev, idx)
+    return map(cu, rev)
+end

--- a/ext/NNlibCUDA/test/activations.jl
+++ b/ext/NNlibCUDA/test/activations.jl
@@ -1,0 +1,43 @@
+@testset "activation broadcast" begin
+    for f in NNlib.ACTIVATIONS
+        if f ∉ [:rrelu]
+            @eval gputest(x -> $f.(x), rand(Float64, 5))
+        end
+    end
+end
+
+@testset "forward diff" begin
+    for f in NNlib.ACTIVATIONS
+        if f ∉ [:rrelu]
+            @eval gputest(x -> $f.(x), Dual.(rand(5), 1))
+        end
+    end
+end
+
+# Broadcasting over complex CuArray works without NNlibCUDA, this test checks that
+# NNlibCUDA does not cause such operations to take a fast path which does not support
+# complex numbers (e.g. cuDNN)
+@testset "complex" begin
+    f(x) = tanh.(x)
+    cs = rand(ComplexF64, 5)
+    @test f(cs) ≈ collect(f(CuArray(cs)))
+end
+
+@testset "softplus" begin 
+  # softplus does not give `Inf` for large arguments
+   x = CuArray([1000.])
+   @test all(softplus.(x) .== x)
+end
+
+@testset "input is preserved" begin
+    x = CUDA.ones(1)
+    @test Array(x) == [1f0]
+    tanh.(x)
+    @test Array(x) == [1f0]
+    y = tanh.(x)
+    @test Array(x) == [1f0]
+    @test Array(y) == [tanh(1f0)]
+    x .= tanh.(y)
+    @test Array(y) == [tanh(1f0)]
+    @test Array(x) == [tanh(tanh(1f0))]
+end

--- a/ext/NNlibCUDA/test/batchedadjtrans.jl
+++ b/ext/NNlibCUDA/test/batchedadjtrans.jl
@@ -1,0 +1,44 @@
+function print_array_strs(x)
+    str = sprint((io, x)->show(io, MIME"text/plain"(), x), x)
+    return @view split(str, '\n')[2:end]
+end
+
+@testset "BatchedAdjOrTrans" begin
+    x = randn(Float32, 3,4,2)
+    y = cu(x)
+
+    bax = batched_adjoint(x)
+    btx = batched_transpose(x)
+    bay = batched_adjoint(y)
+    bty = batched_transpose(y)
+
+    @test sprint(show, bax) == sprint(show, bay)
+    @test sprint(show, btx) == sprint(show, bty)
+
+    @test print_array_strs(bax) == print_array_strs(bay)
+    @test print_array_strs(btx) == print_array_strs(bty)
+
+    @test Array(bax) == Array(bay)
+    @test collect(bax) == collect(bay)
+    @test Array(btx) == Array(bty)
+    @test collect(btx) == collect(bty)
+    
+    for shape in (:, (12, 2))
+        rbax = reshape(bax, shape)
+        rbtx = reshape(btx, shape)
+        rbay = reshape(bay, shape)
+        rbty = reshape(bty, shape)
+
+        @test sprint(show, rbax) == sprint(show, rbay)
+        @test sprint(show, rbtx) == sprint(show, rbty)
+    
+        @test print_array_strs(rbax) == print_array_strs(rbay)
+        @test print_array_strs(rbtx) == print_array_strs(rbty)
+    
+        @test Array(rbax) == Array(rbay)
+        @test collect(rbax) == collect(rbay)
+        @test Array(rbtx) == Array(rbty)
+        @test collect(rbtx) == collect(rbty)
+    end
+
+end

--- a/ext/NNlibCUDA/test/batchedmul.jl
+++ b/ext/NNlibCUDA/test/batchedmul.jl
@@ -1,0 +1,56 @@
+@testset "batched_mul" begin
+    using NNlib: batched_mul, batched_mul!, batched_vec, 
+                 batched_adjoint, batched_transpose
+
+    A = randn(Float32, 3,3,2);
+    B = randn(Float32, 3,3,2);
+
+    C = batched_mul(A, B)
+    @test CuArray(C) ≈ batched_mul(CuArray(A), CuArray(B))
+
+    Ct = batched_mul(batched_transpose(A), B)
+    @test CuArray(Ct) ≈ batched_mul(batched_transpose(CuArray(A)), CuArray(B))
+
+    Ca = batched_mul(A, batched_adjoint(B))
+    @test CuArray(Ca) ≈ batched_mul(CuArray(A), batched_adjoint(CuArray(B)))
+
+    # 5-arg batched_mul!
+    C .= pi
+    batched_mul!(C, A, B, 2f0, 3f0)
+    cuCpi = CuArray(similar(C)) .= pi
+    @test CuArray(C) ≈ batched_mul!(cuCpi, CuArray(A), CuArray(B), 2f0, 3f0)
+
+    # PermutedDimsArray
+    @test CuArray(Ct) ≈ batched_mul(PermutedDimsArray(CuArray(A), (2,1,3)), CuArray(B))
+
+    D = permutedims(B, (1,3,2))
+    Cp = batched_mul(batched_adjoint(A), B)
+    @test CuArray(Cp) ≈ batched_mul(batched_adjoint(CuArray(A)), PermutedDimsArray(CuArray(D), (1,3,2)))
+
+    # Methods which reshape
+    M = randn(Float32, 3,3)
+
+    Cm = batched_mul(A, M)
+    @test CuArray(Cm) ≈ batched_mul(CuArray(A), CuArray(M))
+
+    Cv = batched_vec(permutedims(A,(3,1,2)), M)
+    @test CuArray(Cv) ≈ batched_vec(PermutedDimsArray(CuArray(A),(3,1,2)), CuArray(M))
+end
+
+@testset "NNlib storage_type etc." begin
+    using LinearAlgebra
+    using NNlib: is_strided, are_strided, storage_type
+
+    M = cu(ones(10,10))
+
+    @test is_strided(M)
+    @test is_strided(view(M, 1:2:5,:))
+    @test is_strided(PermutedDimsArray(M, (2,1)))
+
+    @test !is_strided(reshape(view(M, 1:2:10,:), 10,:))
+    @test !is_strided((M .+ im)')
+    @test !is_strided(Diagonal(cu(ones(3))))
+
+    @test storage_type(M) <: CuArray{Float32,2}
+    @test storage_type(reshape(view(M, 1:2:10,:), 10,:)) <: CuArray{Float32,2}
+end

--- a/ext/NNlibCUDA/test/batchnorm.jl
+++ b/ext/NNlibCUDA/test/batchnorm.jl
@@ -1,0 +1,27 @@
+@testset "Batchnorm" begin
+    v = CUDA.rand(Float32, 2)
+    m = CUDA.rand(Float32, 2, 5)
+
+    @testset for training in (true, false), track_stats in (true, false)
+        kws = (training=training, track_stats=track_stats)
+
+        # Normal
+        NNlibCUDA.batchnorm(v, v, m, v, v, 1.0; kws...)
+        NNlibCUDA.∇batchnorm(v, v, m, m, v, v, 1.0; kws...)
+
+        # No affine
+        NNlibCUDA.batchnorm(nothing, nothing, m, v, v, 1.0; kws...)
+        NNlibCUDA.∇batchnorm(nothing, nothing, m, m, v, v, 1.0; kws...)
+
+        # No tracking
+        NNlibCUDA.batchnorm(v, v, m, nothing, nothing, 1.0; kws...)
+        NNlibCUDA.∇batchnorm(v, v, m, m, nothing, nothing, 1.0; kws...)
+
+        # Both or neither tracked or affine params must be set
+        for (α, β) in ((v, nothing), (nothing, v))
+            @test_throws MethodError NNlibCUDA.batchnorm(α, β, m, v, v, 1.0; kws...)
+            @test_throws MethodError NNlibCUDA.∇batchnorm(α, β, m, m, v, v, 1.0; kws...)
+            @test_throws ArgumentError NNlibCUDA.batchnorm(v, v, m, α, β, 1.0; kws...)
+        end
+    end 
+end

--- a/ext/NNlibCUDA/test/conv.jl
+++ b/ext/NNlibCUDA/test/conv.jl
@@ -1,0 +1,64 @@
+using NNlib: DenseConvDims
+
+@testset "convolution" begin
+    a, b, c = rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4), rand(Float64, 9, 9, 4, 1)
+    da, db, dc = CuArray(a), CuArray(b), CuArray(c)
+    cdims = DenseConvDims(a, b)
+    @test NNlib.conv(a, b, cdims) ≈ collect(NNlib.conv(da, db, cdims))
+    @test ∇conv_data(c, b, cdims) ≈ collect(∇conv_data(dc, db, cdims))
+    @test ∇conv_filter(a, c, cdims) ≈ collect(∇conv_filter(da, dc, cdims))
+
+    # Test Conv Bias Activation
+    bias = rand(Float64, 1, 1, 4, 1)
+    dbias = CuArray(bias)
+    @test conv_bias_act(a, b, cdims, bias, NNlib.relu) ≈ collect(conv_bias_act(da, db, cdims, dbias, NNlib.relu))
+    @test conv_bias_act(a, b, cdims, bias, identity) ≈ collect(conv_bias_act(da, db, cdims, dbias, identity))
+
+    # Test for agreement between CPU NNlib and CuDNN versions, across a variety of kwargs
+    options = Dict{Any, Any}.((
+        (), (:dilation => 2), (:flipkernel => true), (:stride => 2),
+        (:padding => 1),
+        (:padding => (1,0)),
+        (:padding => (0,1)),
+        (:padding => (2,3)),
+    ))
+    C_in_ = 3
+    C_out = 4
+    batch_size = 1
+
+    for groups in (1, 2, 4), num_spatial_dims in (1, 2, 3)
+        # Make `C_in = C_out` when using grouped convolution.
+        C_in = groups == 1 ? C_in_ : C_out
+        # Initialize data we'll run our tests over
+        x = rand(Float64, fill(8, num_spatial_dims)..., C_in, batch_size)
+        w = rand(Float64, fill(2, num_spatial_dims)..., C_in ÷ groups, C_out)
+
+        for opts in options
+            opts[:groups] = groups
+            
+            if :padding in keys(opts)
+                padding = opts[:padding]
+                if 1 < length(padding) && length(padding) != 2num_spatial_dims
+                    opts[:padding] = ntuple(i -> padding[mod1(i,2)] .+ 2div(i-1,2), 2num_spatial_dims)   
+                end
+            end
+
+            cdims = DenseConvDims(x, w; opts...)
+            y = NNlib.conv(x, w, cdims)
+
+            # Test that basic convolution is equivalent across GPU/CPU
+            gputest((x, w) -> NNlib.conv(x, w, cdims), x, w)
+            gputest((y, w) -> NNlib.∇conv_data(y, w, cdims), y, w)
+            gputest((x, y) -> NNlib.∇conv_filter(x, y, cdims), x, y, checkgrad=false) # TODO fix grad
+
+            # Scaling factors
+            gputest((x, w) -> NNlib.conv(x, w, cdims; alpha=2.0), x, w, checkgrad=false) # TODO
+            gputest((y, w) -> NNlib.∇conv_data(y, w, cdims; alpha=2.0), y, w, checkgrad=false) # TODO
+            gputest((x, y) -> NNlib.∇conv_filter(x, y, cdims; alpha=2.0), x, y, checkgrad=false) # TODO
+
+            gputest((y, x, w) -> NNlib.conv!(copy(y), x, w, cdims; beta=2.0), y, x, w, checkgrad=false) # TODO
+            # @test_broken gputest((x, y, w) -> NNlib.∇conv_data!(copy(x), y, w, cdims; beta=2.0), x, y, w, checkgrad=false) #TODO
+            gputest((w, x, y) -> NNlib.∇conv_filter!(copy(w), x, y, cdims; beta=2.0), w, x, y, checkgrad=false) # TODO
+        end
+    end
+end

--- a/ext/NNlibCUDA/test/ctc.jl
+++ b/ext/NNlibCUDA/test/ctc.jl
@@ -1,0 +1,55 @@
+using Test
+using NNlib: ctc_loss
+using Zygote: gradient
+using LinearAlgebra
+using CUDA, NNlibCUDA
+
+# Custom function to check numerical gradient of ctc loss,
+# based on `ngradient` in `Tracker.jl`
+function ctc_ngradient(x, y)
+  f = ctc_loss
+  grads = zero(x)
+  for i in 1:length(x)
+    δ = sqrt(eps())
+    tmp = x[i]
+    x[i] = tmp - δ/2
+    y1 = f(x, y)
+    x[i] = tmp + δ/2
+    y2 = f(x, y)
+    x[i] = tmp
+    grads[i] = (y2-y1)/δ
+  end
+  return grads
+end
+
+@testset "ctc-gpu" begin
+  x = rand(10, 50)
+  y = rand(1:9, 30)
+  x_cu = CuArray(x)
+  g1 = gradient(ctc_loss, x_cu, y)[1]
+  g1 = g1 |> collect
+  g2 = ctc_ngradient(x, y)
+  @test g1 ≈ g2 rtol=1e-5 atol=1e-5
+  
+  # test that GPU loss matches CPU implementation
+  l1 = ctc_loss(x_cu, y)
+  l2 = ctc_loss(x, y)
+  @test l1 ≈ l2
+  
+  # tests using hand-calculated values
+  x_cu = [1. 2. 3.; 2. 1. 1.; 3. 3. 2.] |> CuArray
+  y = [1, 2]
+  @test ctc_loss(x_cu, y) ≈ 3.6990738275138035
+  
+  g = [-0.317671 -0.427729 0.665241; 0.244728 -0.0196172 -0.829811; 0.0729422 0.447346 0.16457]
+  ghat = gradient(ctc_loss, x_cu, y)[1] |> collect
+  @test g ≈ ghat rtol=1e-5 atol=1e-5
+
+  x_cu = [-3. 12. 8. 15.; 4. 20. -2. 20.; 8. -33. 6. 5.] |> CuArray
+  y = [1, 2] |> CuArray
+  @test ctc_loss(x_cu, y) ≈ 8.02519869363453
+
+  g = [-2.29294774655333e-06 -0.999662657278862 1.75500863563993e-06 0.00669284889063; 0.017985914969696 0.999662657278861 -1.9907078755387e-06 -0.006693150917307; -0.01798362202195 -2.52019580677916e-20 2.35699239251042e-07 3.02026677058789e-07]
+  ghat = gradient(ctc_loss, x_cu, y)[1] |> collect
+  @test g ≈ ghat rtol=1e-5 atol=1e-5
+end

--- a/ext/NNlibCUDA/test/dropout.jl
+++ b/ext/NNlibCUDA/test/dropout.jl
@@ -1,0 +1,34 @@
+using NNlib, NNlibCUDA, CUDA, Test
+using Zygote, ChainRulesCore
+
+@testset "dropout + CUDA" begin
+    # Basics
+    x1 = CUDA.randn(3, 4)
+    @test size(@inferred dropout(x1, 0.1)) == (3, 4)
+    @test size(@inferred dropout(x1, 0.2; dims=2)) == (3, 4)
+    @test size(@inferred dropout(x1, 0.3; dims=(1,2))) == (3, 4)
+
+    rng =  CUDA.default_rng()
+    @test size(@inferred dropout(rng, x1, 0.1)) == (3, 4)
+    @test size(@inferred dropout(rng, x1, 0.1; dims=2)) == (3, 4)
+
+    # Values
+    d45 = dropout(CUDA.ones(100, 100, 100), 0.45)
+    @test mean(d45) ≈ 1 atol=1e-2
+    dpi2 = dropout(CUDA.fill(1f0 * pi, 1000), 0.2)
+    @test sort(unique(Array(dpi2))) ≈ [0, 5pi/4]
+    d33 = dropout(CUDA.fill(3f0, 10, 1000), 0.3, dims=2)
+    @test sort(unique(vec(Array(d33)))) ≈ [0, 3/(1-0.3)]
+
+    # Gradient rule
+    y, back = rrule(dropout, rng, hcat(CUDA.ones(1000), CUDA.zeros(1000)), 0.45)
+    dx = back(CUDA.fill(3f0, 1000, 2))[3]
+    @test !all(iszero, dx[:,2])  # this is why we save the random choices
+    @test sort(unique(vec(Array(dx)))) ≈ [0, 3/(1-0.45)]
+
+    @testset "Zygote" begin
+        @test Zygote.gradient(x -> sum(dropout(x, 0.3)), x1)[1] isa CuArray{Float32}
+        @test Zygote.gradient(x -> sum(dropout(rng, x, 0.3)), x1)[1] isa CuArray{Float32}
+        @test Zygote.gradient(x -> sum(dropout(x, 0.3, dims=1)), x1)[1] isa CuArray{Float32}
+    end
+end

--- a/ext/NNlibCUDA/test/fold.jl
+++ b/ext/NNlibCUDA/test/fold.jl
@@ -1,0 +1,36 @@
+
+@testset "fold" begin
+    # Test for agreement between CPU/GPU versions, across a variety of kwargs
+    options = Dict{Any, Any}.((
+        (), (:dilation => 2), (:flipkernel => true), (:stride => 2),
+        (:padding => 1),
+        (:padding => (1,0)),
+        (:padding => (0,1)),
+        (:padding => (2,3)),
+    ))
+
+    C_in = 3
+    C_out = 4
+    batch_size = 1
+
+    @testset "spatial_rank=$spatial_rank" for spatial_rank in (1, 2, 3)
+        for opts in options
+            if :padding in keys(opts)
+                padding = opts[:padding]
+                if 1 < length(padding) && length(padding) != 2spatial_rank
+                    opts[:padding] = ntuple(i -> padding[mod1(i,2)] .+ 2div(i-1,2), 2spatial_rank)   
+                end
+            end
+
+            x = rand(Float64, fill(8, spatial_rank)..., C_in, batch_size)
+            w = rand(Float64, fill(2, spatial_rank)..., C_in, C_out)
+            cdims = DenseConvDims(x, w; opts...)
+            y = NNlib.unfold(x, cdims)
+
+            # test equivalence of fold/unfold across GPU/CPU
+            gputest(x -> NNlib.unfold(x, cdims), x) 
+            gputest(y -> NNlib.fold(y, size(x), cdims), y) 
+        end
+    end
+end
+

--- a/ext/NNlibCUDA/test/gather.jl
+++ b/ext/NNlibCUDA/test/gather.jl
@@ -1,0 +1,92 @@
+@testset "gather" begin 
+    T = Float32
+    CT = CuArray{Float32}
+    
+    ## 1d src, 2d index of ints -> 2d output
+    src = CT([3, 4, 5, 6, 7])
+    index = cu([1 2 3 4;
+                4 2 1 3;
+                3 5 5 3])
+    output = CT([3 4 5 6;
+                6 4 3 5;
+                5 7 7 5])
+    
+    y = NNlib.gather(src, index)
+    @test y isa CuArray{Float32,2}
+    @test size(y) == size(index)
+    gputest(src -> NNlib.gather(src, index), src, checkgrad=true)
+    @test NNlib.gather!(CUDA.zeros(T, size(index)...), src, index) == output
+    @test_throws ArgumentError NNlib.gather!(zeros(T, 3, 5), src, index)
+    
+    ## 1d src, 2d index of tuples -> 2d output
+    src = CT([3, 4, 5, 6, 7])
+    index = cu([(1,) (2,) (3,) (4,);
+                (4,) (2,) (1,) (3,);
+                (3,) (5,) (5,) (3,)])
+    output = CT([3 4 5 6;
+                6 4 3 5;
+                5 7 7 5])
+    
+    y = NNlib.gather(src, index)
+    @test y isa CuArray{Float32,2}
+    @test size(y) == size(index)
+    gputest(src -> NNlib.gather(src, index), src, checkgrad=true)
+    @test NNlib.gather!(CUDA.zeros(T, size(index)...), src, index) == output
+    @test_throws ArgumentError NNlib.gather!(zeros(T, 3, 5), src, index)
+    
+    ## 1d src, 2d index of CartesianIndex -> 2d output
+    src = CT([3, 4, 5, 6, 7])
+    index = cu(CartesianIndex.([(1,) (2,) (3,) (4,);
+                (4,) (2,) (1,) (3,);
+                (3,) (5,) (5,) (3,)]))
+    output = CT([3 4 5 6;
+                6 4 3 5;
+                5 7 7 5])
+    
+    y = NNlib.gather(src, index)
+    @test y isa CuArray{Float32,2}
+    @test size(y) == size(index)
+    gputest(src -> NNlib.gather(src, index), src, checkgrad=true)
+    @test NNlib.gather!(CUDA.zeros(T, size(index)...), src, index) == output
+    @test_throws ArgumentError NNlib.gather!(zeros(T, 3, 5), src, index)
+
+    ## 1d src, 3d index of ints -> 3d output
+    src = CT([3, 4, 5, 6, 7])
+    index = cu([1 2 3 4;
+                4 2 1 3;
+                3 5 5 3][:,:,1:1])
+    output = CT([3 4 5 6;
+                6 4 3 5;
+                5 7 7 5][:,:,1:1])
+
+    y = NNlib.gather(src, index)
+    @test y isa CuArray{Float32,3}
+    @test size(y) == size(index)
+    gputest(src -> NNlib.gather(src, index), src, checkgrad=true)
+
+
+    ## 2d src, 2d index of ints -> 3d output
+    src = CT([3 5 7 
+             4 6 8])
+    index = cu([1 2 3;
+                2 2 1;
+                3 1 3])
+
+    output = zeros(T, 2, 3, 3)
+
+    output[:,:,1] = [3 5 7
+                    4 6 8]
+
+    output[:,:,2] = [5 5 3
+                    6 6 4]
+        
+    output[:,:,3] = [7 3 7
+                    8 4 8]
+              
+    y = NNlib.gather(src, index)
+    M = NNlib.typelength(eltype(index))
+    Nsrc = ndims(src)
+    @test y isa CuArray{Float32,3}
+    @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...) 
+    gputest(src -> NNlib.gather(src, index), src, checkgrad=true)
+end

--- a/ext/NNlibCUDA/test/pooling.jl
+++ b/ext/NNlibCUDA/test/pooling.jl
@@ -1,0 +1,19 @@
+@testset "pooling" begin
+
+    # Test for agreement between CPU NNlib and CuDNN versions, across a variety of kwargs
+    for num_spatial_dims in (1, 2, 3)
+        # Initialize data we'll run our tests over
+        C_in = 3
+        batch_size = 1
+        x = rand(Float64, fill(8, num_spatial_dims)..., C_in, batch_size)
+       
+        # Test that pooling is equivalent across GPU/CPU
+        pdims = PoolDims(x, 2)
+        y = maxpool(x, pdims)
+        dy = ones(size(y))
+        gputest(x -> maxpool(x, pdims), x)
+        gputest((dy, y, x) -> ∇maxpool(dy, y, x, pdims), dy, y, x, checkgrad=false)
+        gputest(x -> maxpool(x, pdims), x)
+        gputest((dy, y, x) -> ∇maxpool(dy, y, x, pdims), dy, y, x, checkgrad=false)
+    end
+end

--- a/ext/NNlibCUDA/test/runtests.jl
+++ b/ext/NNlibCUDA/test/runtests.jl
@@ -1,0 +1,26 @@
+using Test
+using NNlib
+using Zygote
+using NNlibCUDA
+using ForwardDiff: Dual
+using Statistics: mean
+using CUDA
+CUDA.allowscalar(false)
+
+@testset "NNlibCUDA" begin
+include("test_utils.jl")
+include("activations.jl")
+include("dropout.jl")
+include("batchedadjtrans.jl")
+include("batchedmul.jl")
+include("upsample.jl")
+include("conv.jl")
+include("ctc.jl")
+include("fold.jl")
+include("pooling.jl")
+include("softmax.jl")
+include("batchnorm.jl")
+include("scatter.jl")
+include("gather.jl")
+include("sampling.jl")
+end

--- a/ext/NNlibCUDA/test/sampling.jl
+++ b/ext/NNlibCUDA/test/sampling.jl
@@ -1,0 +1,53 @@
+@testset "Grid Sampling" begin
+    for T in (Float32, Float64)
+        x = ones(T, (2, 2, 1, 1))
+        grid = Array{T}(undef, 2, 2, 2, 1)
+        grid[:, 1, 1, 1] .= (-1, -1)
+        grid[:, 2, 1, 1] .= (1, -1)
+        grid[:, 1, 2, 1] .= (-1, 1)
+        grid[:, 2, 2, 1] .= (1, 1)
+
+        ∇grid_true = Array{T}(undef, size(grid))
+        ∇grid_true[:, :, 1, 1] = [[0.0, 0.0] [-0.5, 0.0]]
+        ∇grid_true[:, :, 2, 1] = [[0.0, -0.5] [-0.5, -0.5]]
+
+        x_gpu, grid_gpu = CuArray(x), CuArray(grid)
+
+        padding_mode = :zeros
+        y_gpu = grid_sample(x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(y_gpu)
+        @test eltype(y_gpu) == T
+
+        external_grad = CUDA.ones(T, size(y_gpu))
+        ∇input, ∇grid = ∇grid_sample(external_grad, x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(∇input)
+        @test ∇grid_true == collect(∇grid)
+        @test eltype(∇input) == T
+        @test eltype(∇grid) == T
+
+        padding_mode = :border
+        fill!(∇grid_true, 0.0)
+        sampled = grid_sample(x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(sampled)
+        @test eltype(sampled) == T
+
+        ∇input, ∇grid = ∇grid_sample(external_grad, x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(∇input)
+        @test ∇grid_true == collect(∇grid)
+        @test eltype(∇input) == T
+        @test eltype(∇grid) == T
+    end
+end
+
+@testset "Compare grid sampling with NNlib" begin
+    w, h, c, n = 16, 16, 2, 4
+    input = rand(Float64, w, h, c, n)
+    grid = zeros(Float64, 2, w, h, n)
+    @inbounds for xi in 1:w, yi in 1:h, ni in 1:n
+        grid[1, xi, yi, ni] = (xi / w) * 2.0 - 1.0 + 0.01
+        grid[2, xi, yi, ni] = (yi / h) * 2.0 - 1.0
+    end
+    for padding_mode in (:zeros, :border)
+        gputest(grid_sample, input, grid; atol=1e-6, padding_mode=padding_mode)
+    end
+end

--- a/ext/NNlibCUDA/test/scatter.jl
+++ b/ext/NNlibCUDA/test/scatter.jl
@@ -1,0 +1,106 @@
+dsts = Dict(
+    0 => cu([3, 4, 5, 6, 7]),
+    1 => cu([3 3 4 4 5;
+             5 5 6 6 7]),
+)
+srcs = Dict(
+    (0, true) => cu(ones(Int, 3, 4)),
+    (0, false) => cu(ones(Int, 3) * collect(1:4)'),
+    (1, true) => cu(ones(Int, 2, 3, 4)),
+    (1, false) => cu([1, 2] .* reshape(ones(Int, 3) * collect(1:4)', 1,3,4)),
+)
+idxs = [
+    cu([1 2 3 4;
+        4 2 1 3;
+        3 5 5 3]),  # integer index
+    cu([(1,) (2,) (3,) (4,);
+        (4,) (2,) (1,) (3,);
+        (3,) (5,) (5,) (3,)]),  # tuple index
+    cu(CartesianIndex.([(1,) (2,) (3,) (4,);
+        (4,) (2,) (1,) (3,);
+        (3,) (5,) (5,) (3,)])),  # CartesianIndex index
+]
+
+types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}]
+
+
+@testset "scatter" begin
+    for T = types
+        @testset "$(T)" begin
+            @testset "+" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(+, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(+, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+
+            @testset "-" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(-, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(-, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+
+            @testset "max" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(max, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(max, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+
+            @testset "min" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(min, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(min, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+        end
+    end
+
+
+    for T = [CuArray{Float32}, CuArray{Float64}]
+        @testset "$(T)" begin
+            @testset "*" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(*, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(*, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+
+            @testset "/" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(/, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(/, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+
+            @testset "mean" begin
+                for idx = idxs, dims = [0, 1]
+                    mutated = true
+                    gputest((dst, src) -> NNlib.scatter!(mean, dst, src, idx), T(copy(dsts[dims])), T(srcs[(dims, mutated)]), checkgrad=true)
+
+                    mutated = false
+                    gputest(src -> NNlib.scatter(mean, src, idx), T(srcs[(dims, mutated)]), checkgrad=true)
+                end
+            end
+        end
+    end
+end

--- a/ext/NNlibCUDA/test/softmax.jl
+++ b/ext/NNlibCUDA/test/softmax.jl
@@ -1,0 +1,20 @@
+@testset "softmax" begin
+    for (sz, dims) in [((5,), :), ((5,), 1), ((5,5), :), ((5,5), 1), ((5,5), 2), ((5,5,5,5), (2,3)), ((5,5,5,5), (2,4))]
+        x = randn(Float64, sz)
+        dy = randn(Float64, sz)
+
+        y = softmax(x, dims=dims)
+        gputest(softmax, x, dims=dims)
+        gputest(NNlib.∇softmax_data, dy, y; dims=dims)
+
+        y2 = logsoftmax(x, dims=dims)
+        gputest(logsoftmax, x, dims=dims)
+        gputest(NNlib.∇logsoftmax_data, dy, y2; dims=dims)
+
+        # From NNlib 0.8.3, ∇softmax! is not used in the gradient.
+        # But NNlibCUDA still knows how to call cuDNN routines, let's test they agree:
+        @test NNlib.∇softmax_data(dy, y; dims=dims) ≈ collect(∇softmax!(similar(cu(x)), cu(dy), cu(x), cu(y); dims=dims)) atol=1e-4
+        @test NNlib.∇logsoftmax_data(dy, y2; dims=dims) ≈ collect(∇logsoftmax!(similar(cu(x)), cu(dy), cu(x), cu(y2); dims=dims)) atol=1e-4
+        # (Note that ∇softmax! does not depend on x, it's just there to disambiguate from an even older signature.)
+    end
+end

--- a/ext/NNlibCUDA/test/test_utils.jl
+++ b/ext/NNlibCUDA/test/test_utils.jl
@@ -1,0 +1,20 @@
+function gputest(f, xs...; checkgrad=true, atol=1e-10, kws...)
+    cpu_in = xs
+    gpu_in = CuArray.(xs)
+
+    cpu_out = f(cpu_in...; kws...)
+    gpu_out = f(gpu_in...; kws...)
+    @test collect(cpu_out) ≈ collect(gpu_out)
+
+    if checkgrad
+        cpu_grad = gradient((x...) -> sum(f(x...; kws...)), cpu_in...)
+        gpu_grad = gradient((x...) -> sum(f(x...; kws...)), gpu_in...)
+        for (cpu_g, gpu_g) in zip(cpu_grad, gpu_grad)
+            if cpu_g === nothing
+                @test gpu_g === nothing
+            else
+                @test collect(cpu_g) ≈ collect(gpu_g)  atol=atol
+            end
+        end
+    end
+end

--- a/ext/NNlibCUDA/test/upsample.jl
+++ b/ext/NNlibCUDA/test/upsample.jl
@@ -1,0 +1,77 @@
+@testset "Linear upsampling" begin
+    x = Float32.(1:10)[:,:,:]
+    x = cat(x, x; dims=2)
+    x = cat(x, x; dims=3)
+    xgpu = cu(x)
+
+    y_true = Float32.(1:1//2:10)
+    y_true = cat(y_true, y_true; dims=2)
+    y_true = cat(y_true, y_true; dims=3)
+    y_true_gpu = cu(y_true)
+
+    y = upsample_linear(xgpu; size=19)
+    
+    @test size(y) == size(y_true_gpu)
+    @test eltype(y) == Float32
+    @test collect(y) ≈ collect(y_true_gpu)
+
+    gputest(x -> upsample_linear(x, 2), x, atol=1e-5)
+end
+
+@testset "Bilinear upsampling" begin
+    x = Float32[1 2; 3 4][:,:,:,:]
+    x = cat(x,x; dims=3)
+    x = cat(x,x; dims=4)
+    xgpu = cu(x)
+
+    y_true = Float32[ 1//1  4//3   5//3   2//1;
+            7//5 26//15 31//15 12//5;
+            9//5 32//15 37//15 14//5;
+           11//5 38//15 43//15 16//5;
+           13//5 44//15 49//15 18//5;
+            3//1 10//3  11//3   4//1]
+    y_true = cat(y_true,y_true; dims=3)
+    y_true = cat(y_true,y_true; dims=4)
+    y_true_gpu = cu(y_true)
+
+    y = upsample_bilinear(xgpu, (3,2))
+    @test size(y) == size(y_true_gpu)
+    @test eltype(y) == Float32
+    @test collect(y) ≈ collect(y_true_gpu)
+
+    o = CUDA.ones(Float32,6,4,2,1)
+    grad_true = 6*CUDA.ones(Float32,2,2,2,1)
+    @test ∇upsample_bilinear(o; size=(2,2)) ≈ grad_true
+
+    gputest(x -> upsample_bilinear(x, (3, 2)), x, atol=1e-5)
+end
+
+@testset "Trilinear upsampling" begin
+    # Layout: WHDCN, where D is depth
+    # we generate data which is constant along W & H and differs in D
+    # then we upsample along all dimensions
+    x = CUDA.ones(Float32, 3,3,3,1,1)
+    x[:,:,1,:,:] .= 1.
+    x[:,:,2,:,:] .= 2.
+    x[:,:,3,:,:] .= 3.
+
+    y_true = CUDA.ones(Float32, 5,5,5,1,1)
+    y_true[:,:,1,:,:] .= 1.
+    y_true[:,:,2,:,:] .= 1.5
+    y_true[:,:,3,:,:] .= 2.
+    y_true[:,:,4,:,:] .= 2.5
+    y_true[:,:,5,:,:] .= 3.
+
+    y = upsample_trilinear(x; size=(5,5,5))
+
+    @test size(y) == size(y_true)
+    @test eltype(y) == Float32
+    @test collect(y) ≈ collect(y_true)
+
+    # this test only works when align_corners=false
+    # o = CUDA.ones(Float32,8,8,8,1,1)
+    # grad_true = 8*CUDA.ones(Float32,4,4,4,1,1)
+    # @test ∇upsample_trilinear(o; size=(4,4,4)) ≈ grad_true
+
+    gputest(x -> upsample_trilinear(x, (2,2,2)), x, atol=1e-5)
+end


### PR DESCRIPTION
As part of the process of turning NNlibCUDA into a package extension, we need to first move the source into this repo while preserving its history. Without doing so, we [wouldn't be able to](https://github.com/JuliaRegistries/General/pull/73409) re-register it as a subpackage. To that end, I've followed the procedure described in https://github.com/JuliaPlots/Plots.jl/pull/4419#issuecomment-1266604686 to place it under `ext/NNlibCUDA`. Once this is done and registered, https://github.com/FluxML/NNlib.jl/pull/445 can be redone on top of this foundation.

### PR Checklist

- [N/A] Tests are added
- [N/A] Documentation, if applicable
