### PR TITLE
Add rrule for `oftf`

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -14,6 +14,12 @@ ACTIVATIONS = [
 # of type float (to allow for integer inputs)
 oftf(x, y) = oftype(float(x), y)
 
+# oftype contains control flow on 1.10+, which can lead to type instabilities under AD 
+function rrule(::typeof(oftf), x, y)
+    oftf_pullback(Δ) = oftype(y, Δ)
+    return oftf(x, y), oftf_pullback
+end
+
 """
     σ(x) = 1 / (1 + exp(-x))
 

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -16,7 +16,8 @@ oftf(x, y) = oftype(float(x), y)
 
 # oftype contains control flow on 1.10+, which can lead to type instabilities under AD 
 function rrule(::typeof(oftf), x, y)
-    oftf_pullback(Δ) = (NoTangent(), NoTangent(), oftype(y, Δ))
+    proj_y = ChainRulesCore.ProjectTo(y)
+    oftf_pullback(Δ) = (NoTangent(), NoTangent(), proj_y(Δ))
     return oftf(x, y), oftf_pullback
 end
 

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -16,7 +16,7 @@ oftf(x, y) = oftype(float(x), y)
 
 # oftype contains control flow on 1.10+, which can lead to type instabilities under AD 
 function rrule(::typeof(oftf), x, y)
-    oftf_pullback(Δ) = oftype(y, Δ)
+    oftf_pullback(Δ) = (NoTangent(), NoTangent(), oftype(y, Δ))
     return oftf(x, y), oftf_pullback
 end
 


### PR DESCRIPTION
Otherwise diffing with Zygote is type unstable. This is causing all but one of the test failures on stable CI, see https://buildkite.com/julialang/nnlib-dot-jl/builds/1174.

### PR Checklist

- [x] Tests are added
- [ ] ~~Documentation, if applicable~~
