### PR TITLE
feat: catch scalar indexing failures early

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.9.20"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
@@ -31,6 +32,7 @@ NNlibFFTWExt = "FFTW"
 [compat]
 AMDGPU = "0.9.4"
 Adapt = "3.2, 4"
+ArrayInterface = "7.10"
 Atomix = "0.1"
 CUDA = "4, 5"
 ChainRulesCore = "1.13"

--- a/ext/NNlibCUDAExt/utils.jl
+++ b/ext/NNlibCUDAExt/utils.jl
@@ -34,3 +34,10 @@ function NNlib.reverse_indices(idx::AnyCuArray{<:Any,N}) where N
     NNlib.reverse_indices!(rev, idx)
     return map(cu, rev)
 end
+
+for op in (:conv!, :∇conv_data!, :∇conv_filter!, :depthwiseconv!, :∇depthwiseconv_data!, :∇depthwiseconv_filter!)
+    error_msg = "`$(op)` requires all arguments to support fast scalar indexing. You might be missing an `using cuDNN` or `import cuDNN` statement."
+    @eval function NNlib.special_scalar_indexing_error(::Val{$(Meta.quot(op))}, ::CUDA.AnyCuArray)
+        throw(AssertionError($(error_msg)))
+    end
+end

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -3,6 +3,7 @@ module NNlib
 import Atomix
 import ChainRulesCore: rrule
 
