### PR TITLE
Using AbstractFloat instead of Float64 in warning check for slow conv

### DIFF
--- a/src/conv.jl
+++ b/src/conv.jl
@@ -188,7 +188,7 @@ for (front_name, backend, signature) in (
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
                         cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
-            if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+            if $(string(backend)) == "direct" && yT <: AbstractFloat   # warn for accidental mixture of floats, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
@@ -229,7 +229,7 @@ for (front_name, backend, signature) in (
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
                         cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
-            if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+            if $(string(backend)) == "direct" && yT <: AbstractFloat   # warn for accidental mixture of floats, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
@@ -272,7 +272,7 @@ for (front_name, backend, signature) in (
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
                         cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
-            if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+            if $(string(backend)) == "direct" && yT <: AbstractFloat   # warn for accidental mixture of floats, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
@@ -323,7 +323,7 @@ for (front_name, backend, signature) in (
                         in2::AbstractArray{$(signature[3][1]), $(signature[1][2])},
                         cdims::$(signature[4]);
                         kwargs...) where {$(signature[5]...)}
-            if $(string(backend)) == "direct" && yT == Float64  # warn for Float32 + accidental Float64, but don't print warning for ForwardDiff.Dual
+            if $(string(backend)) == "direct" && yT <: AbstractFloat   # warn for accidental mixture of floats, but don't print warning for ForwardDiff.Dual
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end


### PR DESCRIPTION
### PR Checklist

- [X] Tests are added
- [X] Documentation, if applicable

https://github.com/FluxML/NNlib.jl/pull/383 silence some warnings that are not necessarily useful (as discussed in the PR), but keep the warning for Float64 with other types.

But with the support for half-precision floats, some other combinations can happen and go unnoticed, such as a Float16 weight on a Float32 matrix, or a Float32 weight on an Int matrix ("oh no I forgot to convert my Integers to Floats").

This PR changes the type check from Float64 to AbstractFloat, creating a warning for some unintentional and weird combinations, but still preventing issuing warnings for Dual.ForwardDiff, which was the main purpose of the previous PR.

### Some examples
<details><summary>Current NNlib (only shows a warning when there is a Float64):</summary>
<p>

```julia
julia> x = rand(Float16, 5, 5, 1, 1)
5×5×1×1 Array{Float16, 4}:
[:, :, 1, 1] =
 0.3955  0.76    0.8823  0.4844  0.593
 0.2158  0.51    0.9277  0.2725  0.2163
 0.547   0.8364  0.958   0.939   0.3027
 0.1377  0.7285  0.4229  0.943   0.579
 0.7437  0.5874  0.805   0.146   0.269

julia> w = rand(Int8, 3, 3, 1, 1)
3×3×1×1 Array{Int8, 4}:
[:, :, 1, 1] =
 -68  120  -77
 -75   90   11
   3   92  -25

julia> conv(x, w)
3×3×1×1 Array{Float16, 4}:
[:, :, 1, 1] =
  34.44  119.1    61.03
 101.75   29.06  116.0
  60.0    87.0    46.62

julia> w = rand(Float32, 3, 3, 1, 1)
3×3×1×1 Array{Float32, 4}:
[:, :, 1, 1] =
 0.476644  0.732119  0.917347
 0.350704  0.753561  0.0978633
 0.633826  0.753227  0.0496203

julia> conv(x, w)
3×3×1×1 Array{Float32, 4}:
[:, :, 1, 1] =
 3.45243  3.77007  2.86686
 2.86372  3.45715  2.65007
 3.47114  3.27677  2.87541

julia> w = rand(Float64, 3, 3, 1, 1)
3×3×1×1 Array{Float64, 4}:
[:, :, 1, 1] =
 0.220391  0.259412   0.027865
 0.855732  0.353315   0.893624
 0.531092  0.0226233  0.315492

julia> conv(x, w)
┌ Warning: Slow fallback implementation invoked for conv!  You probably don't want this; check your datatypes.
│   yT = Float64
│   T1 = Float16
│   T2 = Float64
└ @ NNlib ~/.julia/packages/NNlib/TZPiH/src/conv.jl:192
3×3×1×1 Array{Float64, 4}:
[:, :, 1, 1] =
 2.22078  2.01215  2.05155
 2.46237  2.55374  2.24465
 1.79309  2.64892  1.81043
```
</details></p>

<details><summary>This PR (shows a warning for any mixture of different Floats):</summary>
<p>

_PS: I did these tests resetting the runtime since there is a maxlog of 1 for the warnings._
```julia
julia> x = rand(Float16, 5, 5, 1, 1)
5×5×1×1 Array{Float16, 4}:
[:, :, 1, 1] =
 0.474   0.5884  0.7637   0.6035  0.6396
 0.0762  0.645   0.0952   0.7197  0.818
 0.3394  0.1221  0.543    0.7017  0.767
 0.7173  0.961   0.08936  0.2783  0.3022
 0.678   0.5005  0.7104   0.965   0.4219

julia> w = rand(Int8, 3, 3, 1, 1)
3×3×1×1 Array{Int8, 4}:
[:, :, 1, 1] =
  81  -48  -76
 -15  -41   58
 -23   72  -56

julia> conv(x, w)
┌ Warning: Slow fallback implementation invoked for conv!  You probably don't want this; check your datatypes.
│   yT = Float16
│   T1 = Float16
│   T2 = Int8
└ @ NNlib ~/NNlib.jl/src/conv.jl:192
3×3×1×1 Array{Float16, 4}:
[:, :, 1, 1] =
 -12.91    52.38  -63.06
 -46.8   -126.2    23.25
 -39.9     70.0   -74.44

julia> w = rand(Float32, 3, 3, 1, 1)
3×3×1×1 Array{Float32, 4}:
[:, :, 1, 1] =
 0.885747  0.745852  0.161355
 0.837498  0.757606  0.457403
 0.86357   0.687177  0.457069

julia> conv(x, w)
┌ Warning: Slow fallback implementation invoked for conv!  You probably don't want this; check your datatypes.
│   yT = Float32
│   T1 = Float16
│   T2 = Float32
└ @ NNlib ~/NNlib.jl/src/conv.jl:192
3×3×1×1 Array{Float32, 4}:
[:, :, 1, 1] =
 2.20351  3.15128  3.26581
 2.8175   3.43277  3.7439
 2.4886   3.27672  3.43359

julia> w = rand(Float64, 3, 3, 1, 1)
3×3×1×1 Array{Float64, 4}:
[:, :, 1, 1] =
 0.191498  0.043293  0.34513
 0.417291  0.227745  0.510484
 0.627288  0.680126  0.0511033

julia> conv(x, w)
┌ Warning: Slow fallback implementation invoked for conv!  You probably don't want this; check your datatypes.
│   yT = Float64
│   T1 = Float16
│   T2 = Float64
└ @ NNlib ~/NNlib.jl/src/conv.jl:192
3×3×1×1 Array{Float64, 4}:
[:, :, 1, 1] =
 1.83448  1.69441  1.53605
 1.48041  2.10666  2.06308
 1.76039  1.72283  2.31743

julia> f = x -> sum(conv(x, w))
#5 (generic function with 1 method)

julia> ForwardDiff.gradient(f, x)
5×5×1×1 Array{Float64, 4}:
[:, :, 1, 1] =
 0.998969  1.54049  2.26595  1.26698  0.725466
 1.57489   2.57254  4.01191  2.43702  1.43937
 2.10452   3.83771  6.0199   3.91539  2.18219
 1.10555   2.29723  3.75395  2.64841  1.45672
 0.529626  1.26517  2.008    1.47837  0.742825
```
</details></p>