### PR TITLE
Add image rotation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,6 +52,8 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 EnzymeTestUtils = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -62,4 +64,4 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [targets]
-test = ["AMDGPU", "CUDA", "ChainRulesTestUtils", "Documenter", "FiniteDifferences", "ForwardDiff", "Logging", "ReverseDiff", "StableRNGs", "Test", "UnicodePlots", "Zygote", "cuDNN", "Enzyme", "EnzymeCore", "EnzymeTestUtils"]
+test = ["AMDGPU", "CUDA", "ChainRulesTestUtils", "Documenter", "FiniteDifferences", "ForwardDiff", "Logging", "ReverseDiff", "StableRNGs", "Test", "UnicodePlots", "Zygote", "cuDNN", "Enzyme", "EnzymeCore", "EnzymeTestUtils", "Interpolations", "ImageTransformations"]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -111,6 +111,14 @@ upsample_trilinear
 pixel_shuffle
 ```
 
+## Rotation
+Rotate images in the first two dimensions of an array.
+
+```@docs
+imrotate
+∇imrotate
+```
+
 ## Batched Operations
 
 `Flux`'s `Bilinear` layer uses `NNlib.batched_mul` internally.

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -123,7 +123,7 @@ include("impl/depthwiseconv_im2col.jl")
 include("impl/pooling_direct.jl")
 include("deprecations.jl")
 
-
 include("rotation.jl")
+export imrotate
 
 end # module NNlib

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -123,4 +123,7 @@ include("impl/depthwiseconv_im2col.jl")
 include("impl/pooling_direct.jl")
 include("deprecations.jl")
 
+
+include("rotation.jl")
+
 end # module NNlib

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,7 +1,7 @@
 """
     _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, round_or_floor)
 
-this rotates the coordinates and either applies round(nearest neighbour)
+This rotates the coordinates and either applies round(nearest neighbour)
 or floor for :bilinear interpolation)
 """
 @inline function _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, round_or_floor)

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -178,7 +178,7 @@ function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(
         throw(ArgumentError("No interpolation method such as $method"))
     end
     kernel!(out, arr, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
-            ndrange=(size(arr, 1), size(arr, 2), size(arr, 3), size(arr, 4)))
+            ndrange=size(arr))
 	return out
 end
 
@@ -214,7 +214,7 @@ function ∇imrotate(dy, arr::AbstractArray{T, 4}, θ; method=:bilinear,
     end
     # don't pass arr but dy! 
     kernel!(out, dy, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
-            ndrange=(size(arr, 1), size(arr, 2), size(arr, 3), size(arr, 4)))
+            ndrange=size(arr))
     return out
 end
 

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -159,10 +159,10 @@ julia> NNlib.imrotate(arr, deg2rad(45), method=:nearest)
  0.0  0.0  0.0
 ```
 """
-function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, rotation_center=size(arr) .÷ 2 .+ 1) where T
-    @assert (T <: Integer && method==:nearest || !(T <: Integer)) "If the array has an Int eltype, only method=:nearest is supported"
-    @assert typeof(rotation_center) <: Tuple "rotation_center keyword has to be a tuple"
-    
+function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, rotation_center::Tuple=size(arr) .÷ 2 .+ 1) where T
+    if (T <: Integer && method==:nearest || !(T <: Integer)) == false
+        throw(ArgumentError("If the array has an Int eltype, only method=:nearest is supported"))
+    end
     # prepare out, the sin and cos and type of rotation_center
     sinθ, cosθ, rotation_center, out = _prepare_imrotate(arr, θ, rotation_center) 
     # such as 0°, 90°, 180°, 270° and only if the rotation_center is suitable
@@ -197,7 +197,7 @@ Adjoint for `imrotate`. Gradient only with respect to `arr` and not `θ`.
 * `rotation_center=size(arr) .÷ 2 .+ 1` rotates around a real center pixel for even and odd sized arrays
 """
 function ∇imrotate(dy, arr::AbstractArray{T, 4}, θ; method=:bilinear, 
-                                               rotation_center=size(arr) .÷ 2 .+ 1) where T
+                                               rotation_center::Tuple=size(arr) .÷ 2 .+ 1) where T
     
     sinθ, cosθ, rotation_center, out = _prepare_imrotate(arr, θ, rotation_center) 
     # for the adjoint, the trivial rotations go in the other direction!

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,14 +1,14 @@
 """
-    rotate_coordinates(sinθ, cosθ, i, j, midpoint, round_or_floor)
+    rotate_coordinates(sinθ, cosθ, i, j, rotation_center, round_or_floor)
 
 this rotates the coordinates and either applies round(nearest neighbour)
 or floor for :bilinear interpolation)
 """
-@inline function rotate_coordinates(sinθ, cosθ, i, j, midpoint, round_or_floor)
-    y = i - midpoint[1]
-    x = j - midpoint[2]
-    yrot = cosθ * y - sinθ * x + midpoint[1]
-    xrot = sinθ * y + cosθ * x + midpoint[2]
+@inline function rotate_coordinates(sinθ, cosθ, i, j, rotation_center, round_or_floor)
+    y = i - rotation_center[1]
+    x = j - rotation_center[2]
+    yrot = cosθ * y - sinθ * x + rotation_center[1]
+    xrot = sinθ * y + cosθ * x + rotation_center[2]
     yrot_f = round_or_floor(yrot)
     xrot_f = round_or_floor(xrot)
     yrot_int = round_or_floor(Int, yrot)
@@ -33,42 +33,42 @@ end
 
 
 """
-    _prepare_imrotate(arr, θ, midpoint)
+    _prepare_imrotate(arr, θ, rotation_center)
 
 Prepate `sin` and `cos`, creates the output array and converts type
-of `midpoint` if required.
+of `rotation_center` if required.
 """
-function _prepare_imrotate(arr::AbstractArray{T}, θ, midpoint) where T
+function _prepare_imrotate(arr::AbstractArray{T}, θ, rotation_center) where T
     # needed for rotation matrix
     θ = mod(real(T)(θ), real(T)(2π))
-    midpoint = real(T).(midpoint)
+    rotation_center = real(T).(rotation_center)
     sinθ, cosθ = sincos(real(T)(θ)) 
     out = similar(arr)
     fill!(out, 0)
-    return sinθ, cosθ, midpoint, out
+    return sinθ, cosθ, rotation_center, out
 end
 
 
 """
-    _check_trivial_rotations!(out, arr, θ, midpoint) 
+    _check_trivial_rotations!(out, arr, θ, rotation_center) 
 
-When `θ = 0 || π /2 || π || 3/2 || π` and if `midpoint` 
+When `θ = 0 || π /2 || π || 3/2 || π` and if `rotation_center` 
 is in the middle of the array.
-For an even array of size 4, the midpoint would need to be 2.5.
-For an odd array of size 5, the midpoint would need to be 3.
+For an even array of size 4, the rotation_center would need to be 2.5.
+For an odd array of size 5, the rotation_center would need to be 3.
 
 In those cases, rotations are trivial just by reversing or swapping some axes.
 """
-function _check_trivial_rotations!(out, arr, θ, midpoint; adjoint=false)
+function _check_trivial_rotations!(out, arr, θ, rotation_center; adjoint=false)
     if iszero(θ)
         out .= arr
         return true 
     end
     # check for special cases where rotations are trivial
     if (iseven(size(arr, 1)) && iseven(size(arr, 2)) && 
-        midpoint[1] ≈ size(arr, 1) ÷ 2 + 0.5 && midpoint[2] ≈ size(arr, 2) ÷ 2 + 0.5) ||
+        rotation_center[1] ≈ size(arr, 1) ÷ 2 + 0.5 && rotation_center[2] ≈ size(arr, 2) ÷ 2 + 0.5) ||
         (isodd(size(arr, 1)) && isodd(size(arr, 2)) && 
-        (midpoint[1] == size(arr, 1) ÷ 2 + 1 && midpoint[1] == size(arr, 2) ÷ 2 + 1))
+        (rotation_center[1] == size(arr, 1) ÷ 2 + 1 && rotation_center[1] == size(arr, 2) ÷ 2 + 1))
         if θ ≈ π / 2 
             if adjoint == false
                 out .= reverse(PermutedDimsArray(arr, (2, 1, 3, 4)), dims=(2,))
