### PR TITLE
Cast FP16 -> FP32 in softmax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ lib/NNlibCUDA/Manifest.toml
 benchmark/Manifest.toml
 benchmark/*.json
 benchmark/report.md
+LocalPreferences.toml

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[AMDGPU]
+use_artifacts = false

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,2 +1,0 @@
-[AMDGPU]
-use_artifacts = false

--- a/ext/NNlibAMDGPUExt/softmax.jl
+++ b/ext/NNlibAMDGPUExt/softmax.jl
@@ -2,13 +2,46 @@ for fname in (:softmax, :logsoftmax)
     @eval function NNlib.$(fname)(x::ROCArray{Float32}; dims = 1)
         MIOpen.$(fname)(x; dims)
     end
-    @eval function NNlib.$(fname)(x::ROCArray{Float16}; dims = 1)
-        Float16.(MIOpen.$(fname)(Float32.(x); dims))
+
+    @eval function NNlib.$(Symbol("∇$(fname)_data"))(
+        dy::ROCArray{T, N}, y::ROCArray{T, N}; dims = 1,
+    ) where {T <: MIOPENFloat, N}
+        MIOpen.$(Symbol("∇$(fname)"))(dy, y; dims)
     end
 
-    @eval function NNlib.$(Symbol("∇$(fname)"))(
-        dy::ROCArray{T, N}, x::ROCArray{T, N}, y::ROCArray{T, N}; dims = 1,
-    ) where {T <: MIOPENFloat, N}
-        MIOpen.$(Symbol("∇$(fname)!"))(dy, y; dims)
+    # FP16 variants. Cast to FP32 -> compute result -> cast back to FP16.
+    # Eagerly free intermediate FP32 arrays.
+
+    @eval function NNlib.$(fname)(x::ROCArray{Float16}; dims = 1)
+        x_fp32 = Float32.(x)
+        y_fp32 = NNlib.$(fname)(x_fp32; dims)
+        y = Float16.(y_fp32)
+
+        AMDGPU.synchronize()
+        AMDGPU.unsafe_free!.((x_fp32, y_fp32))
+        return y
+    end
+
+    @eval function ChainRulesCore.rrule(::typeof(NNlib.$(fname)), x::ROCArray{Float16}; dims = 1)
+        x_fp32 = Float32.(x)
+        y_fp32 = NNlib.$(fname)(x_fp32; dims)
+        AMDGPU.synchronize()
+        AMDGPU.unsafe_free!(x_fp32)
+
+        y = Float16.(y_fp32)
+
+        function _pullback(dy)
+            dy_fp32 = Float32.(unthunk(dy))
+            dx_fp32 = NNlib.$(Symbol("∇$(fname)_data"))(dy_fp32, y_fp32; dims)
+            AMDGPU.synchronize()
+            AMDGPU.unsafe_free!.((dy_fp32, y_fp32))
+
+            dx = Float16.(dx_fp32)
+
+            AMDGPU.synchronize()
+            AMDGPU.unsafe_free!(dx_fp32)
+            NoTangent(), dx
+        end
+        return y, _pullback
     end
 end

--- a/ext/NNlibAMDGPUExt/softmax.jl
+++ b/ext/NNlibAMDGPUExt/softmax.jl
@@ -1,6 +1,9 @@
 for fname in (:softmax, :logsoftmax)
-    @eval function NNlib.$(fname)(x::ROCArray{T}; dims = 1) where T <: MIOPENFloat
+    @eval function NNlib.$(fname)(x::ROCArray{Float32}; dims = 1)
         MIOpen.$(fname)(x; dims)
+    end
+    @eval function NNlib.$(fname)(x::ROCArray{Float16}; dims = 1)
+        Float16.(MIOpen.$(fname)(Float32.(x); dims))
     end
 
     @eval function NNlib.$(Symbol("∇$(fname)"))(

--- a/test/ext_amdgpu/softmax.jl
+++ b/test/ext_amdgpu/softmax.jl
@@ -10,6 +10,7 @@
             else
                 x = randn(T, sz)
             end
+
             gputest(NNlib.softmax, x; atol)
             gputest(NNlib.logsoftmax, x; atol)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,7 +127,7 @@ end
                 @info "AMDGPU.jl package is not functional. Skipping AMDGPU tests."
             end
         else
-            @info "Skipping AMDGPU tests, set NNLIB_TEST_CUDA=true to run them."
+            @info "Skipping AMDGPU tests, set NNLIB_TEST_AMDGPU=true to run them."
         end
 
         @testset "Doctests" begin


### PR DESCRIPTION
Even though MIOpen does support FP16 softmax, it still gives `NaN` values for big arrays (e.g. 4096x4096).
Therefore, cast `FP16 -> FP32`, perform softmax & cast back.

Eagerly free intermediate `FP32` arrays.
Override `rrule` for `FP16` softmax.

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
