### PR TITLE
Fix padding causing device to host copies

### DIFF
--- a/src/padding.jl
+++ b/src/padding.jl
@@ -310,24 +310,25 @@ julia> pad_symmetric(r, (1,2,1,2))
  2  2  5  8  8  5
 ```
 """
-function pad_symmetric(x::AbstractArray, pad::NTuple{M,Int}; 
+function pad_symmetric(x::AbstractArray, pad::NTuple{M,Int};
                      dims=1:M÷2) where M
   length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   for (i, d) in enumerate(dims)
     x = pad_symmetric(x, (pad[2i-1], pad[2i]); dims = d)
-  end  
+  end
   return x
 end
 
-function pad_symmetric(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
-                     dims::Int = 1) where {F,N}
+function pad_symmetric(
+  x::AbstractArray{F,N}, pad::NTuple{2,Int}; dims::Int = 1,
+) where {F,N}
   lpad, rpad = pad
-  
   n = size(x, dims)
-  xl = selectdim(x, dims, lpad:-1:1)
-  xr = selectdim(x, dims, n:-1:n-rpad+1)
-  return cat(xl, x, xr, dims = dims)
+
+  xl = lpad == 0 ? similar(x, 0) : reverse(selectdim(x, dims, 1:lpad); dims)
+  xr = rpad == 0 ? similar(x, 0) : reverse(selectdim(x, dims, n-rpad+1:n); dims)
+  return cat(xl, x, xr; dims)
 end
 
 """

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -255,27 +255,24 @@ julia> pad_reflect(r, (1,2,1,2))
  4  1  4  7  4  1
 ```
 """
-function pad_reflect(x::AbstractArray, pad::NTuple{M,Int}; 
+function pad_reflect(x::AbstractArray, pad::NTuple{M,Int};
                      dims=1:M÷2) where M
   length(dims) == M ÷ 2 ||
     throw(ArgumentError("The number of dims should be equal to the number of padding dimensions"))
   for (i, d) in enumerate(dims)
     x = pad_reflect(x, (pad[2i-1], pad[2i]); dims = d)
-  end  
+  end
   return x
 end
 
-function pad_reflect(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
-                     dims::Int = 1) where {F,N}
+function pad_reflect(
+  x::AbstractArray{F,N}, pad::NTuple{2,Int}; dims::Int = 1,
+) where {F,N}
   lpad, rpad = pad
-  
   n = size(x, dims)
-  xl = selectdim(x, dims, lpad+1:-1:2)
-  xr = selectdim(x, dims, n-1:-1:n-rpad)
-  # Alternative selection, not sure which is faster...
-  # xl = reverse(selectdim(x, dims, 2:lpad+1), dims)
-  # xr = reverse(selectdim(x, dims, n-rpad:n-1), dims)
-  return cat(xl, x, xr, dims = dims)
+  xl = lpad == 0 ? similar(x, 0) : reverse(selectdim(x, dims, 2:lpad+1); dims)
+  xr = rpad == 0 ? similar(x, 0) : reverse(selectdim(x, dims, n-rpad:n-1); dims)
+  return cat(xl, x, xr; dims)
 end
 
 """


### PR DESCRIPTION
Current version of `pad_reflect` causes input array to be copied to host during backpropagation because of [this rule](https://github.com/JuliaDiff/ChainRules.jl/blob/2db48540b2fd9943c4e6db92dba1ee1e8f7f8550/src/rulesets/Base/indexing.jl#L183).

Instead of usign `StepRange` we should use `UnitRange` for `selectdim` and `reverse`, this avoids expensive copying.

```julia
julia> using Revise, CUDA, Zygote

julia> x = CuArray(rand(Float32, 8000, 1));

julia> Δ = CuArray(ones(Float32, 1, 1));

julia> y, back = Zygote.pullback(x) do x
           sum(NNlib.pad_reflect(x, (0, 10)); dims=(1, 2))
       end;

julia> back(Δ);
D to H copy CuArray{Float32, 2, CUDA.DeviceMemory}: (8000, 1) -> Matrix{Float32}: (8000, 1)
D to H copy CuArray{Float32, 2, CUDA.DeviceMemory}: (11, 1) -> Matrix{Float32}: (11, 1)
```

Besides copying needlessly, on AMDGPU device to host copy causes synchronization if the memory is unpinned or there is no hardware support for this.

Before:
```julia
julia> @btime AMDGPU.@sync back($Δ);
  233.065 μs (330 allocations: 75.60 KiB)
```

Now:
```julia
julia> @btime AMDGPU.@sync back($Δ);
  80.891 μs (293 allocations: 11.63 KiB)
```

Same for `pad_symmetric`:

Before:

```julia
julia> @btime AMDGPU.@sync back($Δ);
  243.315 μs (327 allocations: 75.55 KiB)
```

Now:

```julia
julia> @btime AMDGPU.@sync back($Δ);
  75.781 μs (293 allocations: 11.62 KiB)
```

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