@@ -94,9 +94,9 @@ end
 
 
 """
-    imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1)
+    imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, rotation_center=size(arr) .÷ 2 .+ 1)
 
-Rotates a matrix around the center pixel `midpoint`. `midpoint` is defined such that there
+Rotates a matrix around the center pixel `rotation_center`. `rotation_center` is defined such that there
 is a real center pixel for even and odd values which is rotated around.
 The angle `θ` is interpreted in radians.
 
@@ -104,7 +104,7 @@ The adjoint is defined with ChainRulesCore.jl. This method also runs with CUDA (
 
 # Keywords
 * `method=:bilinear` for bilinear interpolation or `method=:nearest` for nearest neighbour
-* `midpoint=size(arr) .÷ 2 .+ 1` means there is a real center pixel around it is rotated.
+* `rotation_center=size(arr) .÷ 2 .+ 1` means there is a real center pixel around it is rotated.
 
 # Examples
 ```julia-repl
@@ -126,7 +126,7 @@ julia> NNlib.imrotate(arr, deg2rad(90)) # rotation around (3,3)
  0.0  0.0  0.0  0.0
  0.0  0.0  0.0  0.0
 
-julia> NNlib.imrotate(arr, deg2rad(90), midpoint=(2,2))
+julia> NNlib.imrotate(arr, deg2rad(90), rotation_center=(2,2))
 4×4×1×1 Array{Float64, 4}:
 [:, :, 1, 1] =
  0.0  0.0  0.0  0.0
@@ -159,14 +159,14 @@ julia> NNlib.imrotate(arr, deg2rad(45), method=:nearest)
  0.0  0.0  0.0
 ```
 """
-function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1) where T
+function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, rotation_center=size(arr) .÷ 2 .+ 1) where T
     @assert (T <: Integer && method==:nearest || !(T <: Integer)) "If the array has an Int eltype, only method=:nearest is supported"
-    @assert typeof(midpoint) <: Tuple "midpoint keyword has to be a tuple"
+    @assert typeof(rotation_center) <: Tuple "rotation_center keyword has to be a tuple"
     
-    # prepare out, the sin and cos and type of midpoint
-    sinθ, cosθ, midpoint, out = _prepare_imrotate(arr, θ, midpoint) 
-    # such as 0°, 90°, 180°, 270° and only if the midpoint is suitable
-    _check_trivial_rotations!(out, arr, θ, midpoint) && return out
+    # prepare out, the sin and cos and type of rotation_center
+    sinθ, cosθ, rotation_center, out = _prepare_imrotate(arr, θ, rotation_center) 
+    # such as 0°, 90°, 180°, 270° and only if the rotation_center is suitable
+    _check_trivial_rotations!(out, arr, θ, rotation_center) && return out
 
     # KernelAbstractions specific
     backend = KernelAbstractions.get_backend(arr)
@@ -177,7 +177,7 @@ function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(
     else 
         throw(ArgumentError("No interpolation method such as $method"))
     end
-    kernel!(out, arr, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
+    kernel!(out, arr, sinθ, cosθ, rotation_center, size(arr, 1), size(arr, 2),
             ndrange=size(arr))
 	return out
 end
@@ -185,7 +185,7 @@ end
 
 """
     ∇imrotate(dy, arr::AbstractArray{T, 4}, θ; method=:bilinear,
-                                               midpoint=size(arr) .÷ 2 .+ 1)
+                                               rotation_center=size(arr) .÷ 2 .+ 1)
 
 Adjoint for `imrotate`. Gradient only with respect to `arr` and not `θ`.
 
@@ -194,15 +194,15 @@ Adjoint for `imrotate`. Gradient only with respect to `arr` and not `θ`.
 * `arr`: Input from primal computation
 * `θ`: rotation angle in radians
 * `method=:bilinear` or `method=:nearest`
-* `midpoint=size(arr) .÷ 2 .+ 1` rotates around a real center pixel for even and odd sized arrays
+* `rotation_center=size(arr) .÷ 2 .+ 1` rotates around a real center pixel for even and odd sized arrays
 """
 function ∇imrotate(dy, arr::AbstractArray{T, 4}, θ; method=:bilinear, 
-                                               midpoint=size(arr) .÷ 2 .+ 1) where T
+                                               rotation_center=size(arr) .÷ 2 .+ 1) where T
     
-    sinθ, cosθ, midpoint, out = _prepare_imrotate(arr, θ, midpoint) 
+    sinθ, cosθ, rotation_center, out = _prepare_imrotate(arr, θ, rotation_center) 
     # for the adjoint, the trivial rotations go in the other direction!
     # pass dy and not arr
-    _check_trivial_rotations!(out, dy, θ, midpoint, adjoint=true) && return out
+    _check_trivial_rotations!(out, dy, θ, rotation_center, adjoint=true) && return out
 
     backend = KernelAbstractions.get_backend(arr)
     if method == :bilinear
@@ -213,26 +213,27 @@ function ∇imrotate(dy, arr::AbstractArray{T, 4}, θ; method=:bilinear,
         throw(ArgumentError("No interpolation method such as $method"))
     end
     # don't pass arr but dy! 
-    kernel!(out, dy, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
+    kernel!(out, dy, sinθ, cosθ, rotation_center, size(arr, 1), size(arr, 2),
             ndrange=size(arr))
     return out
 end
 
 
-@kernel function imrotate_kernel_nearest!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function imrotate_kernel_nearest!(out, arr, sinθ, cosθ, rotation_center, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
+    r(x...) = round(x..., RoundNearestTiesAway)
+    _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, rotation_center, r) 
     if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax
         @inbounds out[i, j, c, b] = arr[yrot_int, xrot_int, c, b]
     end
 end
 
 
-@kernel function imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, rotation_center, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
     
-    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
+    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, rotation_center, floor) 
     if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1 
 
         ydiff, ydiff_1minus, xdiff, xdiff_1minus = 
@@ -246,20 +247,21 @@ end
 end
 
 
-@kernel function ∇imrotate_kernel_nearest!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function ∇imrotate_kernel_nearest!(out, arr, sinθ, cosθ, rotation_center, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
+    r(x...) = round(x..., RoundNearestTiesAway)
+    _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, rotation_center, r) 
     if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax 
         Atomix.@atomic out[yrot_int, xrot_int, c, b] += arr[i, j, c, b]
     end
 end
 
 
-@kernel function ∇imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function ∇imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, rotation_center, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
+    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, rotation_center, floor) 
     if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1
         o = arr[i, j, c, b]
         ydiff, ydiff_1minus, xdiff, xdiff_1minus = 
@@ -275,10 +277,10 @@ end
 # is this rrule good? 
 # no @thunk and @unthunk
 function ChainRulesCore.rrule(::typeof(imrotate), arr::AbstractArray{T}, θ; 
-                              method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1) where T
-    res = imrotate(arr, θ; method, midpoint)
+                              method=:bilinear, rotation_center=size(arr) .÷ 2 .+ 1) where T
+    res = imrotate(arr, θ; method, rotation_center)
     function pb_rotate(dy)
-        ad = ∇imrotate(unthunk(dy), arr, θ; method, midpoint)
+        ad = ∇imrotate(unthunk(dy), arr, θ; method, rotation_center)
         return NoTangent(), ad, NoTangent()
     end    
 

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -197,7 +197,7 @@ end
     i, j, c, b = @index(Global, NTuple)
     
     yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
