### PR TITLE
Fix `NaN` gradient in spectrogram

### DIFF
--- a/src/audio/spectrogram.jl
+++ b/src/audio/spectrogram.jl
@@ -25,11 +25,11 @@ See [`stft`](@ref) for other arguments.
 Spectrogram in the shape `(T, F, B)`, where
 `T` is the number of window hops and `F = n_fft ÷ 2 + 1`.
 """
-function spectrogram(waveform;
+function spectrogram(waveform::AbstractArray{T};
     pad::Int = 0, n_fft::Int, hop_length::Int, window,
     center::Bool = true, power::Real = 2.0,
     normalized::Bool = false, window_normalized::Bool = false,
-)
+) where T
     pad > 0 && (waveform = pad_zeros(waveform, pad; dims=1);)
 
     # Pack batch dimensions.
@@ -41,8 +41,8 @@ function spectrogram(waveform;
     window_normalized && (spec = spec .* inv(norm(window));)
 
     if power > 0
-        p = eltype(waveform)(power)
-        spec = abs.(spec).^p
+        p = T(power)
+        spec = abs.(spec .+ eps(T)).^p
     end
     return spec
 end


### PR DESCRIPTION
With `power > 0` gradient will become `NaN` where spectrogram is `~0` (because of singularity at `abs(0)`).
Adding small epsilon fixes this issue (and the results match pytorch).

```julia
x = gpu(ones(Float32, 1024, 1, 1))
window = gpu(hann_window(1024)))
l, g = Zygote.withgradient(x) do x
    sum(spectrogram(x; n_fft=1024, hop_length=256, power=2.0, window)
end
```

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
