### PR TITLE
Allow regular convolution for AMDGPU

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 AMDGPUExt = "AMDGPU"
 
 [compat]
-AMDGPU = "0.4.7"
+AMDGPU = "0.4.8"
 Adapt = "2, 3.2"
 ChainRulesCore = "1.13"
 Requires = "0.5, 1.0"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -76,6 +76,11 @@ pad_zeros
 
 `Flux`'s `Conv` and `CrossCor` layers use `NNlib.DenseConvDims` and `NNlib.conv` internally. 
 
+!!! AMDGPU MIOpen only supports cross-correlation as its convolution algorithm (`flipkernel=true`).
+    Flip convolution kernel manually before passing it to `NNlib.conv`
+    to perform regular convolution (`flipkernel=false`): `reverse(w; dims=(1, 2))`.
+    `Flux` handles this automatically, this is only required for direct calls.
+
 ```@docs
 conv
 ConvDims

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -76,9 +76,11 @@ pad_zeros
 
 `Flux`'s `Conv` and `CrossCor` layers use `NNlib.DenseConvDims` and `NNlib.conv` internally. 
 
-!!! AMDGPU MIOpen only supports cross-correlation as its convolution algorithm (`flipkernel=true`).
-    Flip convolution kernel manually before passing it to `NNlib.conv`
-    to perform regular convolution (`flipkernel=false`): `reverse(w; dims=(1, 2))`.
+!!! AMDGPU MIOpen supports only cross-correlation (flipkernel=true).
+    Therefore for every regular convolution (flipkernel=false)
+    kernel is flipped before calculation.
+    For better performance, use cross-correlation (flipkernel=true)
+    and manually flip the kernel before `NNlib.conv` call.
     `Flux` handles this automatically, this is only required for direct calls.
 
 ```@docs

--- a/ext/AMDGPUExt/conv.jl
+++ b/ext/AMDGPUExt/conv.jl
@@ -1,6 +1,20 @@
 function NNlib.conv!(
     y::ROCArray{T, N}, x::ROCArray{T, N}, w::ROCArray{T, N}, cdims::DenseConvDims,
 ) where {T <: MIOPENFloat, N}