-    if 1 ≤ yrot_int ≤ imax - 1&& 1 ≤ xrot_int ≤ jmax - 1 
+    if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1 
 
         ydiff, ydiff_1minus, xdiff, xdiff_1minus = 
             bilinear_helper(yrot, xrot, yrot_f, xrot_f)

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,0 +1,232 @@
+
+# this rotates the coordinates and either applies round(nearest neighbour)
+# or floor (:bilinear interpolation)
+function rotate_coordinates(sinθ, cosθ, i, j, midpoint, round_or_floor)
+    y = i - midpoint[1]
+    x = j - midpoint[2]
+    yrot = cosθ * y - sinθ * x + midpoint[1]
+    xrot = sinθ * y + cosθ * x + midpoint[2]
+    yrot_f = round_or_floor(yrot)
+    xrot_f = round_or_floor(xrot)
+    yrot_int = round_or_floor(Int, yrot)
+    xrot_int = round_or_floor(Int, xrot)
+    return yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int
+end
+
+
+# helper function for bilinear
+function bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
+        xdiff = (xrot - xrot_f)
+        xdiff_diff = 1 - xdiff
+        ydiff = (yrot - yrot_f)
+        ydiff_diff = 1 - ydiff
+        # in case we hit the boundary stripe, then we need to avoid out of bounds access
+        Δi = 1#yrot_int != imax
+        Δj = 1#xrot_int != jmax
+      
+        # we need to avoid that we access arr[0]
+        # in rare cases the rounding clips off values on the left and top border
+        # we still try to access them with this extra comparison
+        Δi_min = 0#yrot_int == 0
+        Δj_min = 0#xrot_int == 0
+        return Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff
+end
+
+
+"""
+    imrotate(arr::AbstractArray, θ; method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1)
+
+Rotates a matrix around the center pixel `midpoint`.
+The angle `θ` is interpreted in radians.
+
+The adjoint is defined with ChainRulesCore.jl. This method also runs with CUDA (and in principle all KernelAbstractions.jl supported backends).
+If `arr` is a `AbstractArray{T, 3}`, the third dimension is interpreted as batch dimension.
+
+# Keywords
+* `method=:bilinear` for bilinear interpolation or `method=:nearest` for nearest neighbour
+* `midpoint=size(arr) .÷ 2 .+ 1` means there is always a real center pixel around it is rotated.
+
+# Examples
+```julia-repl
+julia> arr = zeros((6, 6)); arr[3:4, 4] .= 1;
+
+julia> arr
+6×6 Matrix{Float64}:
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  1.0  0.0  0.0
+ 0.0  0.0  0.0  1.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+
+julia> imrotate(arr, deg2rad(45))
+6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
+ 0.0  0.0  0.0        0.0        0.0       0.0
+ 0.0  0.0  0.0        0.0        0.0       0.0
+ 0.0  0.0  0.0        0.292893   0.585786  0.0
+ 0.0  0.0  0.0857864  1.0        0.292893  0.0
+ 0.0  0.0  0.0        0.0857864  0.0       0.0
+ 0.0  0.0  0.0        0.0        0.0       0.0
+
+julia> imrotate(arr, deg2rad(90))
+6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
+ 0.0  0.0  0.0  0.0  0.0          0.0
+ 0.0  0.0  0.0  0.0  0.0          0.0
+ 0.0  0.0  0.0  0.0  1.11022e-16  0.0
+ 0.0  0.0  0.0  1.0  1.0          0.0
+ 0.0  0.0  0.0  0.0  0.0          0.0
+ 0.0  0.0  0.0  0.0  0.0          0.0
+
+julia> imrotate(arr, deg2rad(90), midpoint=(3,3))
+6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  1.0  1.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+
+julia> imrotate(arr, deg2rad(90), method=:nearest)
+6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  1.0  1.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0  0.0
+
+julia> using CUDA
+
+julia> Array(imrotate(CuArray(arr), deg2rad(90))) ≈ imrotate(arr, deg2rad(90))
+true
+
+julia> using Zygote
+
+julia> f(x) = sum(abs2.(imrotate(x, π/4)))
+f (generic function with 1 method)
+
+julia> Zygote.gradient(f, arr)
+([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 5.387705551013979e-17 0.0; … ; 0.0 0.0 … 0.08578643762690495 0.0; 0.0 0.0 … 0.0 0.0],)
+
+```
+"""
+function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1,
+                  adjoint=false) where T
+    @assert (T <: Integer && method==:nearest || !(T <: Integer)) "If the array has an Int eltype, only method=:nearest is supported"
+    @assert typeof(midpoint) <: Tuple "midpoint keyword has to be a tuple"
+    # out array
+    out = similar(arr)
+    fill!(out, 0)
+    # needed for rotation matrix
+    θ = mod(real(T)(θ), real(T)(2π))
+
+    if iszero(θ)
+        out .= arr
+        return out
+    end
+
+    # check for special cases where rotations are trivial
+    if midpoint[1] ≈ size(arr, 1) ÷ 2 + 0.5 && midpoint[2] ≈ size(arr, 2) ÷ 2 + 0.5
+        if θ ≈ π / 2 
+            out .= arr
+            return reverse!(PermutedDimsArray(out, (2, 1, 3, 4)), dims=(2,))
+        elseif θ ≈ π
+            out .= arr
+            return reverse!(out, dims=(1,2))
+        elseif θ ≈ 3 / 2 * π
+            out .= arr
+            return reverse!(PermutedDimsArray(out, (2, 1, 3, 4)), dims=(1,))
+        end
+    end
+    midpoint = real(T).(midpoint)
+    sinθ, cosθ = sincos(real(T)(θ)) 
+    # KernelAbstractions specific
+    backend = get_backend(arr)
+    if adjoint
+        if method == :bilinear
+            kernel! = imrotate_kernel_adj!(backend)
+        elseif method == :nearest
+            kernel! = imrotate_kernel_nearest_adj!(backend)
+        else 
+            throw(ArgumentError("No interpolation method such as $method"))
+        end
+    else
+        if method == :bilinear
+            kernel! = imrotate_kernel!(backend)
+        elseif method == :nearest
+            kernel! = imrotate_kernel_nearest!(backend)
+        else 
+            throw(ArgumentError("No interpolation method such as $method"))
+        end
+    end
+    kernel!(out, arr, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
+            ndrange=(size(arr, 1), size(arr, 2), size(arr, 3), size(arr, 4)))
+	return out
+end
+
+@kernel function imrotate_kernel_nearest!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+    i, j, c, b = @index(Global, NTuple)
+
+    @inline _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
+    if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax
+        @inbounds out[i, j, c, b] = arr[yrot_int, xrot_int, c, b]
+    end
+end
+
+
+@kernel function imrotate_kernel!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+    i, j, c, b = @index(Global, NTuple)
+    
+    @inline yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
+    if 1 ≤ yrot_int ≤ imax - 1&& 1 ≤ xrot_int ≤ jmax - 1 
+
+        @inline Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff = 
+            bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
+        @inbounds out[i, j, c, b] = 
+            (   xdiff_diff  * ydiff_diff    * arr[yrot_int + Δi_min, xrot_int + Δj_min, c, b]
+             +  xdiff_diff  * ydiff         * arr[yrot_int + Δi,     xrot_int + Δj_min, c, b]
+             +  xdiff       * ydiff_diff    * arr[yrot_int + Δi_min, xrot_int + Δj,     c, b] 
+             +  xdiff       * ydiff         * arr[yrot_int + Δi,     xrot_int + Δj,     c, b])
+    end
+end
+
+
+
+@kernel function imrotate_kernel_nearest_adj!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+    i, j, c, b = @index(Global, NTuple)
+
+    @inline _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
+    if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax 
+        Atomix.@atomic out[yrot_int, xrot_int, c, b] += arr[i, j, c, b]
+    end
+end
+
+
+@kernel function imrotate_kernel_adj!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+    i, j, c, b = @index(Global, NTuple)
+
+    @inline yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
+    if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1
+        o = arr[i, j, c, b]
+        @inline Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff = 
+            bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
+        Atomix.@atomic out[yrot_int + Δi_min,   xrot_int + Δj_min, c, b]  += (1 - xdiff)  * (1 - ydiff) * o
+        Atomix.@atomic out[yrot_int + Δi,       xrot_int + Δj_min, c, b]  += (1 - xdiff)  * ydiff       * o
+        Atomix.@atomic out[yrot_int + Δi_min,   xrot_int + Δj,     c, b]  += xdiff        * (1 - ydiff) * o
+        Atomix.@atomic out[yrot_int + Δi,       xrot_int + Δj,     c, b]  += xdiff        * ydiff       * o
+    end
+end
+
+
+
+# is this rrule good? 
+# no @thunk and @unthunk
+function ChainRulesCore.rrule(::typeof(imrotate), array, θ; method=:bilinear, midpoint=size(array) .÷ 2 .+ 1)
+    res = imrotate(array, θ; method, midpoint)
+    function pb_rotate(ȳ)
+        f̄ = NoTangent()
+        ad = imrotate(ȳ, θ; method, midpoint, adjoint=true)
+        return NoTangent(), ad, NoTangent()
+    end    
+	return res, pb_rotate
+end

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -65,10 +65,11 @@ function _check_trivial_rotations!(out, arr, θ, midpoint)
         return true 
     end
     # check for special cases where rotations are trivial
