### PR TITLE
Add export for imrotate gradient

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -124,6 +124,6 @@ include("impl/pooling_direct.jl")
 include("deprecations.jl")
 
 include("rotation.jl")
-export imrotate
+export imrotate, ∇imrotate
 
 end # module NNlib


### PR DESCRIPTION
I think we should have added the export for \nabla imrotate in  #553?