+using ArrayInterface: ArrayInterface
 using Base.Broadcast: broadcasted
 using Base.Threads
 using ChainRulesCore

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -192,6 +192,7 @@ for (front_name, backend, signature) in (
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
+            assert_all_fast_scalar_indexing(Val($(Meta.quot(Symbol(front_name, "!")))), out, in1, in2)
 
             x_cs = Iterators.partition(1:size(in1, 4),
                                     channels_in(cdims) ÷ groupcount(cdims))
@@ -233,7 +234,7 @@ for (front_name, backend, signature) in (
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
-
+            assert_all_fast_scalar_indexing(Val($(Meta.quot(Symbol(front_name, "!")))), out, in1, in2)
 
             dx_cs = Iterators.partition(1:size(out, 4),
                                         channels_in(cdims) ÷ groupcount(cdims))
@@ -276,6 +277,7 @@ for (front_name, backend, signature) in (
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
+            assert_all_fast_scalar_indexing(Val($(Meta.quot(Symbol(front_name, "!")))), out, in1, in2)
 
             dw_cs = Iterators.partition(1:size(out, 5),
                                         channels_out(cdims) ÷ groupcount(cdims))
@@ -327,6 +329,8 @@ for (front_name, backend, signature) in (
                 @warn string("Slow fallback implementation invoked for ", $(string(front_name)), "!  ",
                         "You probably don't want this; check your datatypes.") yT T1 T2 maxlog=1
             end
+            assert_all_fast_scalar_indexing(Val($(Meta.quot(Symbol(front_name, "!")))), out, in1, in2)
+
             $(Symbol("$(front_name)_$(backend)!"))(out, in1, in2, cdims; kwargs...)
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -162,3 +162,11 @@ if VERSION < v"1.7.0-DEV.793"
     end
 end
 
+function assert_all_fast_scalar_indexing(call::Val{C}, args::AbstractArray...) where {C}
+    if !all(ArrayInterface.fast_scalar_indexing, args)
+        foreach(Base.Fix1(special_scalar_indexing_error, call), args)
+        throw(AssertionError("`$(C)` requires all arguments to support fast scalar indexing"))
+    end
+end
+
+special_scalar_indexing_error(::Val, ::AbstractArray) = nothing


### PR DESCRIPTION
fixes #523 (maybe also https://github.com/FluxML/Flux.jl/issues/2440)

```julia
using CUDA, NNlib

x = cu(rand(Float32, 4, 4, 3, 2))
w = cu(rand(Float32, 3, 3, 3, 4))
cdims = DenseConvDims(x, w)

conv(x, w, cdims)
```

<details>
<summary>New Error Message</summary>

```julia
ERROR: AssertionError: `conv!` requires all arguments to support fast scalar indexing. You might be missing an `using cuDNN` or `import cuDNN` statement.
Stacktrace:
  [1] special_scalar_indexing_error(::Val{:conv!}, ::CuArray{Float32, 5, CUDA.DeviceMemory})
    @ NNlibCUDAExt /mnt/research/lux/NNlib.jl/ext/NNlibCUDAExt/utils.jl:41
  [2] (::Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}})(y::CuArray{Float32, 5, CUDA.DeviceMemory})
    @ Base ./operators.jl:1127
  [3] (::Base.var"#70#71"{Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}}})(::Nothing, x::CuArray{Float32, 5, CUDA.DeviceMemory})
    @ Base ./tuple.jl:692
  [4] BottomRF
    @ ./reduce.jl:86 [inlined]
  [5] afoldl(::Base.BottomRF{Base.var"#70#71"{Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}}}}, ::Nothing, ::CuArray{Float32, 5, CUDA.DeviceMemory}, ::CuArray{Float32, 5, CUDA.DeviceMemory}, ::CuArray{Float32, 5, CUDA.DeviceMemory})
    @ Base ./operators.jl:553
  [6] _foldl_impl(op::Base.BottomRF{Base.var"#70#71"{Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}}}}, init::Nothing, itr::Tuple{CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}})
    @ Base ./reduce.jl:68
  [7] foldl_impl(op::Base.BottomRF{Base.var"#70#71"{Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}}}}, nt::Nothing, itr::Tuple{CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}})
    @ Base ./reduce.jl:48
  [8] mapfoldl_impl(f::typeof(identity), op::Base.var"#70#71"{Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}}}, nt::Nothing, itr::Tuple{CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}})
    @ Base ./reduce.jl:44
  [9] mapfoldl(f::Function, op::Function, itr::Tuple{CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}}; init::Nothing)
    @ Base ./reduce.jl:175
 [10] mapfoldl
    @ ./reduce.jl:175 [inlined]
 [11] #foldl#336
    @ ./reduce.jl:198 [inlined]
 [12] foreach(f::Base.Fix1{typeof(NNlib.special_scalar_indexing_error), Val{:conv!}}, itr::Tuple{CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}, CuArray{Float32, 5, CUDA.DeviceMemory}})
    @ Base ./tuple.jl:692
 [13] assert_all_fast_scalar_indexing(::Val{:conv!}, ::CuArray{Float32, 5, CUDA.DeviceMemory}, ::Vararg{CuArray{Float32, 5, CUDA.DeviceMemory}})
    @ NNlib /mnt/research/lux/NNlib.jl/src/utils.jl:167
 [14] conv!(out::CuArray{Float32, 5, CUDA.DeviceMemory}, in1::CuArray{Float32, 5, CUDA.DeviceMemory}, in2::CuArray{Float32, 5, CUDA.DeviceMemory}, cdims::DenseConvDims{3, 3, 3, 6, 3}; kwargs::@Kwargs{})
    @ NNlib /mnt/research/lux/NNlib.jl/src/conv.jl:195
 [15] conv!(out::CuArray{Float32, 5, CUDA.DeviceMemory}, in1::CuArray{Float32, 5, CUDA.DeviceMemory}, in2::CuArray{Float32, 5, CUDA.DeviceMemory}, cdims::DenseConvDims{3, 3, 3, 6, 3})
    @ NNlib /mnt/research/lux/NNlib.jl/src/conv.jl:185
 [16] conv!(y::CuArray{Float32, 4, CUDA.DeviceMemory}, x::CuArray{Float32, 4, CUDA.DeviceMemory}, w::CuArray{Float32, 4, CUDA.DeviceMemory}, cdims::DenseConvDims{2, 2, 2, 4, 2}; kwargs::@Kwargs{})
    @ NNlib /mnt/research/lux/NNlib.jl/src/conv.jl:145
 [17] conv!(y::CuArray{Float32, 4, CUDA.DeviceMemory}, x::CuArray{Float32, 4, CUDA.DeviceMemory}, w::CuArray{Float32, 4, CUDA.DeviceMemory}, cdims::DenseConvDims{2, 2, 2, 4, 2})
    @ NNlib /mnt/research/lux/NNlib.jl/src/conv.jl:140
 [18] conv(x::CuArray{Float32, 4, CUDA.DeviceMemory}, w::CuArray{Float32, 4, CUDA.DeviceMemory}, cdims::DenseConvDims{2, 2, 2, 4, 2}; kwargs::@Kwargs{})
    @ NNlib /mnt/research/lux/NNlib.jl/src/conv.jl:88
 [19] conv(x::CuArray{Float32, 4, CUDA.DeviceMemory}, w::CuArray{Float32, 4, CUDA.DeviceMemory}, cdims::DenseConvDims{2, 2, 2, 4, 2})
    @ NNlib /mnt/research/lux/NNlib.jl/src/conv.jl:83
 [20] top-level scope
    @ REPL[38]:1
 [21] top-level scope
    @ none:1
```

</details>

ArrayInterface.jl doesn't support <1.10. Now that the LTS is 1.10 can we drop 1.9 support? #600 does this