-    if ((midpoint[1] ≈ size(arr, 1) ÷ 2 + 0.5 && midpoint[2] ≈ size(arr, 2) ÷ 2 + 0.5) ||
+    if (iseven(size(arr, 1)) && iseven(size(arr, 2)) && 
+        midpoint[1] ≈ size(arr, 1) ÷ 2 + 0.5 && midpoint[2] ≈ size(arr, 2) ÷ 2 + 0.5) ||
+        (isodd(size(arr, 1)) && isodd(size(arr, 2)) && 
         (midpoint[1] == size(arr, 1) ÷ 2 + 1 && midpoint[1] == size(arr, 2) ÷ 2 + 1))
         if θ ≈ π / 2 
-            @show "hallo"
             out .= reverse(PermutedDimsArray(arr, (2, 1, 3, 4)), dims=(2,))
             return true
         elseif θ ≈ π

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,3 +1,5 @@
+export imrotate
+
 
 # this rotates the coordinates and either applies round(nearest neighbour)
 # or floor (:bilinear interpolation)
@@ -34,13 +36,12 @@ end
 
 
 """
-    imrotate(arr::AbstractArray, θ; method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1)
+    imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(arr) .÷ 2 .+ 1)
 
 Rotates a matrix around the center pixel `midpoint`.
 The angle `θ` is interpreted in radians.
 
 The adjoint is defined with ChainRulesCore.jl. This method also runs with CUDA (and in principle all KernelAbstractions.jl supported backends).
-If `arr` is a `AbstractArray{T, 3}`, the third dimension is interpreted as batch dimension.
 
 # Keywords
 * `method=:bilinear` for bilinear interpolation or `method=:nearest` for nearest neighbour
@@ -48,65 +49,6 @@ If `arr` is a `AbstractArray{T, 3}`, the third dimension is interpreted as batch
 
 # Examples
 ```julia-repl
-julia> arr = zeros((6, 6)); arr[3:4, 4] .= 1;
-
-julia> arr
-6×6 Matrix{Float64}:
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  1.0  0.0  0.0
- 0.0  0.0  0.0  1.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
-
-julia> imrotate(arr, deg2rad(45))
-6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
- 0.0  0.0  0.0        0.0        0.0       0.0
- 0.0  0.0  0.0        0.0        0.0       0.0
- 0.0  0.0  0.0        0.292893   0.585786  0.0
- 0.0  0.0  0.0857864  1.0        0.292893  0.0
- 0.0  0.0  0.0        0.0857864  0.0       0.0
- 0.0  0.0  0.0        0.0        0.0       0.0
-
-julia> imrotate(arr, deg2rad(90))
-6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
- 0.0  0.0  0.0  0.0  0.0          0.0
- 0.0  0.0  0.0  0.0  0.0          0.0
- 0.0  0.0  0.0  0.0  1.11022e-16  0.0
- 0.0  0.0  0.0  1.0  1.0          0.0
- 0.0  0.0  0.0  0.0  0.0          0.0
- 0.0  0.0  0.0  0.0  0.0          0.0
-
-julia> imrotate(arr, deg2rad(90), midpoint=(3,3))
-6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  1.0  1.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
-
-julia> imrotate(arr, deg2rad(90), method=:nearest)
-6×6 view(::Array{Float64, 3}, :, :, 1) with eltype Float64:
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  1.0  1.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
-
-julia> using CUDA
-
-julia> Array(imrotate(CuArray(arr), deg2rad(90))) ≈ imrotate(arr, deg2rad(90))
-true
-
-julia> using Zygote
-
-julia> f(x) = sum(abs2.(imrotate(x, π/4)))
-f (generic function with 1 method)
-
-julia> Zygote.gradient(f, arr)
-([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 5.387705551013979e-17 0.0; … ; 0.0 0.0 … 0.08578643762690495 0.0; 0.0 0.0 … 0.0 0.0],)
 
 ```
 """

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,9 +1,6 @@
-export imrotate
-
-
 # this rotates the coordinates and either applies round(nearest neighbour)
 # or floor (:bilinear interpolation)
-function rotate_coordinates(sinθ, cosθ, i, j, midpoint, round_or_floor)
+@inline function rotate_coordinates(sinθ, cosθ, i, j, midpoint, round_or_floor)
     y = i - midpoint[1]
     x = j - midpoint[2]
     yrot = cosθ * y - sinθ * x + midpoint[1]
@@ -17,7 +14,7 @@ end
 
 
 # helper function for bilinear
-function bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
+@inline function bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
         xdiff = (xrot - xrot_f)
         xdiff_diff = 1 - xdiff
         ydiff = (yrot - yrot_f)
@@ -32,6 +29,55 @@ function bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, j
         Δi_min = 0#yrot_int == 0
         Δj_min = 0#xrot_int == 0
         return Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff
+end
+
+"""
+    _prepare_imrotate(arr, θ, midpoint)
+
+Prepate `sin` and `cos`, creates the output array and converts type
+of `midpoint` if required.
+"""
+function _prepare_imrotate(arr::AbstractArray{T}, θ, midpoint) where T
+    # needed for rotation matrix
+    θ = mod(real(T)(θ), real(T)(2π))
+    midpoint = real(T).(midpoint)
+    sinθ, cosθ = sincos(real(T)(θ)) 
+    out = similar(arr)
+    fill!(out, 0)
+    return sinθ, cosθ, midpoint, out
+end
+
+"""
+    _check_trivial_rotations!(out, arr, θ, midpoint) 
+
+When `θ = 0 || π /2 || π || 3/2 || π` and if `midpoint` 
+is in the middle of the array.
+For an even array of size 4, the midpoint would need to be 2.5.
+For an odd array of size 5, the midpoint would need to be 3.
+
+In those cases, rotations are trivial just by reversing or swapping some axes.
+"""
+function _check_trivial_rotations!(out, arr, θ, midpoint)
+    if iszero(θ)
+        out .= arr
+        return true 
+    end
+    # check for special cases where rotations are trivial
+    if ((midpoint[1] ≈ size(arr, 1) ÷ 2 + 0.5 && midpoint[2] ≈ size(arr, 2) ÷ 2 + 0.5) ||
+        (midpoint[1] == size(arr, 1) ÷ 2 + 1 && midpoint[1] == size(arr, 2) ÷ 2 + 1))
+        if θ ≈ π / 2 
+            out .= reverse(PermutedDimsArray(out, (2, 1, 3, 4)), dims=(2,))
+            return true
+        elseif θ ≈ π
+            out .= reverse(out, dims=(1,2))
+            return true
+        elseif θ ≈ 3 / 2 * π
+            out .= reverse(PermutedDimsArray(out, (2, 1, 3, 4)), dims=(1,))
+            return true
+        end
+    end
+
+    return false
 end
 
 
@@ -56,73 +102,63 @@ function imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, midpoint=size(
                   adjoint=false) where T
     @assert (T <: Integer && method==:nearest || !(T <: Integer)) "If the array has an Int eltype, only method=:nearest is supported"
     @assert typeof(midpoint) <: Tuple "midpoint keyword has to be a tuple"
-    # out array
-    out = similar(arr)
-    fill!(out, 0)
-    # needed for rotation matrix
-    θ = mod(real(T)(θ), real(T)(2π))
+    
+    # prepare out, the sin and cos and type of midpoint
+    sinθ, cosθ, midpoint, out = _prepare_imrotate(arr, θ, midpoint) 
+    # such as 0°, 90°, 180°, 270° and only if the midpoint is suitable
+    _check_trivial_rotations!(out, arr, θ, midpoint) && return out
 
-    if iszero(θ)
-        out .= arr
-        return out
-    end
-
-    # check for special cases where rotations are trivial
-    if midpoint[1] ≈ size(arr, 1) ÷ 2 + 0.5 && midpoint[2] ≈ size(arr, 2) ÷ 2 + 0.5
-        if θ ≈ π / 2 
-            out .= arr
-            return reverse!(PermutedDimsArray(out, (2, 1, 3, 4)), dims=(2,))
-        elseif θ ≈ π
-            out .= arr
-            return reverse!(out, dims=(1,2))
-        elseif θ ≈ 3 / 2 * π
-            out .= arr
-            return reverse!(PermutedDimsArray(out, (2, 1, 3, 4)), dims=(1,))
-        end
-    end
-    midpoint = real(T).(midpoint)
-    sinθ, cosθ = sincos(real(T)(θ)) 
     # KernelAbstractions specific
     backend = get_backend(arr)
-    if adjoint
-        if method == :bilinear
-            kernel! = imrotate_kernel_adj!(backend)
-        elseif method == :nearest
-            kernel! = imrotate_kernel_nearest_adj!(backend)
-        else 
-            throw(ArgumentError("No interpolation method such as $method"))
-        end
-    else
-        if method == :bilinear
-            kernel! = imrotate_kernel!(backend)
-        elseif method == :nearest
-            kernel! = imrotate_kernel_nearest!(backend)
-        else 
-            throw(ArgumentError("No interpolation method such as $method"))
-        end
+    if method == :bilinear
+        kernel! = imrotate_kernel_bilinear!(backend)
+    elseif method == :nearest
+        kernel! = imrotate_kernel_nearest!(backend)
+    else 
+        throw(ArgumentError("No interpolation method such as $method"))
     end
     kernel!(out, arr, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
             ndrange=(size(arr, 1), size(arr, 2), size(arr, 3), size(arr, 4)))
 	return out
 end
 
+function ∇imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, 
+                                               midpoint=size(arr) .÷ 2 .+ 1) where T
+    
+    sinθ, cosθ, midpoint, out = _prepare_imrotate(arr, θ, midpoint) 
+    _check_trivial_rotations!(out, arr, θ, midpoint) || return out
+
+    backend = get_backend(arr)
+    if method == :bilinear
+        kernel! = ∇imrotate_kernel_bilinear_adj!(backend)
+    elseif method == :nearest
+        kernel! = ∇imrotate_kernel_nearest_adj!(backend)
+    else 
+        throw(ArgumentError("No interpolation method such as $method"))
+    end
+    kernel!(out, arr, sinθ, cosθ, midpoint, size(arr, 1), size(arr, 2),
+            ndrange=(size(arr, 1), size(arr, 2), size(arr, 3), size(arr, 4)))
+    return out
+end
+
+
 @kernel function imrotate_kernel_nearest!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    @inline _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
