### PR TITLE
Add dropout & attention tests for AMDGPU

### DIFF
--- a/test/amd/attention.jl
+++ b/test/amd/attention.jl
@@ -1,0 +1,42 @@
+@testset "Compare CPU & GPU" begin
+    n = 15
+    lenq = 3
+    lenkv = 4
+    for batch_size in [(), 1, 2, (2, 1, 3)], nheads in [1, 3, 5]
+        q = AMDGPU.rand(Float32, n, lenq, batch_size...)
+        k = AMDGPU.rand(Float32, n, lenkv, batch_size...)
+        v = AMDGPU.rand(Float32, n, lenkv, batch_size...)
+        y, α = @inferred dot_product_attention(q, k, v; nheads)
+
+        @test y isa ROCArray{Float32}
+        @test size(y) == (n, lenq, batch_size...)
+        @test size(α) == (lenkv, lenq, nheads, batch_size...)
+        @test sum(Array(α), dims=1) ≈ ones(1, lenq, nheads, batch_size...)
+
+        qh = rand(Float32, n, lenq, batch_size...)
+        kh = rand(Float32, n, lenkv, batch_size...)
+        vh = rand(Float32, n, lenkv, batch_size...)
+        gputest(
+            (x...) -> dot_product_attention(x...; nheads)[1], qh, kh, vh;
+            atol=1f-5)
+    end
+end
+
+@testset "Mask" begin
+    x = AMDGPU.rand(Float32, 4, 2, 3, 1)
+    mask = make_causal_mask(x, dims=3)
+    @test mask isa ROCArray{Bool}
+    α = dot_product_attention_scores(x, x; mask)
+
+    α_host, mask_host = Array.((α, mask))
+    @test all((α_host[:, :, 1, 1] .> 0) .== mask_host)
+    @test all((α_host[:, :, 2, 1] .> 0) .== mask_host)
+end
+
+@testset "Dropout" begin
+    q = k = v = AMDGPU.rand(Float32, 10, 10, 10)
+    fdrop(x, p) = (rand!(similar(x)) .> p) .* x ./ (1-p)
+    y, α = dot_product_attention(
+        q, k, v; nheads=2, fdrop=x -> dropout(x, 0.5))
+    @test 0.6 > mean(>(0), α) > 0.4
+end

--- a/test/amd/dropout.jl
+++ b/test/amd/dropout.jl
@@ -1,0 +1,20 @@
+@testset "Test API" begin
+    x = AMDGPU.randn(Float32, 3, 4)
+    @test size(@inferred dropout(x, 0.1)) == (3, 4)
+    @test size(@inferred dropout(x, 0.2; dims=2)) == (3, 4)
+    @test size(@inferred dropout(x, 0.3; dims=(1, 2))) == (3, 4)
+
+    rng = AMDGPU.rocRAND.default_rng()
+    @test size(@inferred dropout(rng, x, 0.1)) == (3, 4)
+    @test size(@inferred dropout(rng, x, 0.1; dims=2)) == (3, 4)
+
+    # Values
+    d45 = dropout(AMDGPU.ones(100, 100, 100), 0.45)
+    @test mean(d45) ≈ 1 atol=1e-2
+    dpi2 = dropout(AMDGPU.fill(1f0 * pi, 1000), 0.2)
+    @test sort(unique(Array(dpi2))) ≈ [0, 5 * pi / 4]
+    d33 = dropout(AMDGPU.fill(3f0, 10, 1000), 0.3, dims=2)
+    @test sort(unique(vec(Array(d33)))) ≈ [0, 3 / (1 - 0.3)]
+
+    @test Zygote.gradient(x -> sum(dropout(x, 0.1)), x)[1] isa ROCArray{Float32}
+end

--- a/test/amd/runtests.jl
+++ b/test/amd/runtests.jl
@@ -52,3 +52,11 @@ end
 @testset "Activations" begin
     include("activations.jl")
 end
+
+@testset "Dropout" begin
+    include("dropout.jl")
+end
+
+@testset "Attention" begin
+    include("attention.jl")
+end

--- a/test/attention.jl
+++ b/test/attention.jl
@@ -36,7 +36,7 @@ end
 @testset "mask" begin
     q = rand(4, 2, 3, 1)
     k = rand(4, 2, 5, 1)
-    
+
     mask = rand(Bool, (5, 3))
     α = dot_product_attention_scores(q, k; mask)
     @test all((α[:,:,1,1].> 0) .== mask)
@@ -53,7 +53,7 @@ end
 
 @testset "dropout" begin
     q = k = v = rand(10, 10, 10)
-    fdrop(x, p) = (rand!(similar(x)) .> p) .* x ./ (1-p) 
+    fdrop(x, p) = (rand!(similar(x)) .> p) .* x ./ (1-p)
     y, α = dot_product_attention(q, k, v; nheads=2, fdrop = x -> fdrop(x, 0.5))
     @test 0.6 > mean(>(0), α) > 0.4
 end
@@ -63,7 +63,7 @@ end
     k = v = rand(4, 3, 1)
     bias = randn(3, 5)
     y, α = dot_product_attention(q, k, v, bias; nheads=2)
-    @test size(α) == (3, 5, 2, 1) 
+    @test size(α) == (3, 5, 2, 1)
     @test size(y) == (4, 5, 1)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ include("test_utils.jl")
     if get(ENV, "NNLIB_TEST_AMDGPU", "false") == "true"
         using AMDGPU
         if AMDGPU.functional() && AMDGPU.functional(:MIOpen)
+            AMDGPU.versioninfo()
             @testset "AMDGPU" begin
                 include("amd/runtests.jl")
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ include("test_utils.jl")
         using AMDGPU
         if AMDGPU.functional() && AMDGPU.functional(:MIOpen)
             AMDGPU.versioninfo()
+            @show AMDGPU.MIOpen.version()
             @testset "AMDGPU" begin
                 include("amd/runtests.jl")
             end


### PR DESCRIPTION
- Add tests for dropout & attention for AMDGPU extension.
- Add more detailed error messages. Instead of saying that, for example, batch size is incorrect we can also print the values itself, since this is the natural next question.
- Minor refactor (remove trailing spaces).

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
