### PR TITLE
Allow non-Int64 indices in scatter

### DIFF
--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -108,7 +108,7 @@ end
 
 @kernel function _scatter!(op::OP, dst, src, idxs) where OP
     i = @index(Global)
-    @inbounds idx = Tuple(_atomix_convert_i64(idxs[i]))
+    @inbounds idx = Tuple(_convert_i64(idxs[i]))
     @inbounds Atomix.modify!(Atomix.IndexableRef(dst, idx), op, src[i])
     # FIXME `@atomic` macro silently fails to perform atomic op below
     # @atomic dst[idx...] = op(dst[idx...], src[i])
@@ -119,7 +119,7 @@ end
 ) where OP
     i = @index(Global)
     j, k = divrem(i - 1, max_dims_idx)
-    @inbounds idx = (Tuple(dim_ids[k + 1])..., Tuple(_atomix_convert_i64(idxs[j + 1]))...)
+    @inbounds idx = (Tuple(dim_ids[k + 1])..., Tuple(_convert_i64(idxs[j + 1]))...)
     @inbounds Atomix.modify!(Atomix.IndexableRef(dst, idx), op, src[i])
     # FIXME `@atomic` macro silently fails to perform atomic op below
     # dim_i = Tuple(dim_ids[k + 1])
@@ -129,9 +129,9 @@ end
 
 # Allow non-Int64 indices by converting them to Int64 when index eltype <: Integer.
 # All other index types (tuples, cartesian indices) must be in Int64 already.
-@inline _atomix_convert_i64(x::Int64) = x
-@inline _atomix_convert_i64(x::Integer) = Int(x)
-@inline _atomix_convert_i64(x) = x
+@inline _convert_i64(x::Int) = x
+@inline _convert_i64(x::Integer) = Int(x)
+@inline _convert_i64(x) = x
 
 """
     NNlib.scatter(op, src, idx; [init, dstsize])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using Adapt
 using KernelAbstractions
 import ReverseDiff as RD        # used in `pooling.jl`
 
-const Test_Enzyme = VERSION <= v"1.10" && !Sys.iswindows()
+const Test_Enzyme = VERSION <= v"1.10-" && !Sys.iswindows()
 
 DocMeta.setdocmeta!(NNlib, :DocTestSetup, :(using NNlib, UnicodePlots); recursive=true)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,9 @@ using Adapt
 using KernelAbstractions
 import ReverseDiff as RD        # used in `pooling.jl`
 
-const Test_Enzyme = VERSION <= v"1.10-" && !Sys.iswindows()
+const Test_Enzyme = VERSION <= v"1.10-" && !Sys.iswindows() &&
+    # TODO Enzyme is not working properly with AMDGPU yet.
+    get(ENV, "NNLIB_TEST_AMDGPU", "false") != "true"
 
 DocMeta.setdocmeta!(NNlib, :DocTestSetup, :(using NNlib, UnicodePlots); recursive=true)
 


### PR DESCRIPTION
- Allow non-`Int64` indices in scatter by promoting them to `Int64` inside the kernel.
This is especially useful when performing reduction over big arrays into a few bins.
Indices can be of `Int8` type, saving a lot of space.
- Fix typo in `Test_Enzyme`. I guess the intention was to disallow any Julia 1.10 version.
```julia
julia> v"1.10.0-beta2" <= v"1.10"
true

julia> v"1.10.0-beta2" <= v"1.10-"
false
```

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