+    _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
     if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax
         @inbounds out[i, j, c, b] = arr[yrot_int, xrot_int, c, b]
     end
 end
 
 
-@kernel function imrotate_kernel!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
     
-    @inline yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
+    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
     if 1 ≤ yrot_int ≤ imax - 1&& 1 ≤ xrot_int ≤ jmax - 1 
 
-        @inline Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff = 
+        Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff = 
             bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
         @inbounds out[i, j, c, b] = 
             (   xdiff_diff  * ydiff_diff    * arr[yrot_int + Δi_min, xrot_int + Δj_min, c, b]
@@ -133,24 +169,23 @@ end
 end
 
 
-
-@kernel function imrotate_kernel_nearest_adj!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function ∇imrotate_kernel_nearest!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    @inline _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
+    _, _, _, _, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, round) 
     if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax 
         Atomix.@atomic out[yrot_int, xrot_int, c, b] += arr[i, j, c, b]
     end
 end
 
 
-@kernel function imrotate_kernel_adj!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
+@kernel function ∇imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, midpoint, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    @inline yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
+    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = rotate_coordinates(sinθ, cosθ, i, j, midpoint, floor) 
     if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1
         o = arr[i, j, c, b]
-        @inline Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff = 
+        Δi, Δj, Δi_min, Δj_min, ydiff, ydiff_diff, xdiff, xdiff_diff = 
             bilinear_helper(yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int, imax, jmax)
         Atomix.@atomic out[yrot_int + Δi_min,   xrot_int + Δj_min, c, b]  += (1 - xdiff)  * (1 - ydiff) * o
         Atomix.@atomic out[yrot_int + Δi,       xrot_int + Δj_min, c, b]  += (1 - xdiff)  * ydiff       * o
@@ -160,14 +195,12 @@ end
 end
 
 
-
 # is this rrule good? 
 # no @thunk and @unthunk
 function ChainRulesCore.rrule(::typeof(imrotate), array, θ; method=:bilinear, midpoint=size(array) .÷ 2 .+ 1)
     res = imrotate(array, θ; method, midpoint)
-    function pb_rotate(ȳ)
-        f̄ = NoTangent()
-        ad = imrotate(ȳ, θ; method, midpoint, adjoint=true)
+    function pb_rotate(dy)
+        ad = imrotate(dy, θ; method, midpoint, adjoint=true)
         return NoTangent(), ad, NoTangent()
     end    
 	return res, pb_rotate

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -97,8 +97,9 @@ end
     imrotate(arr::AbstractArray{T, 4}, θ; method=:bilinear, rotation_center=size(arr) .÷ 2 .+ 1)
 
 Rotates an array in the first two dimensions around the center pixel `rotation_center`. 
-`rotation_center` is defined such that there is a real center pixel for even and odd values which is rotated around.
+The default value of `rotation_center` is defined such that there is a integer center pixel for even and odd sized arrays which it is rotated around.
 For an even sized array of size `(4,4)` this would be `(3,3)`, for an odd array of size `(3,3)` this would be `(2,2)`
+However, `rotation_center` can be also non-integer numbers if specified.
 
 The angle `θ` is interpreted in radians.
 

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,10 +1,10 @@
 """
-    _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, round_or_floor)
+    _rotate_coordinates(sinθ, cosθ, i, j, rotation_center, round_or_floor)
 
 This rotates the coordinates and either applies round(nearest neighbour)
 or floor for :bilinear interpolation)
 """
-@inline function _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, round_or_floor)
+@inline function _rotate_coordinates(sinθ, cosθ, i, j, rotation_center, round_or_floor)
     y = i - rotation_center[1]
     x = j - rotation_center[2]
     yrot = cosθ * y - sinθ * x + rotation_center[1]
@@ -225,7 +225,7 @@ end
     i, j, c, b = @index(Global, NTuple)
 
     r(x...) = round(x..., RoundNearestTiesAway)
-    _, _, _, _, yrot_int, xrot_int = _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, r) 
+    _, _, _, _, yrot_int, xrot_int = _rotate_coordinates(sinθ, cosθ, i, j, rotation_center, r) 
     if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax
         @inbounds out[i, j, c, b] = arr[yrot_int, xrot_int, c, b]
     end
@@ -235,7 +235,7 @@ end
 @kernel function imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, rotation_center, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
     
-    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, floor) 
+    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = _rotate_coordinates(sinθ, cosθ, i, j, rotation_center, floor) 
     if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1 
 
         ydiff, ydiff_1minus, xdiff, xdiff_1minus = 
@@ -253,7 +253,7 @@ end
     i, j, c, b = @index(Global, NTuple)
 
     r(x...) = round(x..., RoundNearestTiesAway)
-    _, _, _, _, yrot_int, xrot_int = _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, r) 
+    _, _, _, _, yrot_int, xrot_int = _rotate_coordinates(sinθ, cosθ, i, j, rotation_center, r) 
     if 1 ≤ yrot_int ≤ imax && 1 ≤ xrot_int ≤ jmax 
         Atomix.@atomic out[yrot_int, xrot_int, c, b] += arr[i, j, c, b]
     end
@@ -263,7 +263,7 @@ end
 @kernel function ∇imrotate_kernel_bilinear!(out, arr, sinθ, cosθ, rotation_center, imax, jmax)
     i, j, c, b = @index(Global, NTuple)
 
-    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = _rotate_coordinatess(sinθ, cosθ, i, j, rotation_center, floor) 
+    yrot, xrot, yrot_f, xrot_f, yrot_int, xrot_int = _rotate_coordinates(sinθ, cosθ, i, j, rotation_center, floor) 
     if 1 ≤ yrot_int ≤ imax - 1 && 1 ≤ xrot_int ≤ jmax - 1
         o = arr[i, j, c, b]
         ydiff, ydiff_1minus, xdiff, xdiff_1minus = 

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -4,87 +4,75 @@ function rotation_testsuite(Backend)
     T = Float32
     atol = T == Float32 ? 1e-3 : 1e-6
     rtol = T == Float32 ? 1f-2 : 1f-6
-    
-    @testset "Image Rotation" begin
+    angles = deg2rad.([0, 0.0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 
+
+    @testset "imrotate" begin
         @testset "Simple test" begin
             arr = device(zeros((6, 6, 1, 1))); 
             arr[3:4, 4, 1, 1] .= 1;
             @test all(cpu(NNlib.imrotate(arr, deg2rad(45))) .≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.29289321881345254 0.585786437626905 0.0; 0.0 0.0 0.08578643762690495 1.0 0.2928932188134524 0.0; 0.0 0.0 0.0 0.08578643762690495 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0])
         end
-    end
 
 
-    @testset "Compare with ImageTransformations" begin
-        arr = device(zeros(T, (51, 51, 1, 1)))
-        arr[15:40, 15:40, :, :] .= device(1 .+ randn((26, 26)))                                                                       
-        
-        arr2 = device(zeros(T, (51, 51, 1, 5)))
-        arr2[15:40, 15:40, :, :] .= device(arr[15:40, 15:40, :, :])
+        @testset "Compare with ImageTransformations" begin
+            for sz in [(51,51,1,1)]
+                
+                arr1 = device(zeros(T, sz))
+                arr1[15:40, 15:40, :, :] .= device(1 .+ randn((26, 26)))                                                                       
+                arr2 = device(zeros(T, (sz[1], sz[2], sz[3], 3)))
+                arr2[15:40, 15:40, :, :] .= device(arr1[15:40, 15:40, :, :])
 
-
-        for method in [:nearest, :bilinear]
-            for angle in deg2rad.([0, 35, 45, 90, 135, 170, 180, 270, 360])
-                res1 = cpu(NNlib.imrotate(arr, angle; method))
-                res3 = cpu(NNlib.imrotate(arr2, angle; method))
-                if method == :nearest
-                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
-                elseif method == :bilinear
-                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
+                for method in [:nearest, :bilinear]
+                    @testset "$method" begin
+                        for angle in angles
+                            if iseven(sz[1])
+                                res1 = cpu(NNlib.imrotate(arr1, angle; method, midpoint=size(arr1).÷2 .+ 0.5))
+                                res2 = cpu(NNlib.imrotate(arr2, angle; method, midpoint=size(arr1).÷2 .+ 0.5))
+                            else
+                                res1 = cpu(NNlib.imrotate(arr1, angle; method))
+                                res2 = cpu(NNlib.imrotate(arr2, angle; method))
+                            end
+                            if method == :nearest
+                                res_IT = ImageTransformations.imrotate(cpu(arr1)[:, :, 1, 1], angle, axes(arr1)[1:2], method=Constant(), fillvalue=0)
+                            elseif method == :bilinear
+                                res_IT = ImageTransformations.imrotate(cpu(arr1)[:, :, 1, 1], angle, axes(arr1)[1:2], fillvalue=0)
+                            end
+                            @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res_IT[:, :], rtol=rtol))
+                            @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :,:, 1], rtol=rtol))
+                            @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :,:, 2], rtol=rtol))
+                        end
+                    end
                 end
