### PR TITLE
Transition to `LinearAlgebra.BLAS.libblastrampoline` instead of `Base.libblas_name`

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -18,8 +18,6 @@ using Requires
 using Statistics
 using Statistics: mean
 
-const libblas = Base.libblas_name
-
 const Numeric = Union{AbstractArray{<:T}, T} where {T<:Number}
 
 # Include APIs

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -3,6 +3,12 @@
 
 using LinearAlgebra.BLAS: get_num_threads, set_num_threads
 
+if isdefined(LinearAlgebra.BLAS, :libblastrampoline)
+    const libblas = LinearAlgebra.BLAS.libblastrampoline
+else
+    const libblas = Base.libblas_name
+end
+
 """
     gemm!()
 


### PR DESCRIPTION
This change is in support of https://github.com/JuliaLang/julia/pull/50699