### PR TITLE
Add Atomix.jl v1 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ NNlibForwardDiffExt = "ForwardDiff"
 [compat]
 AMDGPU = "1"
 Adapt = "3.2, 4"
-Atomix = "0.1"
+Atomix = "0.1, 1"
 CUDA = "4, 5"
 ChainRulesCore = "1.25"
 EnzymeCore = "0.5, 0.6, 0.7, 0.8"


### PR DESCRIPTION
Keep 0.1 compat as no previously-released functionality has been changed.

See [release notes](https://github.com/JuliaConcurrent/Atomix.jl/releases/tag/v1.0.0) and https://github.com/JuliaGPU/KernelAbstractions.jl/pull/545 for more details.

Depends on https://github.com/JuliaGPU/KernelAbstractions.jl/pull/545