-                @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :], rtol=rtol))
-                @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res3[:, :,:, 1], rtol=rtol))
-                @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res3[:, :,:, 2], rtol=rtol))
             end
         end
-        
-        arr = device(zeros(T, (52, 52, 1, 1)))
-        arr[15:40, 15:40, :, :] .= device(1 .+ randn((26, 26)))
-        
-        arr2 = device(zeros(T, (52, 52, 5, 1)))
-        arr2[15:40, 15:40, :, 1] .= device(arr[15:40, 15:40, :, 1])
+            
+        @testset "Compare for plausibilty" begin
+            @testset "Special cases of rotation" begin
+                arr = device(zeros(T, (10, 10, 1, 3)))
+                arr[6, 6, :, 1] .= 1
+                arr[6, 6, :, 2] .= 2
+                arr[6, 6, :, 3] .= 2
 
-        for method in [:nearest, :bilinear]
-            for angle in deg2rad.([0, 35,  90, 170, 180, 270, 360])
-                res1 = cpu(NNlib.imrotate(arr, angle; method, midpoint=size(arr) .÷2 .+0.5))
-                res3 = cpu(NNlib.imrotate(arr2, angle; method, midpoint=size(arr) .÷2 .+0.5))
-                if method == :nearest
-                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
-                elseif method == :bilinear
-                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
+                for method in [:bilinear, :nearest]
+                    @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(0); method)))
+                    @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(90); method)))
+                    @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(180); method)))
+                    @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(270); method)))
+                    @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(360); method)))
                 end
-                @test all(1 .+ res1[:, :, :, :] .≈ 1 .+ res2[:, :])
-                @test all(1 .+ res1[:, :, :, :] .≈ 1 .+ res3[:, :, :, :])
-                @test all(1 .+ res1[:, :, :, :] .≈ 1 .+ res3[:, :, :, :])
             end
         end
 
-    end
-
-    @testset "Compare for plausibilty" begin
-        arr = zeros(T, (10, 10, 1, 3))
-        arr[6, 6, :, 1] .= 1
-        arr[6, 6, :, 2] .= 2
-        arr[6, 6, :, 3] .= 2
-
-        for method in [:bilinear, :nearest]
-            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(0); method)))
-            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(90); method)))
-            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(180); method)))
-            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(270); method)))
-            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(360); method)))
-        end
-    end
-
-
-    @testset "Test gradients" begin
-        for method in [:nearest, :bilinear]
-            for angle in deg2rad.([0, 0.0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234])
-                gradtest_fn(
-                    x -> NNlib.imrotate(x, angle; method),
-                    device(rand(T, 11,11,1,1)); atol)
-                gradtest_fn(
-                    x -> NNlib.imrotate(x, angle; method),
-                    device(rand(T, 10,10,1,1)); atol)        
+        @testset "Test gradients" begin
+            for method in [:nearest, :bilinear]
+                for angle in angles 
+                    gradtest_fn(
+                        x -> NNlib.imrotate(x, angle; method),
+                        device(rand(T, 11,11,1,1)); atol)
+                    gradtest_fn(
+                        x -> NNlib.imrotate(x, angle; method),
+                        device(rand(T, 10,10,1,1)); atol)        
+                end
             end
         end
     end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -3,7 +3,8 @@ function rotation_testsuite(Backend)
     gradtest_fn = Backend == CPU ? gradtest : gputest
     T = Float32
     atol = T == Float32 ? 1e-3 : 1e-6
-
+    rtol = T == Float32 ? 1f-3 : 1f-6
+    
     @testset "Image Rotation" begin
         @testset "Simple test" begin
             arr = device(zeros((6, 6, 1, 1))); 
@@ -30,9 +31,9 @@ function rotation_testsuite(Backend)
                 elseif method == :bilinear
                     res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
                 end
-                @test all(1 .+ res1[:, :, :, :] .≈ 1 .+ res2[:, :])
-                @test all(1 .+ res1[:, :, :, :] .≈ 1 .+ res3[:, :,:, 1])
-                @test all(1 .+ res1[:, :, :, :] .≈ 1 .+ res3[:, :,:, 2])
+                @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :], rtol=rtol))
+                @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res3[:, :,:, 1], rtol=rtol))
+                @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res3[:, :,:, 2], rtol=rtol))
             end
         end
         

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -4,7 +4,7 @@ function rotation_testsuite(Backend)
     T = Float32
     atol = T == Float32 ? 1e-3 : 1e-6
     rtol = T == Float32 ? 1f-2 : 1f-6
-    angles = deg2rad.([0, 0.0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 
+    angles = deg2rad.([0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 
 
     @testset "imrotate" begin
         @testset "Simple test" begin
@@ -15,7 +15,7 @@ function rotation_testsuite(Backend)
 
 
         @testset "Compare with ImageTransformations" begin
-            for sz in [(51,51,1,1)]
+            for sz in [(51,51,1,1), (52,52,1,1)]
                 
                 arr1 = device(zeros(T, sz))
                 arr1[15:40, 15:40, :, :] .= device(1 .+ randn((26, 26)))                                                                       
@@ -37,7 +37,6 @@ function rotation_testsuite(Backend)
                             elseif method == :bilinear
                                 res_IT = ImageTransformations.imrotate(cpu(arr1)[:, :, 1, 1], angle, axes(arr1)[1:2], fillvalue=0)
                             end
-                            @show res1, res_IT 
                             @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res_IT[:, :], rtol=rtol))
                             @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :,:, 1], rtol=rtol))
                             @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :,:, 2], rtol=rtol))
@@ -52,7 +51,7 @@ function rotation_testsuite(Backend)
                 arr = device(zeros(T, (10, 10, 1, 3)))
                 arr[6, 6, :, 1] .= 1
                 arr[6, 6, :, 2] .= 2
-                arr[6, 6, :, 3] .= 2
+                arr[6, 6, :, 3] .= 3
 
                 for method in [:bilinear, :nearest]
                     @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(0); method)))

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -1,4 +1,4 @@
-function upsample_testsuite(Backend)
+function rotation_testsuite(Backend)
     device(x) = adapt(Backend(), x)
     gradtest_fn = Backend == CPU ? gradtest : gputest
     T = Float32

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -2,8 +2,8 @@ function rotation_testsuite(Backend)
     device(x) = adapt(Backend(), x)
     gradtest_fn = Backend == CPU ? gradtest : gputest
     T = Float64
