### PR TITLE
CUDA: Fix compilation failure.

### DIFF
--- a/ext/NNlibCUDAExt/ctc.jl
+++ b/ext/NNlibCUDAExt/ctc.jl
@@ -14,7 +14,7 @@ import NNlib: ctc_loss, ctc_alpha, ∇ctc_loss
 
 const MAX_THREADS = 256
 
-function log_plus_f(p1, p2)
+@inline function log_plus_f(p1, p2)
   isinf(p1) && return p2
   isinf(p2) && return p1
   if p1 < p2


### PR DESCRIPTION
It looks like CUDA CI is broken here. As I wanted to test NNlib.jl for upcoming cuDNN.jl changes (and possibly add the package to CUDA.jl's reverse-CI), I had a quick look, and for whatever reason inlining this method fixes the compilation error:

```
ctc-gpu: Error During Test at /var/lib/buildkite-agent/builds/gpuci-10/julialang/nnlib-dot-jl/test/ext_cuda/ctc.jl:19
  Got exception outside of a @test
  InvalidIRError: compiling MethodInstance for NNlibCUDAExt.compute_beta_and_grad_kernel(::CuDeviceMatrix{Float64, 1}, ::Int64, ::Int64, ::Int64, ::CuDeviceVector{Int64, 1}, ::CuDeviceMatrix{Float64, 1}, ::CuDeviceMatrix{Float64, 1}, ::CuDeviceMatrix{Float64, 1}, ::CuDeviceMatrix{Float64, 1}, ::CuDeviceMatrix{Float64, 1}, ::Int64, ::Float64) resulted in invalid LLVM IR
  Reason: unsupported call to an unknown function (call to julia.new_gc_frame)
  Reason: unsupported call to an unknown function (call to julia.push_gc_frame)
  Reason: unsupported call to an unknown function (call to julia.pop_gc_frame)
  Reason: unsupported call to an unknown function (call to julia.get_gc_frame_slot)
```