### PR TITLE
Add unthunk in conv.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.9.26"
+version = "0.9.27"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -343,8 +343,8 @@ for conv in [:conv, :depthwiseconv]
     conv_pullback, ∇conv_data_pullback = Symbol.([conv, ∇conv_data], :_pullback)
 
     @eval function rrule(::typeof($conv), x, w, cdims; kw...)
-        function $conv_pullback(Δ)
-            Δ = colmajor(Δ)
+        function $conv_pullback(Δraw)
+            Δ = colmajor(unthunk(Δraw))
             return (
                 NoTangent(),
                 @thunk($∇conv_data(unthunk(Δ), w, cdims, kw...)),
@@ -356,8 +356,8 @@ for conv in [:conv, :depthwiseconv]
     end
 
     @eval function rrule(::typeof($∇conv_data), x, w, cdims; kw...)
-        function $∇conv_data_pullback(Δ)
-            Δ = colmajor(Δ)
+        function $∇conv_data_pullback(Δraw)
+            Δ = colmajor(unthunk(Δraw))
             return (
                 NoTangent(),
                 @thunk($conv(unthunk(Δ), w, cdims, kw...)),

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -348,7 +348,7 @@ for conv in [:conv, :depthwiseconv]
             return (
                 NoTangent(),
                 @thunk($∇conv_data(Δ, w, cdims, kw...)),
-                @thunk($∇conv_filter(x, unthunk(Δ), cdims, kw...)),
+                @thunk($∇conv_filter(x, Δ, cdims, kw...)),
                 NoTangent(),
             )
         end
@@ -361,7 +361,7 @@ for conv in [:conv, :depthwiseconv]
             return (
                 NoTangent(),
                 @thunk($conv(Δ, w, cdims, kw...)),
-                @thunk($∇conv_filter(unthunk(Δ), x, cdims, kw...)),
+                @thunk($∇conv_filter(Δ, x, cdims, kw...)),
                 NoTangent(),
             )
         end

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -347,7 +347,7 @@ for conv in [:conv, :depthwiseconv]
             Δ = colmajor(unthunk(Δraw))
             return (
                 NoTangent(),
-                @thunk($∇conv_data(unthunk(Δ), w, cdims, kw...)),
+                @thunk($∇conv_data(Δ, w, cdims, kw...)),
                 @thunk($∇conv_filter(x, unthunk(Δ), cdims, kw...)),
                 NoTangent(),
             )
@@ -360,7 +360,7 @@ for conv in [:conv, :depthwiseconv]
             Δ = colmajor(unthunk(Δraw))
             return (
                 NoTangent(),
-                @thunk($conv(unthunk(Δ), w, cdims, kw...)),
+                @thunk($conv(Δ, w, cdims, kw...)),
                 @thunk($∇conv_filter(unthunk(Δ), x, cdims, kw...)),
                 NoTangent(),
             )


### PR DESCRIPTION
Aims to fix errors like this in CI, from Zygote 0.7:
```
AutoDiff: spatial_rank=3: Error During Test at /home/runner/work/Zygote.jl/Zygote.jl/downstream/test/conv.jl:889
  Got exception outside of a @test
  MethodError: no method matching length(::InplaceableThunk{Thunk{ChainRules.var"#719#722"{Float64, Colon, Array{Float64, 5}, ProjectTo{AbstractArray, @NamedTuple{element::ProjectTo{Float64, @NamedTuple{}}, axes::NTuple{5, Base.OneTo{Int64}}}}}}, ChainRules.var"#718#721"{Float64, Colon}})
  The function `length` exists, but no method is defined for this combination of argument types.
  You may need to implement the `length` method or define `IteratorSize` for this type to be `SizeUnknown`.
  
  Closest candidates are:
    length(::JSON.Parser.MemoryParserState)
     @ JSON ~/.julia/packages/JSON/93Ea8/src/Parser.jl:28
    length(::CompositeException)
     @ Base task.jl:51
    length(::LLVM.MemoryBuffer)
     @ LLVM ~/.julia/packages/LLVM/wMjUU/src/buffer.jl:81
    ...
  
  Stacktrace:
    [1] _similar_shape(itr::InplaceableThunk{Thunk{ChainRules.var"#719#722"{Float64, Colon, Array{Float64, 5}, ProjectTo{AbstractArray, @NamedTuple{element::ProjectTo{Float64, @NamedTuple{}}, axes::NTuple{5, Base.OneTo{Int64}}}}}}, ChainRules.var"#718#721"{Float64, Colon}}, ::Base.HasLength)
      @ Base ./array.jl:663
    [2] _collect(cont::UnitRange{Int64}, itr::InplaceableThunk{Thunk{ChainRules.var"#719#722"{Float64, Colon, Array{Float64, 5}, ProjectTo{AbstractArray, @NamedTuple{element::ProjectTo{Float64, @NamedTuple{}}, axes::NTuple{5, Base.OneTo{Int64}}}}}}, ChainRules.var"#718#721"{Float64, Colon}}, ::Base.HasEltype, isz::Base.HasLength)
      @ Base ./array.jl:722
    [3] collect(itr::InplaceableThunk{Thunk{ChainRules.var"#719#722"{Float64, Colon, Array{Float64, 5}, ProjectTo{AbstractArray, @NamedTuple{element::ProjectTo{Float64, @NamedTuple{}}, axes::NTuple{5, Base.OneTo{Int64}}}}}}, ChainRules.var"#718#721"{Float64, Colon}})
      @ Base ./array.jl:716
    [4] colmajor(x::InplaceableThunk{Thunk{ChainRules.var"#719#722"{Float64, Colon, Array{Float64, 5}, ProjectTo{AbstractArray, @NamedTuple{element::ProjectTo{Float64, @NamedTuple{}}, axes::NTuple{5, Base.OneTo{Int64}}}}}}, ChainRules.var"#718#721"{Float64, Colon}})
      @ NNlib ~/work/Zygote.jl/Zygote.jl/downstream/src/conv.jl:339
```

Closes #619