-    atol = T == Float32 ? 1e-3 : 5e-5
-    rtol = T == Float32 ? 1f-3 : 5e-5
+    atol = T == Float32 ? 1e-3 : 1e-6
+    rtol = T == Float32 ? 1f-3 : 1f-6
     angles = deg2rad.([0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 
 
     @testset "imrotate" begin

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -2,8 +2,8 @@ function rotation_testsuite(Backend)
     device(x) = adapt(Backend(), x)
     gradtest_fn = Backend == CPU ? gradtest : gputest
     T = Float64
-    atol = T == Float32 ? 1e-3 : 1e-6
-    rtol = T == Float32 ? 1f-3 : 1f-6
+    atol = T == Float32 ? 1e-3 : 5e-5
+    rtol = T == Float32 ? 1f-3 : 5e-5
     angles = deg2rad.([0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 
 
     @testset "imrotate" begin

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -77,17 +77,17 @@
                 f(x) = sum(abs2.(NNlib.imrotate(x, deg2rad(angle); method)))
        
                 img2 = randn((14, 14, 1, 1));
-                grad = FiniteDifferences.grad(central_fdm(7, 1), f, img2)[1]
+                grad = FiniteDifferences.grad(FiniteDifferences.central_fdm(7, 1), f, img2)[1]
                 grad2 = Zygote.gradient(f, img2)[1];
                 @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
                 
                 img2 = randn((9, 9, 1, 2));
-                grad = FiniteDifferences.grad(central_fdm(7, 1), f, img2)[1]
+                grad = FiniteDifferences.grad(FiniteDifferences.central_fdm(7, 1), f, img2)[1]
                 grad2 = Zygote.gradient(f, img2)[1];
                 @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
 
                 img2 = randn((8, 12, 1, 1));
-                grad = FiniteDifferences.grad(central_fdm(7, 1), f, img2)[1]
+                grad = FiniteDifferences.grad(FiniteDifferences.central_fdm(7, 1), f, img2)[1]
                 grad2 = Zygote.gradient(f, img2)[1];
                 @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
             end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -1,7 +1,7 @@
 function rotation_testsuite(Backend)
     device(x) = adapt(Backend(), x)
     gradtest_fn = Backend == CPU ? gradtest : gputest
-    T = Float32
+    T = Float64
     atol = T == Float32 ? 1e-3 : 1e-6
     rtol = T == Float32 ? 1f-3 : 1f-6
     angles = deg2rad.([0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -1,50 +1,55 @@
+function upsample_testsuite(Backend)
+    device(x) = adapt(Backend(), x)
+    gradtest_fn = Backend == CPU ? gradtest : gputest
+    T = Float32
 
-@testset "Image Rotation" begin
-    @testset "SImple test" begin
-        arr = zeros((6, 6, 1, 1)); arr[3:4, 4, 1, 1] .= 1;
-        @test all(NNlib.imrotate(arr, deg2rad(45)) .≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.29289321881345254 0.585786437626905 0.0; 0.0 0.0 0.08578643762690495 1.0 0.2928932188134524 0.0; 0.0 0.0 0.0 0.08578643762690495 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0])
 
+    @testset "Image Rotation" begin
+        @testset "SImple test" begin
+            arr = device(zeros((6, 6, 1, 1))); 
+            arr[3:4, 4, 1, 1] .= 1;
+            @test all(cpu(NNlib.imrotate(arr, deg2rad(45))) .≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.29289321881345254 0.585786437626905 0.0; 0.0 0.0 0.08578643762690495 1.0 0.2928932188134524 0.0; 0.0 0.0 0.0 0.08578643762690495 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0])
+        end
     end
 
+
     @testset "Compare with ImageTransformations" begin
-        arr = zeros((51, 51, 1, 1))
-        arr[15:40, 15:40, :, :] .= 1 .+ randn((26, 26))
+        arr = device(zeros(T, (51, 51, 1, 1)))
+        arr[15:40, 15:40, :, :] .= device(1 .+ randn((26, 26)))                                                                       
         
-        arr2 = zeros((51, 51, 1, 5))
-        arr2[15:40, 15:40, :, :] .= arr[15:40, 15:40, :, :] 
+        arr2 = device(zeros(T, (51, 51, 1, 5)))
+        arr2[15:40, 15:40, :, :] .= device(arr[15:40, 15:40, :, :])
 
 
         for method in [:nearest, :bilinear]
             for angle in deg2rad.([0, 35, 45, 90, 135, 170, 180, 270, 360])
-                res1 = NNlib.imrotate(arr, angle; method)
-                res3 = NNlib.imrotate(arr2, angle; method)
+                res1 = cpu(NNlib.imrotate(arr, angle; method))
+                res3 = cpu(NNlib.imrotate(arr2, angle; method))
                 if method == :nearest
-                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
+                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
                 elseif method == :bilinear
-                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
+                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
                 end
                 @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res2[20:35, 20:35])
                 @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, 1])
                 @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, 2])
             end
         end
-
-
         
-        arr = zeros((52, 52, 1, 1))
-        arr[15:40, 15:40, :, :] .= 1 .+ randn((26, 26))
+        arr = device(zeros(T, (52, 52, 1, 1)))
+        arr[15:40, 15:40, :, :] .= device(1 .+ randn((26, 26)))
         
-        arr2 = zeros((52, 52, 5, 1))
-        arr2[15:40, 15:40, :, 1] .= arr[15:40, 15:40, :, 1]
+        arr2 = device(zeros(T, (52, 52, 5, 1)))
+        arr2[15:40, 15:40, :, 1] .= device(arr[15:40, 15:40, :, 1])
 
         for method in [:nearest, :bilinear]
             for angle in deg2rad.([0, 35,  90, 170, 180, 270, 360])
-                res1 = NNlib.imrotate(arr, angle; method, midpoint=size(arr) .÷2 .+0.5)
-                res3 = NNlib.imrotate(arr2, angle; method, midpoint=size(arr) .÷2 .+0.5)
+                res1 = cpu(NNlib.imrotate(arr, angle; method, midpoint=size(arr) .÷2 .+0.5))
+                res3 = cpu(NNlib.imrotate(arr2, angle; method, midpoint=size(arr) .÷2 .+0.5))
                 if method == :nearest
-                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
+                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
                 elseif method == :bilinear
-                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
+                    res2 = ImageTransformations.imrotate(cpu(arr)[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
                 end
                 @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res2[20:35, 20:35])
                 @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, :])
@@ -55,7 +60,7 @@
     end
 
     @testset "Compare for plausibilty" begin
-        arr = zeros((10, 10, 1, 3))
+        arr = zeros(T, (10, 10, 1, 3))
         arr[6, 6, :, 1] .= 1
         arr[6, 6, :, 2] .= 2
         arr[6, 6, :, 3] .= 2
@@ -76,22 +81,21 @@
             for angle in deg2rad.([0, 45, 90, 137, 180, 270, 360])
                 f(x) = sum(abs2.(NNlib.imrotate(x, deg2rad(angle); method)))
        
-                img2 = randn((14, 14, 1, 1));
+                img2 = randn(T, (14, 14, 1, 1));
                 grad = FiniteDifferences.grad(FiniteDifferences.central_fdm(7, 1), f, img2)[1]
                 grad2 = Zygote.gradient(f, img2)[1];
                 @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
                 
-                img2 = randn((9, 9, 1, 2));
+                img2 = randn(T, (9, 9, 1, 2));
                 grad = FiniteDifferences.grad(FiniteDifferences.central_fdm(7, 1), f, img2)[1]
                 grad2 = Zygote.gradient(f, img2)[1];
                 @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
 
-                img2 = randn((8, 12, 1, 1));
+                img2 = randn(T, (8, 12, 1, 1));
                 grad = FiniteDifferences.grad(FiniteDifferences.central_fdm(7, 1), f, img2)[1]
                 grad2 = Zygote.gradient(f, img2)[1];
                 @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
             end
         end
     end
-
 end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -37,6 +37,7 @@ function rotation_testsuite(Backend)
                             elseif method == :bilinear
                                 res_IT = ImageTransformations.imrotate(cpu(arr1)[:, :, 1, 1], angle, axes(arr1)[1:2], fillvalue=0)
                             end
+                            @show res1, res_IT 
                             @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res_IT[:, :], rtol=rtol))
                             @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :,:, 1], rtol=rtol))
                             @test all(.≈(1 .+ res1[:, :, :, :], 1 .+ res2[:, :,:, 2], rtol=rtol))

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -3,7 +3,7 @@ function rotation_testsuite(Backend)
     gradtest_fn = Backend == CPU ? gradtest : gputest
     T = Float32
     atol = T == Float32 ? 1e-3 : 1e-6
-    rtol = T == Float32 ? 1f-3 : 1f-6
+    rtol = T == Float32 ? 1f-2 : 1f-6
     
     @testset "Image Rotation" begin
         @testset "Simple test" begin

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -77,7 +77,7 @@ function upsample_testsuite(Backend)
 
     @testset "Test gradients" begin
         for method in [:nearest, :bilinear]
-            for angle in deg2rad.([0, 35,  90, 170, 180, 270, 360])
+            for angle in deg2rad.([0, 0.0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234])
                 gradtest_fn(
                     x -> NNlib.imrotate(x, angle; method),
                     device(rand(T, 11,11,1,1)); atol)

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -79,10 +79,10 @@ function upsample_testsuite(Backend)
         for method in [:nearest, :bilinear]
             for angle in deg2rad.([0, 35,  90, 170, 180, 270, 360])
                 gradtest_fn(
-                    x -> NNlib.imrotate(x, angle),
+                    x -> NNlib.imrotate(x, angle; method),
                     device(rand(T, 11,11,1,1)); atol)
                 gradtest_fn(
-                    x -> NNlib.imrotate(x, angle),
+                    x -> NNlib.imrotate(x, angle; method),
                     device(rand(T, 10,10,1,1)); atol)        
             end
         end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -3,7 +3,7 @@ function rotation_testsuite(Backend)
     gradtest_fn = Backend == CPU ? gradtest : gputest
     T = Float32
     atol = T == Float32 ? 1e-3 : 1e-6
