### PR TITLE
Fix nthreads on 1.9 (failure in the presence of interactive threads)

### DIFF
--- a/src/dim_helpers/ConvDims.jl
+++ b/src/dim_helpers/ConvDims.jl
@@ -73,7 +73,7 @@ function im2col_dims(c::ConvDims)
         # Size of single dotproduct within convolution
         prod(kernel_size(c))*channels_in(c),
         # One workspace per thread
-        Threads.nthreads(),
+        VERSION > v"1.9.0-0" ? Threads.maxthreadid() : Threads.nthreads(),
     )
 end
 

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -88,7 +88,9 @@ for (gemm, elt) in gemm_datatype_mappings
             strB = size(B, 3) == 1 ? 0 : Base.stride(B, 3)
             strC = Base.stride(C, 3)
 
-            n_threads = min(Threads.nthreads(), 1 + max(length(A), length(B)) ÷ 8000)
+            n_threads = min(
+                VERSION > v"1.9.0-0" ? Threads.maxthreadid() : Threads.nthreads(),
+                1 + max(length(A), length(B)) ÷ 8000)
             # In some tests, size (20,20,20) is worth splitting between two threads,
             # as is size (32,32,8).
 


### PR DESCRIPTION
Currently NNlib threaded functions fail if julia is sstarted with > 0 threads in the `:interactive` threadpool.

Here julia had `-t2,1`

```
BoundsError: attempt to access 196608×9×2 Array{Float32, 3} at index [1:196608, 1:9, 3]
        Stacktrace:
         [1] throw_boundserror(A::Array{Float32, 3}, I::Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Int64})
           @ Base ./abstractarray.jl:744
         [2] checkbounds
           @ ./abstractarray.jl:709 [inlined]
         [3] view
           @ ./subarray.jl:177 [inlined]
         [4] macro expansion
           @ ~/.julia/packages/NNlib/Jmwx0/src/impl/conv_im2col.jl:49 [inlined]
         [5] (::NNlib.var"#1110#threadsfor_fun#635"{NNlib.var"#1110#threadsfor_fun#634#636"{Array{Float32, 3}, Float32, Float32, SubArray{Float32, 5, Array{Float32, 5}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}, Base.Slice{Base.OneTo{Int64}}}, false}, SubArray{Float32, 5, Array{Float32, 5}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}, Base.Slice{Base.OneTo{Int64}}}, false}, SubArray{Float32, 5, Array{Float32, 5}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}}, true}, NNlib.DenseConvDims{3, 3, 3, 6, 3}, Int64, Int64, Int64, UnitRange{Int64}}})(tid::Int64; onethread::Bool)

``` 