+    if !NNlib.flipkernel(cdims)
+        @warn """
+        MIOpen supports only cross-correlation (flipkernel=true).
+        Therefore for every regular convolution (flipkernel=false)
+        kernel is flipped before calculation.
+        For better performance, use cross-correlation (flipkernel=true)
+        and manually flip the kernel before `NNlib.conv` call.
+        """ maxlog=1
+        flip_dims = ntuple(
+            i -> (i ≤ ndims(w) - 2) ? (size(w, i):-1:1) : Colon(),
+            ndims(w))
+        w = w[flip_dims...]
+    end
+
     nd = max(0, 4 - N)
     ncdims = NNlib.insert_singleton_spatial_dimension(cdims, nd)
     MIOpen.convolution!(
@@ -15,6 +29,20 @@ end
 function NNlib.∇conv_data!(
     dx::ROCArray{T, N}, dy::ROCArray{T, N}, w::ROCArray{T, N}, cdims::DenseConvDims,
 ) where {T <: MIOPENFloat, N}
+    if !NNlib.flipkernel(cdims)
+        @warn """
+        MIOpen supports only cross-correlation (flipkernel=true).
+        Therefore for every regular convolution (flipkernel=false)
+        kernel is flipped before calculation.
+        For better performance, use cross-correlation (flipkernel=true)
+        and manually flip the kernel before `NNlib.conv` call.
+        """ maxlog=1
+        flip_dims = ntuple(
+            i -> (i ≤ ndims(w) - 2) ? (size(w, i):-1:1) : Colon(),
+            ndims(w))
+        w = w[flip_dims...]
+    end
+
     nd = max(0, 4 - N)
     ncdims = NNlib.insert_singleton_spatial_dimension(cdims, nd)
     MIOpen.∇convolution_data!(
@@ -37,5 +65,19 @@ function NNlib.∇conv_filter!(
         NNlib.insert_singleton_spatial_dimension(x, nd);
         padding=nnlib_padding(ncdims), stride=NNlib.stride(ncdims),
         dilation=NNlib.dilation(ncdims), groups=NNlib.groupcount(ncdims))
+
+    if !NNlib.flipkernel(cdims)
+        @warn """
+        MIOpen supports only cross-correlation (flipkernel=true).
+        Therefore for every regular convolution (flipkernel=false)
+        kernel is flipped before calculation.
+        For better performance, use cross-correlation (flipkernel=true)
+        and manually flip the kernel before `NNlib.conv` call.
+        """ maxlog=1
+        flip_dims = ntuple(
+            i -> (i ≤ ndims(dw) - 2) ? (size(dw, i):-1:1) : Colon(),
+            ndims(dw))
+        dw = dw[flip_dims...]
+    end
     return dw
 end

--- a/ext/AMDGPUExt/conv.jl
+++ b/ext/AMDGPUExt/conv.jl
@@ -1,9 +1,6 @@
 function NNlib.conv!(
     y::ROCArray{T, N}, x::ROCArray{T, N}, w::ROCArray{T, N}, cdims::DenseConvDims,
 ) where {T <: MIOPENFloat, N}
-    NNlib.flipkernel(cdims) || throw(ArgumentError(
-        "MIOpen supports only cross-correlation as its convolution implementation."))
-
     nd = max(0, 4 - N)
     ncdims = NNlib.insert_singleton_spatial_dimension(cdims, nd)
     MIOpen.convolution!(
@@ -18,9 +15,6 @@ end
 function NNlib.∇conv_data!(
     dx::ROCArray{T, N}, dy::ROCArray{T, N}, w::ROCArray{T, N}, cdims::DenseConvDims,
 ) where {T <: MIOPENFloat, N}
-    NNlib.flipkernel(cdims) || throw(ArgumentError(
-        "MIOpen supports only cross-correlation as its convolution implementation."))
-
     nd = max(0, 4 - N)
     ncdims = NNlib.insert_singleton_spatial_dimension(cdims, nd)
     MIOpen.∇convolution_data!(
@@ -35,9 +29,6 @@ end
 function NNlib.∇conv_filter!(
     dw::ROCArray{T, N}, x::ROCArray{T, N}, dy::ROCArray{T, N}, cdims::DenseConvDims,
 ) where {T <: MIOPENFloat, N}
-    NNlib.flipkernel(cdims) || throw(ArgumentError(
-        "MIOpen supports only cross-correlation as its convolution implementation."))
-
     nd = max(0, 4 - N)
     ncdims = NNlib.insert_singleton_spatial_dimension(cdims, nd)
     MIOpen.∇convolution_weight!(

--- a/test/amd/conv.jl
+++ b/test/amd/conv.jl
@@ -7,3 +7,14 @@
         gputest((x, w) -> NNlib.conv(x, w, cdims), x, w; atol=1e-4)
     end
 end
+
+@testset "Regular convolution with flipped kernel" begin
+    x = rand(Float32, 16, 16, 3, 1)
+    w = rand(Float32, 2, 2, 3, 4)
+    xd, wd = ROCArray.((x, reverse(w; dims=(1, 2))))
+
+    cdims = DenseConvDims(x, w)
+    y = NNlib.conv(x, w, cdims)
+    yd = NNlib.conv(xd, wd, cdims)
+    @test Array(yd) ≈ y atol=1f-3
+end

--- a/test/amd/conv.jl
+++ b/test/amd/conv.jl
@@ -3,18 +3,12 @@
     for T in (Float16, Float32), nd in (1, 2, 3)
         x = rand(Float32, fill(4, nd)..., 3, 1)
         w = rand(Float32, fill(2, nd)..., channels, 4)
+
         cdims = DenseConvDims(x, w, flipkernel=true)
         gputest((x, w) -> NNlib.conv(x, w, cdims), x, w; atol=1e-4)
+
+        # This one flips manually kernel for AMDGPU.
+        cdims = DenseConvDims(x, w)
+        gputest((x, w) -> NNlib.conv(x, w, cdims), x, w; atol=1e-4)
     end
-end
-
-@testset "Regular convolution with flipped kernel" begin
-    x = rand(Float32, 16, 16, 3, 1)
-    w = rand(Float32, 2, 2, 3, 4)
-    xd, wd = ROCArray.((x, reverse(w; dims=(1, 2))))
-
-    cdims = DenseConvDims(x, w)
-    y = NNlib.conv(x, w, cdims)
-    yd = NNlib.conv(xd, wd, cdims)
-    @test Array(yd) ≈ y atol=1f-3
 end


### PR DESCRIPTION
MIOpen only [supports](https://rocmsoftwareplatform.github.io/MIOpen/doc/html/convolution.html) cross-correlation as its convolution.

To perform regular convolution we can reverse the kernel along first two dimensions (for 2D conv).
Doing this every time during `NNlib.conv` calls is expensive, therefore on NNlib level a user will need to manually flip convolution kernel before passing it as an argument.
On the Flux level this will be handled automatically during `Flux.gpu(conv)` conversion once.

Flux's part is done in this PR: https://github.com/FluxML/Flux.jl/pull/2189

- Bump AMDGPU compat, since it has important performance optimizations.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