-    rtol = T == Float32 ? 1f-2 : 1f-6
+    rtol = T == Float32 ? 1f-3 : 1f-6
     angles = deg2rad.([0, 0.0001, 35, 90, -90, -90.0123, 170, 180, 270, 360, 450, 1234.1234]) 
 
     @testset "imrotate" begin

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -1,0 +1,97 @@
+
+@testset "Image Rotation" begin
+    @testset "SImple test" begin
+        arr = zeros((6, 6, 1, 1)); arr[3:4, 4, 1, 1] .= 1;
+        @test all(NNlib.imrotate(arr, deg2rad(45)) .≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.29289321881345254 0.585786437626905 0.0; 0.0 0.0 0.08578643762690495 1.0 0.2928932188134524 0.0; 0.0 0.0 0.0 0.08578643762690495 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0])
+
+    end
+
+    @testset "Compare with ImageTransformations" begin
+        arr = zeros((51, 51, 1, 1))
+        arr[15:40, 15:40, :, :] .= 1 .+ randn((26, 26))
+        
+        arr2 = zeros((51, 51, 1, 5))
+        arr2[15:40, 15:40, :, :] .= arr[15:40, 15:40, :, :] 
+
+
+        for method in [:nearest, :bilinear]
+            for angle in deg2rad.([0, 35, 45, 90, 135, 170, 180, 270, 360])
+                res1 = NNlib.imrotate(arr, angle; method)
+                res3 = NNlib.imrotate(arr2, angle; method)
+                if method == :nearest
+                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
+                elseif method == :bilinear
+                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
+                end
+                @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res2[20:35, 20:35])
+                @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, 1])
+                @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, 2])
+            end
+        end
+
+
+        
+        arr = zeros((52, 52, 1, 1))
+        arr[15:40, 15:40, :, :] .= 1 .+ randn((26, 26))
+        
+        arr2 = zeros((52, 52, 5, 1))
+        arr2[15:40, 15:40, :, 1] .= arr[15:40, 15:40, :, 1]
+
+        for method in [:nearest, :bilinear]
+            for angle in deg2rad.([0, 35,  90, 170, 180, 270, 360])
+                res1 = NNlib.imrotate(arr, angle; method, midpoint=size(arr) .÷2 .+0.5)
+                res3 = NNlib.imrotate(arr2, angle; method, midpoint=size(arr) .÷2 .+0.5)
+                if method == :nearest
+                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], method=Constant(), fillvalue=0)
+                elseif method == :bilinear
+                    res2 = ImageTransformations.imrotate(arr[:, :, 1, 1], angle, axes(arr)[1:2], fillvalue=0)
+                end
+                @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res2[20:35, 20:35])
+                @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, :])
+                @test all(1 .+ res1[20:35, 20:35, :, :] .≈ 1 .+ res3[20:35, 20:35, :, :])
+            end
+        end
+
+    end
+
+    @testset "Compare for plausibilty" begin
+        arr = zeros((10, 10, 1, 3))
+        arr[6, 6, :, 1] .= 1
+        arr[6, 6, :, 2] .= 2
+        arr[6, 6, :, 3] .= 2
+
+        for method in [:bilinear, :nearest]
+            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(0); method)))
+            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(90); method)))
+            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(180); method)))
+            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(270); method)))
+            @test all(.≈(arr , NNlib.imrotate(arr, deg2rad(360); method)))
+        end
+    end
+
+
+    @testset "Test gradients" begin
+
+        for method in [:nearest, :bilinear]
+            for angle in deg2rad.([0, 45, 90, 137, 180, 270, 360])
+                f(x) = sum(abs2.(NNlib.imrotate(x, deg2rad(angle); method)))
+       
+                img2 = randn((14, 14, 1, 1));
+                grad = FiniteDifferences.grad(central_fdm(7, 1), f, img2)[1]
+                grad2 = Zygote.gradient(f, img2)[1];
+                @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
+                
+                img2 = randn((9, 9, 1, 2));
+                grad = FiniteDifferences.grad(central_fdm(7, 1), f, img2)[1]
+                grad2 = Zygote.gradient(f, img2)[1];
+                @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
+
+                img2 = randn((8, 12, 1, 1));
+                grad = FiniteDifferences.grad(central_fdm(7, 1), f, img2)[1]
+                grad2 = Zygote.gradient(f, img2)[1];
+                @test all(.≈(1 .+ grad, 1 .+ grad2, rtol=1f-7))
+            end
+        end
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ function nnlib_testsuite(Backend; skip_tests = Set{String}())
         upsample_testsuite(Backend)
     end
     @conditional_testset "rotation" skip_tests begin
-        upsample_testsuite(Backend)
+        rotation_testsuite(Backend)
     end
     @conditional_testset "Gather" skip_tests begin
         gather_testsuite(Backend)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,9 @@ function nnlib_testsuite(Backend; skip_tests = Set{String}())
     @conditional_testset "Upsample" skip_tests begin
         upsample_testsuite(Backend)
     end
+    @conditional_testset "rotation" skip_tests begin
+        upsample_testsuite(Backend)
+    end
     @conditional_testset "Gather" skip_tests begin
         gather_testsuite(Backend)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ using Zygote: gradient
 using StableRNGs
 using Documenter
 using Adapt
+using ImageTransformations
+using Interpolations: Constant
 using KernelAbstractions
 import ReverseDiff as RD        # used in `pooling.jl`
 
@@ -43,6 +45,7 @@ cpu(x) = adapt(CPU(), x)
 include("gather.jl")
 include("scatter.jl")
 include("upsample.jl")
+include("rotation.jl")
 
 function nnlib_testsuite(Backend; skip_tests = Set{String}())
     @conditional_testset "Upsample" skip_tests begin


### PR DESCRIPTION
Hi,

based on  [DiffImageRotation.jl](https://github.com/roflmaostc/DiffImageRotation.jl) and as discussed in #552 I tried to add image rotation into NNlib.jl.

Some comments:
I always assumed a 4D array. In principle, the results match the ones from  [ImageTransformations.jl](https://github.com/JuliaImages/ImageTransformations.jl) closely. But, the boundary handling is different and sometimes rounding artifacts occur.
I compared this a little but I think there is space for interpretation how to do it. There is some code left, to change the boundary handling at the cost of ~20% performance.

### PR Checklist

- [x] Tests are added
- [x] Documentation -> comes later


## Benchmarks
@maxfreu mentioned something about different parallelization schemes for CPU vs GPU.

Benchmarking between my implementation and the parallelized elementwise application shows that the timings are roughly equal. So not sure if we should make the code much more verbose and complicated? But please share your experience with me! Especially, if we can squeeze out more performance out of CUDA, that would be great! But on CPU we already beat existing code:

Some benchmarking:
```julia
julia> CUDA.versioninfo()
CUDA runtime 11.8, artifact installation
CUDA driver 11.4
NVIDIA driver 470.223.2

CUDA libraries: 
- CUBLAS: 11.11.3
- CURAND: 10.3.0
- CUFFT: 10.9.0
- CUSOLVER: 11.4.1
- CUSPARSE: 11.7.5
- CUPTI: 18.0.0
- NVML: 11.0.0+470.223.2

Julia packages: 
- CUDA: 5.1.1
- CUDA_Driver_jll: 0.7.0+0
- CUDA_Runtime_jll: 0.10.1+0

Toolchain:
- Julia: 1.9.4
- LLVM: 14.0.6

1 device:
  0: NVIDIA GeForce RTX 3060 (sm_86, 11.369 GiB / 11.749 GiB available)


julia> versioninfo()
Julia Version 1.9.4
Commit 8e5136fa297 (2023-11-14 08:46 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 12 × AMD Ryzen 5 5600X 6-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, znver3)
  Threads: 12 on 12 virtual cores
Environment:
  JULIA_NUM_THREADS = 12
```


### Comparison to ImageTransformations:

```julia
# multithreaded
julia> arr_2D = randn((2000, 3000));

julia> @btime NNlib.imrotate(reshape($arr_2D, 2000, 3000, 1, 1), deg2rad(13));
  24.449 ms (153 allocations: 45.79 MiB)

julia> @btime ImageTransformations.imrotate($arr_2D, deg2rad(13));
  81.811 ms (3 allocations: 67.55 MiB)

# julia -t 1
julia> @btime NNlib.imrotate(reshape($arr_2D, 2000, 3000, 1, 1), deg2rad(13));
  45.397 ms (29 allocations: 45.78 MiB)

julia> @btime ImageTransformations.imrotate($arr_2D, deg2rad(13));
  95.694 ms (3 allocations: 67.55 MiB)
```


```julia
julia> using CUDA, NNLib, BenchmarkTools, Tullio

julia> arr = randn(Float32, (256, 256, 3, 32));

julia> arrc = CuArray(arr);

julia> @btime NNlib.imrotate($arr, deg2rad(37));
  8.020 ms (147 allocations: 24.01 MiB)

julia> @btime @tullio out := sin.($arr[i, j, c, b]);
  8.358 ms (196 allocations: 10.77 KiB)

julia> @btime CUDA.@sync NNlib.imrotate($arrc, deg2rad(37));
  510.106 μs (99 allocations: 5.39 KiB)

julia> @btime CUDA.@sync sin.($arrc);
  291.288 μs (37 allocations: 2.36 KiB)


```


Would be great if someone reviews this and we can merge it! Not urgent for me, since DiffImageRotation.jl is registered and I anyway use this currently.