### PR TITLE
move from bad thread-local to task-local

### DIFF
--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -45,7 +45,7 @@ function conv_im2col!(
     N = channels_out(cdims)
     K = prod(kernel_size(cdims))*channels_in(cdims)
 
-    parts = Iterators.partition(axes(x, 5), ntasks)
+    parts = collect(Iterators.partition(axes(x, 5), ntasks))
 
     @sync for task_n in 1:ntasks
         Threads.@spawn begin
@@ -150,7 +150,7 @@ function ∇conv_data_im2col!(
     N = prod(kernel_size(cdims))*channels_in(cdims)
     K = channels_out(cdims)
 
-    parts = Iterators.partition(axes(dx, 5), ntasks)
+    parts = collect(Iterators.partition(axes(dx, 5), ntasks))
 
     @sync for task_n in 1:ntasks
         Threads.@spawn begin

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -45,7 +45,7 @@ function conv_im2col!(
     N = channels_out(cdims)
     K = prod(kernel_size(cdims))*channels_in(cdims)
 
-    parts = collect(Iterators.partition(axes(x, 5), ntasks))
+    parts = collect(Iterators.partition(axes(x, 5), ceil(Int, size(x, 5) / ntasks)))
 
     @sync for task_n in 1:ntasks
         Threads.@spawn begin
@@ -150,7 +150,7 @@ function ∇conv_data_im2col!(
     N = prod(kernel_size(cdims))*channels_in(cdims)
     K = channels_out(cdims)
 
-    parts = collect(Iterators.partition(axes(dx, 5), ntasks))
+    parts = collect(Iterators.partition(axes(dx, 5), ceil(Int, size(dx, 5) / ntasks)))
 
     @sync for task_n in 1:ntasks
         Threads.@spawn begin

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -24,7 +24,8 @@ function conv_im2col!(
                 y::AbstractArray{T,5}, x::AbstractArray{T,5},
                 w::AbstractArray{T,5}, cdims::DenseConvDims;
                 col::AbstractArray{T,3}=similar(x, im2col_dims(cdims)),
-                alpha::T=T(1), beta::T=T(0)) where {T}
+                alpha::T=T(1), beta::T=T(0),
+                ntasks::Int=nthreads()) where {T}
     check_dims(size(x), size(w), size(y), cdims)
 
     #   COL   *    W    ->    Y
@@ -44,16 +45,20 @@ function conv_im2col!(
     N = channels_out(cdims)
     K = prod(kernel_size(cdims))*channels_in(cdims)
 
-    @threads for batch_idx in 1:size(x,5)
-        # col_slice is a thread-local workspace
-        col_slice = view(col, :, :, threadid())
+    parts = Iterators.partition(axes(x, 5), ntasks)
 
-        im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
-        GC.@preserve col_slice w y begin
-            col_ptr = pointer(col_slice)
-            w_ptr = pointer(w)
-            y_ptr = pointer(y, (batch_idx - 1)*M*N + 1)
-            gemm!(Val(false), Val(false), M, N, K, alpha, col_ptr, w_ptr, beta, y_ptr)
+    @sync for task_n in 1:ntasks
+        Threads.@spawn begin
+            col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
+            for batch_idx in parts[task_n]
+                im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
+                GC.@preserve col_slice w y begin
+                    col_ptr = pointer(col_slice)
+                    w_ptr = pointer(w)
+                    y_ptr = pointer(y, (batch_idx - 1)*M*N + 1)
+                    gemm!(Val(false), Val(false), M, N, K, alpha, col_ptr, w_ptr, beta, y_ptr)
+                end
+            end
         end
     end
     return y
@@ -122,7 +127,8 @@ function ∇conv_data_im2col!(
                 dx::AbstractArray{T,5}, dy::AbstractArray{T,5},
                 w::AbstractArray{T,5}, cdims::DenseConvDims;
                 col::AbstractArray{T,3} = similar(dx, im2col_dims(cdims)),
-                alpha::T=T(1), beta::T=T(0)) where {T}
+                alpha::T=T(1), beta::T=T(0),
+                ntasks::Int=nthreads()) where {T}
     check_dims(size(dx), size(w), size(dy), cdims)
 
     #    dY        W'   ->    dX
@@ -144,17 +150,21 @@ function ∇conv_data_im2col!(
     N = prod(kernel_size(cdims))*channels_in(cdims)
     K = channels_out(cdims)
 
-    @threads for batch_idx in 1:size(dx, 5)
-        # col_slice is a thread-local workspace
-        col_slice = view(col, :, :, threadid())
+    parts = Iterators.partition(axes(dx, 5), ntasks)
 
-        GC.@preserve col_slice w dy begin
-            dy_ptr = pointer(dy, (batch_idx - 1)*M*K + 1)
-            w_ptr = pointer(w)
-            col_ptr = pointer(col_slice)
-            gemm!(Val(false), Val(true), M, N, K, alpha, dy_ptr, w_ptr, T(0), col_ptr)
+    @sync for task_n in 1:ntasks
+        Threads.@spawn begin
+            col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
+            for batch_idx in parts[task_n]
+                GC.@preserve col_slice w dy begin
+                    dy_ptr = pointer(dy, (batch_idx - 1)*M*K + 1)
+                    w_ptr = pointer(w)
+                    col_ptr = pointer(col_slice)
+                    gemm!(Val(false), Val(true), M, N, K, alpha, dy_ptr, w_ptr, T(0), col_ptr)
+                end
+                col2im!(view(dx, :, :, :, :, batch_idx), col_slice, cdims)
+            end
         end
-        col2im!(view(dx, :, :, :, :, batch_idx), col_slice, cdims)
     end
     return dx
 end

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -47,7 +47,7 @@ function conv_im2col!(
 
     parts = collect(Iterators.partition(axes(x, 5), ceil(Int, size(x, 5) / ntasks)))
 
-    @sync for task_n in 1:ntasks
+    @sync for task_n in eachindex(parts)
         Threads.@spawn begin
             col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
             for batch_idx in parts[task_n]
@@ -152,7 +152,7 @@ function ∇conv_data_im2col!(
 
     parts = collect(Iterators.partition(axes(dx, 5), ceil(Int, size(dx, 5) / ntasks)))
 
-    @sync for task_n in 1:ntasks
+    @sync for task_n in eachindex(parts)
         Threads.@spawn begin
             col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
             for batch_idx in parts[task_n]

--- a/src/impl/depthwiseconv_im2col.jl
+++ b/src/impl/depthwiseconv_im2col.jl
@@ -26,7 +26,7 @@ function depthwiseconv_im2col!(
     N = channel_multiplier(cdims)
     K = prod(kernel_size(cdims))
 
-    parts = Iterators.partition(axes(y)[end], ntasks)
+    parts = collect(Iterators.partition(axes(y)[end], ntasks))
 
     dcdims = DenseConvDims(cdims)
 
@@ -114,7 +114,7 @@ function ∇depthwiseconv_data_im2col!(
     N = prod(kernel_size(cdims))
     K = channel_multiplier(cdims)
 
-    parts = Iterators.partition(axes(dx)[end], ntasks)
+    parts = collect(Iterators.partition(axes(dx)[end], ntasks))
 
     @sync for task_n in 1:ntasks
         Threads.@spawn begin

--- a/src/impl/depthwiseconv_im2col.jl
+++ b/src/impl/depthwiseconv_im2col.jl
@@ -26,7 +26,7 @@ function depthwiseconv_im2col!(
     N = channel_multiplier(cdims)
     K = prod(kernel_size(cdims))
 
-    parts = collect(Iterators.partition(axes(y)[end], ntasks))
+    parts = collect(Iterators.partition(axes(y)[end], ceil(Int, size(y, 5) / ntasks)))
 
     dcdims = DenseConvDims(cdims)
 
@@ -114,7 +114,7 @@ function ∇depthwiseconv_data_im2col!(
     N = prod(kernel_size(cdims))
     K = channel_multiplier(cdims)
 
-    parts = collect(Iterators.partition(axes(dx)[end], ntasks))
+    parts = collect(Iterators.partition(axes(dx)[end], ceil(Int, size(dx, 5) / ntasks)))
 
     @sync for task_n in 1:ntasks
         Threads.@spawn begin

--- a/src/impl/depthwiseconv_im2col.jl
+++ b/src/impl/depthwiseconv_im2col.jl
@@ -13,7 +13,8 @@ function depthwiseconv_im2col!(
                 y::AbstractArray{T,5}, x::AbstractArray{T,5},
                 w::AbstractArray{T,5}, cdims::DepthwiseConvDims;
                 col::AbstractArray{T,3} = similar(x, im2col_dims(cdims)),
-                alpha::T=T(1), beta::T=T(0)) where T
+                alpha::T=T(1), beta::T=T(0),
+                ntasks::Int=nthreads()) where T
     check_dims(size(x), size(w), size(y), cdims)
 
     # This functions exactly the same as conv_im2col!(), except that we shard the
@@ -25,21 +26,26 @@ function depthwiseconv_im2col!(
     N = channel_multiplier(cdims)
     K = prod(kernel_size(cdims))
 
+    parts = Iterators.partition(axes(y)[end], ntasks)
+
     dcdims = DenseConvDims(cdims)
-    @threads for batch_idx in 1:size(x)[end]
-        # col_slice is a thread-local workspace
-        col_slice = view(col, :, :, threadid())
 
-        im2col!(col_slice, view(x, :, :, :, :, batch_idx), dcdims)
+    @sync for task_n in 1:ntasks
+        Threads.@spawn begin
+            col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
+            for batch_idx in parts[task_n]
+                im2col!(col_slice, view(x, :, :, :, :, batch_idx), dcdims)
 
-        # We do a separate convolution for each channel in x, as we must
-        for c_in in 1:channels_in(cdims)
-            # Walk each pointer forward as we process each input channel
-            GC.@preserve col_slice w y begin
-                col_ptr = pointer(col_slice, (c_in-1)*M*K+1)
-                w_ptr = pointer(w, (c_in-1)*K*N+1)
-                y_ptr = pointer(y, ((batch_idx - 1)*channels_in(cdims) + c_in - 1)*M*N + 1)
-                gemm!(Val(false), Val(false), M, N, K, alpha, col_ptr, w_ptr, beta, y_ptr)
+                # We do a separate convolution for each channel in x, as we must
+                for c_in in 1:channels_in(cdims)
+                    # Walk each pointer forward as we process each input channel
+                    GC.@preserve col_slice w y begin
+                        col_ptr = pointer(col_slice, (c_in-1)*M*K+1)
+                        w_ptr = pointer(w, (c_in-1)*K*N+1)
+                        y_ptr = pointer(y, ((batch_idx - 1)*channels_in(cdims) + c_in - 1)*M*N + 1)
+                        gemm!(Val(false), Val(false), M, N, K, alpha, col_ptr, w_ptr, beta, y_ptr)
+                    end
+                end
             end
         end
     end
@@ -108,21 +114,25 @@ function ∇depthwiseconv_data_im2col!(
     N = prod(kernel_size(cdims))
     K = channel_multiplier(cdims)
 
-    @threads for batch_idx in 1:size(dx)[end]
-        # col_slice is a thread-local workspace
-        col_slice = view(col, :, :, threadid())
+    parts = Iterators.partition(axes(dx)[end], ntasks)
 
-        # We do a separate convolution for each channel in x, as we must
-        for cidx in 1:channels_in(cdims)
-            GC.@preserve col_slice w dy begin
-                # Walk each pointer forward as we process each input channel
-                dy_ptr = pointer(dy, (batch_idx - 1)*M*K*channels_in(cdims)+(cidx - 1)*K*M + 1)
-                w_ptr = pointer(w, (cidx - 1)*K*N + 1)
-                col_ptr = pointer(col_slice, (cidx - 1)*M*N + 1)
-                gemm!(Val(false), Val(true), M, N, K, alpha, dy_ptr, w_ptr, T(0), col_ptr)
+    @sync for task_n in 1:ntasks
+        Threads.@spawn begin
+            col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
+            for batch_idx in parts[task_n]
+                # We do a separate convolution for each channel in x, as we must
+                for cidx in 1:channels_in(cdims)
+                    GC.@preserve col_slice w dy begin
+                        # Walk each pointer forward as we process each input channel
+                        dy_ptr = pointer(dy, (batch_idx - 1)*M*K*channels_in(cdims)+(cidx - 1)*K*M + 1)
+                        w_ptr = pointer(w, (cidx - 1)*K*N + 1)
+                        col_ptr = pointer(col_slice, (cidx - 1)*M*N + 1)
+                        gemm!(Val(false), Val(true), M, N, K, alpha, dy_ptr, w_ptr, T(0), col_ptr)
+                    end
+                end
+                col2im!(view(dx, :, :, :, :, batch_idx), col_slice, cdims)
             end
         end
-        col2im!(view(dx, :, :, :, :, batch_idx), col_slice, cdims)
     end
     return dx
 end

--- a/src/impl/depthwiseconv_im2col.jl
+++ b/src/impl/depthwiseconv_im2col.jl
@@ -107,7 +107,8 @@ function ∇depthwiseconv_data_im2col!(
                 dx::AbstractArray{T,5}, dy::AbstractArray{T,5},
                 w::AbstractArray{T,5}, cdims::DepthwiseConvDims;
                 col::AbstractArray{T,3} = similar(dx, im2col_dims(cdims)),
-                alpha::T=T(1), beta::T=T(0)) where T
+                alpha::T=T(1), beta::T=T(0),
+                ntasks::Int=nthreads()) where T
     check_dims(size(dx), size(w), size(dy), cdims)
 
     M = prod(output_size(cdims))

--- a/src/impl/depthwiseconv_im2col.jl
+++ b/src/impl/depthwiseconv_im2col.jl
@@ -30,7 +30,7 @@ function depthwiseconv_im2col!(
 
     dcdims = DenseConvDims(cdims)
 
-    @sync for task_n in 1:ntasks
+    @sync for task_n in eachindex(parts)
         Threads.@spawn begin
             col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
             for batch_idx in parts[task_n]
@@ -117,7 +117,7 @@ function ∇depthwiseconv_data_im2col!(
 
     parts = collect(Iterators.partition(axes(dx)[end], ceil(Int, size(dx, 5) / ntasks)))
 
-    @sync for task_n in 1:ntasks
+    @sync for task_n in eachindex(parts)
         Threads.@spawn begin
             col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
             for batch_idx in parts[task_n]


### PR DESCRIPTION
The previous `threadid`-based buffering may have been susceptible to error due to task migration.