### PR TITLE
[Dummy] Slow down some functions intentionally for testing benchmarking tools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.8.20"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,12 +14,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-
-[weakdeps]
-AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
-
-[extensions]
-NNlibAMDGPUExt = "AMDGPU"
 
 [compat]
 AMDGPU = "0.4.8"
@@ -30,5 +25,11 @@ KernelAbstractions = "0.9.2"
 Requires = "0.5, 1.0"
 julia = "1.6"
 
+[extensions]
+NNlibAMDGPUExt = "AMDGPU"
+
 [extras]
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+
+[weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -172,7 +172,17 @@ julia> lineplot(relu, -2, 2, height=7)
           ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀x⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀        
 ```
 """
-relu(x) = ifelse(x<0, zero(x), x)  # faster than max(zero(x), x), still preserves NaN
+function relu(x)
+  if x < 0
+    zero(x)
+  else
+    y = x
+    for i in 1:10
+      y += i
+    end
+    x + zero(y)
+  end
+end
 
 """
     leakyrelu(x, a=0.01) = max(a*x, x)

--- a/src/dim_helpers/ConvDims.jl
+++ b/src/dim_helpers/ConvDims.jl
@@ -73,7 +73,7 @@ function im2col_dims(c::ConvDims)
         # Size of single dotproduct within convolution
         prod(kernel_size(c))*channels_in(c),
         # One workspace per thread
-        Threads.nthreads(),
+        VERSION > v"1.9.0-0" ? Threads.maxthreadid() : Threads.nthreads(),
     )
 end
 

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -88,7 +88,9 @@ for (gemm, elt) in gemm_datatype_mappings
             strB = size(B, 3) == 1 ? 0 : Base.stride(B, 3)
             strC = Base.stride(C, 3)
 
-            n_threads = min(Threads.nthreads(), 1 + max(length(A), length(B)) ÷ 8000)
+            n_threads = min(
+                VERSION > v"1.9.0-0" ? Threads.maxthreadid() : Threads.nthreads(),
+                1 + max(length(A), length(B)) ÷ 8000)
             # In some tests, size (20,20,20) is worth splitting between two threads,
             # as is size (32,32,8).
 

--- a/src/softmax.jl
+++ b/src/softmax.jl
@@ -1,3 +1,4 @@
+using Dates
 
 """
     softmax(x; dims = 1)
@@ -58,6 +59,7 @@ softmax(x::AbstractArray{T}; dims = 1) where {T} = softmax!(similar(x, float(T))
 softmax!(x::AbstractArray; dims = 1) = softmax!(x, x; dims)
 
 function softmax!(out::AbstractArray{T}, x::AbstractArray; dims = 1) where {T}
+    sleep(Millisecond(20)) # slow down intentionally
     max_ = fast_maximum(x; dims)
     if all(isfinite, max_)
         @fastmath out .= exp.(x .- max_)


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Description

**[NO MERGE] This PR is created to get through the whole process of FluxMLBenchmarks.jl in PR sceniro**.

In this PR, I slowed down `relu` and `softmax`:

```julia
julia> @btime relu(4.0)
  1.589 ns (0 allocations: 0 bytes)
4.0

julia> # after slowing down

julia> @btime relu(4.0)
  2.844 ns (0 allocations: 0 bytes)
4.0
```
