### PR TITLE
Support `conv_direct!` on custom datatypes

### DIFF
--- a/src/impl/conv_direct.jl
+++ b/src/impl/conv_direct.jl
@@ -81,8 +81,10 @@ function conv_direct!(
     # Use `calc_padding_regions` to determine where we do or don't need to worry about padding
     padded_regions, central_region = calc_padding_regions(cdims)
 
-    # Set outputs to zero (https://github.com/FluxML/NNlib.jl/issues/490)
-    y = fill!(y, zero(yT))
+    # Set outputs to zero to support custom datatypes (https://github.com/FluxML/NNlib.jl/issues/490)
+    if iszero(beta)
+        y = fill!(y, zero(yT))
+    end
 
     # Start with the central region
     w_region, h_region, d_region = central_region

--- a/src/impl/conv_direct.jl
+++ b/src/impl/conv_direct.jl
@@ -81,6 +81,9 @@ function conv_direct!(
     # Use `calc_padding_regions` to determine where we do or don't need to worry about padding
     padded_regions, central_region = calc_padding_regions(cdims)
 
+    # Set outputs to zero (https://github.com/FluxML/NNlib.jl/issues/490)
+    y = fill!(y, zero(yT))
+
     # Start with the central region
     w_region, h_region, d_region = central_region
     @inbounds for batch in 1:size(x, 5),

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -899,6 +899,8 @@ end
     y = Array{MyFloat}(undef, y_size...);
     cdims = DenseConvDims(x_size, w_size)
     y_out = NNlib.conv_direct!(y, x, w, cdims)
+
+    @test eltype(y_out) == MyFloat
     @test size(y_out) == y_size
 end
 


### PR DESCRIPTION
Closes #490, #405.

As described in #490, undefined array elements can't be indexed on all datatypes:

```Julia-repl
julia> v1 = Array{Float32}(undef, 3)
3-element Vector{Float32}:
 2.7761215f-21
 1.0f-45
 2.7765319f-21

julia> v2 = Array{Set}(undef, 3)
3-element Vector{Set}:
 #undef
 #undef
 #undef

julia> v1[1] # works
2.7761215f-21

julia> v2[1] # doesn't work
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getindex(A::Vector{Set}, i1::Int64)
   @ Base ./essentials.jl:13
 [2] top-level scope
   @ REPL[34]:1
```

Such indexing is used in the right-hand side of `conv_direct!` on main
https://github.com/FluxML/NNlib.jl/blob/627374ca51090c4e5b9cfbed5c15bdaa992891f8/src/impl/conv_direct.jl#L111

which means that `conv_direct!` doesn't support all input datatypes.

However, assignments work, which is way the problem can be solved by first setting `y` to zero, as suggested [here](https://github.com/FluxML/NNlib.jl/issues/490#issuecomment-1522434576) by @ToucheSir.
