### PR TITLE
Fix batchnorm in testmode without track stats

### DIFF
--- a/test/ext_cuda/batchnorm.jl
+++ b/test/ext_cuda/batchnorm.jl
@@ -1,3 +1,5 @@
+using Statistics
+
 @testset "Batchnorm" begin
     v = CUDA.rand(Float32, 2)
     m = CUDA.rand(Float32, 2, 5)
@@ -24,4 +26,13 @@
             @test_throws ArgumentError batchnorm(v, v, m, α, β, 1.0; kws...)
         end
     end 
+    @testset "test mode" begin
+        y_no_track_stats = batchnorm(v, v, m, nothing, nothing, 1.0; training=false, track_stats=false)
+        running_mean = mean(m, dims=[2])
+        running_var = var(m, mean=running_mean, dims=[2], corrected=false)
+        y_track_stats = batchnorm(v, v, m, running_mean, running_var, 1.0; training=false, track_stats=true)
+        # batchnorm without tracked stats should equal bathnorm with tracked stats where the
+        # stats are calculated only on the input.
+        @test y_no_track_stats ≈ y_track_stats
+    end
 end


### PR DESCRIPTION
In test mode, the CUDA cuDNN implementation of batchnorm was not matching the CPU batchnorm in FLUX. In FLUX, with track_stats=False, the mean and variance of the current batch are used. Here, mean and variance were initialized to 0 and 1, respectively, and passed to cudnnBatchNormalizationForwardInference.

To fix this, we need to calculate the mean and variance over the current batch to match the CPU implementation. Unfortunately, cudnnBatchNormalizationForwardInference requires a trained running mean and variance. However, batchnorm train and test should be identical without tracked stats since they both normalize over the current batch. As a result we can use cudnnBatchNormalizationForwardTraining in test mode as well, which works without a running mean and variance.

This is needed to help address FluxML/Flux.jl#1606 along with [Flux.jl PR 2427](https://github.com/FluxML/Flux.jl/pull/2427).

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
