### PR TITLE
Add Grid Sampling for 3D images.

### DIFF
--- a/ext/NNlibCUDAExt/sampling.jl
+++ b/ext/NNlibCUDAExt/sampling.jl
@@ -2,7 +2,7 @@
     @inbounds CUDA.@atomic dx[ix, iy, c, n] += value
 end
 
-function grid_sample_kernel!(n_elem, output, input, grid, padding_mode)
+function grid_sample_kernel!(n_elem, output::AbstractArray{T, 4}, input::AbstractArray{T, 4}, grid::AbstractArray{V, 4}, padding_mode) where {T,V}
     index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
     if index < n_elem
         iW, iH, iC, _ = size(input)
@@ -16,7 +16,7 @@ function grid_sample_kernel!(n_elem, output, input, grid, padding_mode)
     nothing
 end
 
-function ∇grid_sample_kernel!(n_elem, dx, dgrid, Δ, input, grid, padding_mode)
+function ∇grid_sample_kernel!(n_elem, dx::AbstractArray{T, 4}, dgrid::AbstractArray{V, 4}, Δ::AbstractArray{T, 4}, input::AbstractArray{T, 4}, grid::AbstractArray{V, 4}, padding_mode) where {T,V}
     index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
     if index < n_elem
         iW, iH, iC, _ = size(input)
@@ -50,6 +50,77 @@ function NNlib.∇grid_sample(Δ::CuArray{T, 4}, x::CuArray{T, 4}, grid::CuArray
     xN = size(x, 4)
     _, gW, gH, _ = size(grid)
     n_elem = gW * gH * xN
+    dx, dgrid = CUDA.zeros(T, size(x)), similar(grid)
+
+    kernel = @cuda launch=false ∇grid_sample_kernel!(n_elem, dx, dgrid, Δ, x, grid, pad)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(n_elem, config.threads)
+    blocks = cld(n_elem, threads)
+    kernel(n_elem, dx, dgrid, Δ, x, grid, pad; threads=threads, blocks=blocks)
+    dx, dgrid
+end
+
+
+@inline function NNlib._safe_add!(dx::CuDeviceArray{T, 5}, value, ix, iy, iz, c, n) where T
+    @inbounds CUDA.@atomic dx[ix, iy, iz, c, n] += value
+end
+
+function grid_sample_kernel!(n_elem, output::AbstractArray{T, 5}, input::AbstractArray{T, 5}, grid::AbstractArray{V, 5}, padding_mode) where {T,V}
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+    if index < n_elem
+        iW, iH,iD, iC, _ = size(input)
+        _, gW, gH, gD, _ = size(grid)
+
+        w = index % gW + 1
+        h = (index ÷ gW) % gH + 1
+        d = (index ÷ (gW * gH)) % gD + 1
+        n = index ÷ (gW * gH * gD) + 1
+        # n = index ÷ (gW * gH) + 1
+        # d = (index ÷ (gW * gH * n)) + 1
+
+        NNlib._grid_sample_kernel!(output, input, grid, padding_mode, w, h, d, n, iW, iH, iD, iC)
+    end
+    nothing
+end
+
+function ∇grid_sample_kernel!(n_elem, dx::AbstractArray{T, 5}, dgrid::AbstractArray{V, 5}, Δ::AbstractArray{T, 5}, input::AbstractArray{T, 5}, grid::AbstractArray{V, 5}, padding_mode) where {T,V}
+    index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
+    if index < n_elem
+        iW, iH, iC, _ = size(input)
+        _, gW, gH, gD, _ = size(grid)
+
+        w = index % gW + 1
+        h = (index ÷ gW) % gH + 1
+        d = (index ÷ (gW * gH)) % gD + 1
+        n = index ÷ (gW * gH * gD) + 1
+        # n = index ÷ (gW * gH) + 1
+        # d = (index ÷ (gW * gH * n)) + 1
+
+        NNlib._∇grid_sample_kernel!(dx, dgrid, Δ, input, grid, padding_mode, w, h, d, n, iW, iH, iD, iC)
+    end
+    nothing
+end
+
+function NNlib.grid_sample(x::CuArray{T, 5}, grid::CuArray{V, 5}; padding_mode = :zeros) where {T, V}
+    pad = Val(padding_mode)
+    _, _, _, xC, xN = size(x)
+    _, gW, gH, gD, _ = size(grid)
+    n_elem = gW * gH * gD * xN
+    y = similar(x, T, (gW, gH, gD, xC, xN))
+
+    kernel = @cuda launch=false grid_sample_kernel!(n_elem, y, x, grid, pad)
+    config = launch_configuration(kernel.fun; max_threads=256)
+    threads = min(n_elem, config.threads)
+    blocks = cld(n_elem, threads)
+    kernel(n_elem, y, x, grid, pad; threads=threads, blocks=blocks)
+    y
+end
+
+function NNlib.∇grid_sample(Δ::CuArray{T, 5}, x::CuArray{T, 5}, grid::CuArray{V, 5}; padding_mode = :zeros) where {T, V}
+    pad = Val(padding_mode)
+    xN = size(x, 5)
+    _, gW, gH, gD, _ = size(grid)
+    n_elem = gW * gH * gD * xN
     dx, dgrid = CUDA.zeros(T, size(x)), similar(grid)
 
     kernel = @cuda launch=false ∇grid_sample_kernel!(n_elem, dx, dgrid, Δ, x, grid, pad)

--- a/ext/NNlibCUDAExt/sampling.jl
+++ b/ext/NNlibCUDAExt/sampling.jl
@@ -86,7 +86,7 @@ end
 function ∇grid_sample_kernel!(n_elem, dx::AbstractArray{T, 5}, dgrid::AbstractArray{V, 5}, Δ::AbstractArray{T, 5}, input::AbstractArray{T, 5}, grid::AbstractArray{V, 5}, padding_mode) where {T,V}
     index = (threadIdx().x - 1) + (blockIdx().x - 1) * blockDim().x
     if index < n_elem
-        iW, iH, iC, _ = size(input)
+        iW, iH, iD, iC, _ = size(input)
         _, gW, gH, gD, _ = size(grid)
 
         w = index % gW + 1

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -156,7 +156,7 @@ end
     se = (ix - ix_nw) * (iy - iy_nw)
     # ∀ channel: Calculate bilinear weighted pixel value.
     @inbounds for c in 1:iC
-        r = 0.0
+        r = zero(T)
         if in_bounds(iy_nw, ix_nw, iH, iW)
             r += input[ix_nw, iy_nw, c, n] * nw
         end
@@ -204,7 +204,7 @@ end
 
     # ∀ channel: Calculate trilinear weighted voxel value.
     @inbounds for c in 1:iC
-        r = 0.0
+        r = zero(T)
         if in_bounds(iy_nw, ix_nw, iz_nw, iH, iW, iD)
             r += input[ix_nw, iy_nw, iz_nw, c, n] * nw
         end
@@ -304,7 +304,7 @@ end
     sw = (ix_ne - ix) * (iy - iy_ne)
     se = (ix - ix_nw) * (iy - iy_nw)
     # ∀ channel: Calculate billinear weighted pixel value.
-    gix, giy = 0.0, 0.0
+    gix, giy = zero(V), zero(V)
     @inbounds for c in 1:iC
         g_out = Δ[w, h, c, n]
         # Calculate dx and dgrid partials.
@@ -378,7 +378,7 @@ end
     # abc are the index of the vertex of the cube (001,010...)
 
     # Initialize gradient accumulators
-    gix, giy, giz = 0.0, 0.0, 0.0
+    gix, giy, giz = zero(V), zero(V), zero(V)
     
     @inbounds for c in 1:iC
         g_out = Δ[w, h, d, c, n]

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -26,6 +26,7 @@ end
 
 """
     grid_sample(input::AbstractArray{T, 4}, grid::AbstractArray{T, 4}; padding_mode = :zeros)
+    grid_sample(input::AbstractArray{T, 5}, grid::AbstractArray{T, 4}; padding_mode = :zeros)
 
     Given `input`, compute output by sampling `input` values at pixel
     locations from `grid`. Uses bilinear interpolation to calculate output values.
@@ -36,14 +37,14 @@ end
 
     # Arguments
 
-    - `input`: Input array in `(W_in, H_in, C, N)` shape.
-    - `grid`: Input grid in `(2, W_out, H_out, N)` shape.
-        Where for each `(W_out, H_out, N)` grid contains `(x, y)`
+    - `input`: Input array in `(W_in, H_in, [D_in,] C, N)` shape.
+    - `grid`: Input grid in `(2, W_out, H_out, [D_out,] N)` shape.
+        Where for each `(W_out, H_out, [D_out,] N)` grid contains `(x, y [,z])`
         coordinates that specify sampling locations normalized by the `input` shape.
 
-        Therefore, `x` and `y` should have values in `[-1, 1]` range.
-        For example, `(x = -1, y = -1)` is the left-top pixel of `input`,
-        and `(x = 1, y = 1)` is the right-bottom pixel of `input`.
+        Therefore, `x`, `y` and [`z`] should have values in `[-1, 1]` range.
+        For example, `(x = -1, y = -1, [z = -1])` is the left-top[-front] pixel of `input`,
+        and `(x = 1, y = 1, [z = 1])` is the right-bottom-back pixel of `input`.
 
         Out-of-bound values are handled according to the `padding_mode`.
     - `padding_mode`: Out-of-bound padding.
@@ -53,7 +54,7 @@ end
 
     # Returns
 
-    `(W_out, H_out, C, N)` sampled grid from `input`.
+    `(W_out, H_out, [D_out,] C, N)` sampled grid from `input`.
 
     # Examples
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,7 +1,8 @@
 @inline in_bounds(h, w, H, W) = 1 ≤ h ≤ H && 1 ≤ w ≤ W
+@inline in_bounds(h, w, d, H, W, D) = 1 ≤ h ≤ H && 1 ≤ w ≤ W && 1 ≤ d ≤ D
 # Borders are considered out-of-bounds for gradient.
 @inline clip_coordinate(coordinate, dim_size) = min(dim_size, max(1, coordinate))
-@inline function ∇clip_coordinate(coordinate::C, dim_size) where C
+@inline function ∇clip_coordinate(coordinate::C, dim_size) where {C}
     if coordinate ≤ 1
         return C(1), C(0)
     elseif coordinate ≥ dim_size
@@ -26,74 +27,74 @@ end
 """
     grid_sample(input::AbstractArray{T, 4}, grid::AbstractArray{T, 4}; padding_mode = :zeros)
 
-Given `input`, compute output by sampling `input` values at pixel
-locations from `grid`. Uses bilinear interpolation to calculate output values.
+    Given `input`, compute output by sampling `input` values at pixel
+    locations from `grid`. Uses bilinear interpolation to calculate output values.
 
-This implementation assumes the extrema (`-1` and `1`) are considered
-as referring to the center points of the input’s corner pixels
-(i.e. align corners is `true`).
+    This implementation assumes the extrema (`-1` and `1`) are considered
+    as referring to the center points of the input’s corner pixels
+    (i.e. align corners is `true`).
 
-# Arguments
+    # Arguments
 
-- `input`: Input array in `(W_in, H_in, C, N)` shape.
-- `grid`: Input grid in `(2, W_out, H_out, N)` shape.
-    Where for each `(W_out, H_out, N)` grid contains `(x, y)`
-    coordinates that specify sampling locations normalized by the `input` shape.
+    - `input`: Input array in `(W_in, H_in, C, N)` shape.
+    - `grid`: Input grid in `(2, W_out, H_out, N)` shape.
+        Where for each `(W_out, H_out, N)` grid contains `(x, y)`
+        coordinates that specify sampling locations normalized by the `input` shape.
 
-    Therefore, `x` and `y` should have values in `[-1, 1]` range.
-    For example, `(x = -1, y = -1)` is the left-top pixel of `input`,
-    and `(x = 1, y = 1)` is the right-bottom pixel of `input`.
+        Therefore, `x` and `y` should have values in `[-1, 1]` range.
+        For example, `(x = -1, y = -1)` is the left-top pixel of `input`,
+        and `(x = 1, y = 1)` is the right-bottom pixel of `input`.
 
-    Out-of-bound values are handled according to the `padding_mode`.
-- `padding_mode`: Out-of-bound padding.
-    `:zeros` to use `0` for out-of-bound grid locations.
-    `:border` to use border values for out-of-bound grid locations.
-    Default is `:zeros`.
+        Out-of-bound values are handled according to the `padding_mode`.
+    - `padding_mode`: Out-of-bound padding.
+        `:zeros` to use `0` for out-of-bound grid locations.
+        `:border` to use border values for out-of-bound grid locations.
+        Default is `:zeros`.
 
-# Returns
+    # Returns
 
-`(W_out, H_out, C, N)` sampled grid from `input`.
+    `(W_out, H_out, C, N)` sampled grid from `input`.
 
-# Examples
+    # Examples
 
-In the example below, grid contains two out-of-bound sampling locations,
-which are handled differently, depending on the `padding_mode`.
+    In the example below, grid contains two out-of-bound sampling locations,
+    which are handled differently, depending on the `padding_mode`.
 
-```jldoctest
-julia> x = reshape(collect(1.0:4.0), (2, 2, 1, 1))
-2×2×1×1 Array{Float64, 4}:
-[:, :, 1, 1] =
- 1.0  3.0
- 2.0  4.0
+    ```jldoctest
+    julia> x = reshape(collect(1.0:4.0), (2, 2, 1, 1))
+    2×2×1×1 Array{Float64, 4}:
+    [:, :, 1, 1] =
+    1.0  3.0
+    2.0  4.0
 
-julia> grid = Array{Float64}(undef, 2, 3, 2, 1);
+    julia> grid = Array{Float64}(undef, 2, 3, 2, 1);
 
-julia> grid[:, 1, 1, 1] .= (-3, -1);
+    julia> grid[:, 1, 1, 1] .= (-3, -1);
 
-julia> grid[:, 2, 1, 1] .= (0, -1);
+    julia> grid[:, 2, 1, 1] .= (0, -1);
 
-julia> grid[:, 3, 1, 1] .= (1, -1);
+    julia> grid[:, 3, 1, 1] .= (1, -1);
 
-julia> grid[:, 1, 2, 1] .= (-1, 1);
+    julia> grid[:, 1, 2, 1] .= (-1, 1);
 
-julia> grid[:, 2, 2, 1] .= (0, 1);
+    julia> grid[:, 2, 2, 1] .= (0, 1);
 
-julia> grid[:, 3, 2, 1] .= (3, 1);
+    julia> grid[:, 3, 2, 1] .= (3, 1);
 
-julia> grid_sample(x, grid; padding_mode=:zeros)
-3×2×1×1 Array{Float64, 4}:
-[:, :, 1, 1] =
- 0.0  3.0
- 1.5  3.5
- 2.0  0.0
+    julia> grid_sample(x, grid; padding_mode=:zeros)
+    3×2×1×1 Array{Float64, 4}:
+    [:, :, 1, 1] =
+    0.0  3.0
+    1.5  3.5
+    2.0  0.0
 
-julia> grid_sample(x, grid; padding_mode=:border)
-3×2×1×1 Array{Float64, 4}:
-[:, :, 1, 1] =
- 1.0  3.0
- 1.5  3.5
- 2.0  4.0
-```
+    julia> grid_sample(x, grid; padding_mode=:border)
+    3×2×1×1 Array{Float64, 4}:
+    [:, :, 1, 1] =
+    1.0  3.0
+    1.5  3.5
+    2.0  4.0
+    ```
 """
 function grid_sample(input::AbstractArray{T, 4}, grid; padding_mode = :zeros) where T
     _, _, iC, iN = size(input)
@@ -101,7 +102,15 @@ function grid_sample(input::AbstractArray{T, 4}, grid; padding_mode = :zeros) wh
     output = similar(input, T, (gW, gH, iC, iN))
     grid_sample!(output, input, grid, padding_mode)
 end
-function grid_sample!(output, input, grid, padding_mode)
+
+function grid_sample(input::AbstractArray{T,5}, grid; padding_mode=:zeros) where {T}
+    _, _, _, iC, iN = size(input)  # Input dimensions: (width, height, depth, channels, batch)
+    _, gW, gH, gD, _ = size(grid)  # Grid dimensions: (3, width, height, depth, batch)
+    output = similar(input, T, (gW, gH, gD, iC, iN))  # Output dimensions: (width, height, depth, channels, batch)
+    grid_sample!(output, input, grid, padding_mode)
+end
+
+function grid_sample!(output::AbstractArray{T,4}, input::AbstractArray{T,4}, grid, padding_mode=:zeros) where {T}
     pad = Val(padding_mode)
     iW, iH, iC, iN = size(input)
     _, gW, gH, _ = size(grid)
@@ -113,9 +122,23 @@ function grid_sample!(output, input, grid, padding_mode)
     end
     output
 end
+
+function grid_sample!(output::AbstractArray{T,5}, input::AbstractArray{T,5}, grid, padding_mode=:zeros) where {T}
+    pad = Val(padding_mode)
+    iW, iH, iD, iC, iN = size(input)
+    _, gW, gH, gD, _ = size(grid)
+    # Loop over each output pixel.
+    Threads.@threads for n in 1:iN
+        for w in 1:gW, h in 1:gH, d in 1:gD
+            _grid_sample_kernel!(output, input, grid, pad, w, h, d, n, iW, iH, iD, iC)
+        end
+    end
+    output
+end
+
 @inline function _grid_sample_kernel!(
-    output, input, grid, padding_mode, w, h, n, iW, iH, iC,
-)
+    output::AbstractArray{T,4}, input::AbstractArray{T,4}, grid, padding_mode, w, h, n, iW, iH, iC,
+) where {T}
     # Get the corresponding (x, y) coordinates from the grid.
     @inbounds x, y = grid[1, w, h, n], grid[2, w, h, n]
     ix = compute_source_index(x, iW, padding_mode)
@@ -149,6 +172,67 @@ end
     end
 end
 
+@inline function _grid_sample_kernel!(
+    output::AbstractArray{T,5}, input::AbstractArray{T,5}, grid, padding_mode, w, h, d, n, iW, iH, iD, iC,
+) where {T}
+    # Get the corresponding (x, y, z) coordinates from the grid.
+    @inbounds x, y, z = grid[1, w, h, d, n], grid[2, w, h, d, n], grid[3, w, h, d, n]
+    ix = compute_source_index(x, iW, padding_mode)
+    iy = compute_source_index(y, iH, padding_mode)
+    iz = compute_source_index(z, iD, padding_mode)
+
+    # Get corner voxel values from (ix, iy, iz) in 8 directions (north-east-south-west-bottom-up).
+    ix_nw, iy_nw, iz_nw = unsafe_trunc(Int, floor(ix)), unsafe_trunc(Int, floor(iy)), unsafe_trunc(Int, floor(iz))
+    ix_ne, iy_ne, iz_ne = ix_nw + 1, iy_nw, iz_nw
+    ix_sw, iy_sw, iz_sw = ix_nw, iy_nw + 1, iz_nw
+    ix_se, iy_se, iz_se = ix_ne, iy_sw, iz_nw
+    ix_nw_u, iy_nw_u, iz_nw_u = ix_nw, iy_nw, iz_nw + 1
+    ix_ne_u, iy_ne_u, iz_ne_u = ix_ne, iy_ne, iz_ne + 1
+    ix_sw_u, iy_sw_u, iz_sw_u = ix_sw, iy_sw, iz_sw + 1
+    ix_se_u, iy_se_u, iz_se_u = ix_se, iy_se, iz_se + 1
+
+    # Get volumes to each neighbor (a.k.a. interpolation weights).
+    nw = (ix_se - ix) * (iy_se - iy) * (iz_se_u - iz)
+    ne = (ix - ix_sw) * (iy_sw - iy) * (iz_sw_u - iz)
+    sw = (ix_ne - ix) * (iy - iy_ne) * (iz_ne_u - iz)
+    se = (ix - ix_nw) * (iy - iy_nw) * (iz_nw_u - iz)
+    nw_u = (ix_se - ix) * (iy_se - iy) * (iz - iz_nw)
+    ne_u = (ix - ix_sw) * (iy_sw - iy) * (iz - iz_sw)
+    sw_u = (ix_ne - ix) * (iy - iy_ne) * (iz - iz_ne)
+    se_u = (ix - ix_nw) * (iy - iy_nw) * (iz - iz_nw)
+
+    # ∀ channel: Calculate trilinear weighted voxel value.
+    @inbounds for c in 1:iC
+        r = 0.0
+        if in_bounds(iy_nw, ix_nw, iz_nw, iH, iW, iD)
+            r += input[ix_nw, iy_nw, iz_nw, c, n] * nw
+        end
+        if in_bounds(iy_ne, ix_ne, iz_ne, iH, iW, iD)
+            r += input[ix_ne, iy_ne, iz_ne, c, n] * ne
+        end
+        if in_bounds(iy_sw, ix_sw, iz_sw, iH, iW, iD)
+            r += input[ix_sw, iy_sw, iz_sw, c, n] * sw
+        end
+        if in_bounds(iy_se, ix_se, iz_se, iH, iW, iD)
+            r += input[ix_se, iy_se, iz_se, c, n] * se
+        end
+        if in_bounds(iy_nw_u, ix_nw_u, iz_nw_u, iH, iW, iD)
+            r += input[ix_nw_u, iy_nw_u, iz_nw_u, c, n] * nw_u
+        end
+        if in_bounds(iy_ne_u, ix_ne_u, iz_ne_u, iH, iW, iD)
+            r += input[ix_ne_u, iy_ne_u, iz_ne_u, c, n] * ne_u
+        end
+        if in_bounds(iy_sw_u, ix_sw_u, iz_sw_u, iH, iW, iD)
+            r += input[ix_sw_u, iy_sw_u, iz_sw_u, c, n] * sw_u
+        end
+        if in_bounds(iy_se_u, ix_se_u, iz_se_u, iH, iW, iD)
+            r += input[ix_se_u, iy_se_u, iz_se_u, c, n] * se_u
+        end
+        output[w, h, d, c, n] = r
+    end
+end
+
+
 """
     ∇grid_sample(Δ::AbstractArray{T, 4}, input::AbstractArray{T, 4}, grid::AbstractArray{T, 4}; padding_mode = :zeros) where T
 
@@ -168,12 +252,13 @@ end
 
 `dinput` (same shape as `input`) and `dgrid` (same shape as `grid`) gradients.
 """
-function ∇grid_sample(Δ::AbstractArray{T, 4}, input::AbstractArray{T, 4}, grid; padding_mode = :zeros) where T
+function ∇grid_sample(Δ::Union{AbstractArray{T,4}, AbstractArray{T,5}}, input::Union{AbstractArray{T,4}, AbstractArray{T,5}}, grid; padding_mode=:zeros) where {T}
     dx = zeros(T, size(input))
     dgrid = similar(grid)
     ∇grid_sample!(dx, dgrid, Δ, input, grid, padding_mode)
 end
-function ∇grid_sample!(dx, dgrid, Δ, input, grid, padding_mode)
+
+function ∇grid_sample!(dx::AbstractArray{T,4}, dgrid::AbstractArray{T,4}, Δ::AbstractArray{T,4}, input::AbstractArray{T,4}, grid::AbstractArray{T,4}, padding_mode) where {T}
     pad = Val(padding_mode)
     iW, iH, iC, iN = size(input)
     gW, gH = size(grid, 2), size(grid, 3)
@@ -185,12 +270,26 @@ function ∇grid_sample!(dx, dgrid, Δ, input, grid, padding_mode)
     end
     dx, dgrid
 end
+
+function ∇grid_sample!(dx::AbstractArray{T,5}, dgrid::AbstractArray{T,5}, Δ::AbstractArray{T,5}, input::AbstractArray{T,5}, grid::AbstractArray{T,5}, padding_mode) where {T}
+    pad = Val(padding_mode)
+    iW, iH, iD, iC, iN = size(input)
+    gW, gH, gD = size(grid, 2), size(grid, 3), size(grid, 4)
+    # Loop over each output voxel.
+    Threads.@threads for n in 1:iN
+        for w in 1:gW, h in 1:gH, d in 1:gD
+            _∇grid_sample_kernel!(dx, dgrid, Δ, input, grid, pad, w, h, d, n, iW, iH, iD, iC)
+        end
+    end
+    dx, dgrid
+end
+
 @inline function _∇grid_sample_kernel!(
-    dx, dgrid, Δ, input, grid, padding_mode, w, h, n, iW, iH, iC,
-)
+    dx::AbstractArray{T,4}, dgrid::AbstractArray{V,4}, Δ::AbstractArray{T,4}, input::AbstractArray{T,4}, grid::AbstractArray{V,4}, padding_mode, w, h, n, iW, iH, iC,
+) where {T,V}
     # Get corresponding (x, y) from grid.
     @inbounds x, y = grid[1, w, h, n], grid[2, w, h, n]
-    # Compute multipliers for gradinets on ix, iy.
+    # Compute multipliers for gradients on ix, iy.
     ix, gix_mult = ∇compute_source_index(x, iW, padding_mode)
     iy, giy_mult = ∇compute_source_index(y, iH, padding_mode)
     # Get corner pixel values from (ix, iy) in north-east-south-west directions.
@@ -237,8 +336,129 @@ end
     @inbounds dgrid[2, w, h, n] = giy_mult * giy
 end
 
+@inline function _∇grid_sample_kernel!(
+    dx::AbstractArray{T,5}, dgrid::AbstractArray{V,5}, Δ::AbstractArray{T,5}, input::AbstractArray{T,5}, grid::AbstractArray{V,5}, padding_mode, w, h, d, n, iW, iH, iD, iC,
+) where {T,V}
+    # Get corresponding (x, y, z) from grid.
+    @inbounds x, y, z = grid[1, w, h, d, n], grid[2, w, h, d, n], grid[3, w, h, d, n]
+    # Compute multipliers for gradients on ix, iy, iz.
+    ix, gix_mult = ∇compute_source_index(x, iW, padding_mode)
+    iy, giy_mult = ∇compute_source_index(y, iH, padding_mode)
+    iz, giz_mult = ∇compute_source_index(z, iD, padding_mode)
+     
+    # Get corner pixel values from (ix, iy, iz)
+    ix_0 = unsafe_trunc(Int, floor(ix))
+    iy_0 = unsafe_trunc(Int, floor(iy))
+    iz_0 = unsafe_trunc(Int, floor(iz))
+    ix_1 = ix_0 + 1
+    iy_1 = iy_0 + 1
+    iz_1 = iz_0 + 1
+    
+    # Get difference of coordinate
+    wx_0 = ix - ix_0
+    wy_0 = iy - iy_0
+    wz_0 = iz - iz_0
+    wx_1 = ix_1 - ix
+    wy_1 = iy_1 - iy
+    wz_1 = iz_1 - iz
+    
+    # Calculate weights (volume of diagnal vertex cube) 
+    # w_{abc} = wx_{¬a}*wy_{¬b}*wz_{¬c}
+    weight_000 = wx_1 * wy_1 * wz_1
+    weight_001 = wx_1 * wy_1 * wz_0
+    weight_010 = wx_1 * wy_0 * wz_1
+    weight_011 = wx_1 * wy_0 * wz_0
+    weight_100 = wx_0 * wy_1 * wz_1
+    weight_101 = wx_0 * wy_1 * wz_0
+    weight_110 = wx_0 * wy_0 * wz_1
+    weight_111 = wx_0 * wy_0 * wz_0
+
+    # ∂w_{abc}/∂x=(-1)^{¬a} wy_{¬b}*wz_{¬c}, ∂w/∂y = (-1)^{¬b} wx_{¬a}*wz_{¬c}, ∂w/∂z=(-1)^{¬c} wx_{¬a}*wy_{¬b}
+    # abc are the index of the vertex of the cube (001,010...)
+
+    # Initialize gradient accumulators
+    gix, giy, giz = 0.0, 0.0, 0.0
+    
+    @inbounds for c in 1:iC
+        g_out = Δ[w, h, d, c, n]
+        
+        # Calculate dx and dgrid partials for all 8 corners
+        if in_bounds(iy_0, ix_0, iz_0, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_000, ix_0, iy_0, iz_0, c, n)
+            val = input[ix_0, iy_0, iz_0, c, n]
+            gix -= val * wy_1 * wz_1 * g_out
+            giy -= val * wx_1 * wz_1 * g_out
+            giz -= val * wx_1 * wy_1 * g_out
+        end
+
+        if in_bounds(iy_0, ix_0, iz_1, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_001, ix_0, iy_0, iz_1, c, n)
+            val = input[ix_0, iy_0, iz_1, c, n]
+            gix -= val * wy_1 * wz_0 * g_out
+            giy -= val * wx_1 * wz_0 * g_out
+            giz += val * wx_1 * wy_1 * g_out
+        end
+        
+        if in_bounds(iy_1, ix_0, iz_0, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_010, ix_0, iy_1, iz_0, c, n)
+            val = input[ix_0, iy_1, iz_0, c, n]
+            gix -= val * wy_0 * wz_1 * g_out
+            giy += val * wx_1 * wz_1 * g_out
+            giz -= val * wx_1 * wy_0 * g_out
+        end
+        
+        if in_bounds(iy_1, ix_0, iz_1, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_011, ix_0, iy_1, iz_1, c, n)
+            val = input[ix_0, iy_1, iz_1, c, n]
+            gix -= val * wy_0 * wz_0 * g_out
+            giy += val * wx_1 * wz_0 * g_out
+            giz += val * wx_1 * wy_0 * g_out
+        end
+
+        if in_bounds(iy_0, ix_1, iz_0, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_100, ix_1, iy_0, iz_0, c, n)
+            val = input[ix_1, iy_0, iz_0, c, n]
+            gix += val * wy_1 * wz_1 * g_out
+            giy -= val * wx_0 * wz_1 * g_out
+            giz -= val * wx_0 * wy_1 * g_out
+        end
+        
+        if in_bounds(iy_0, ix_1, iz_1, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_101, ix_1, iy_0, iz_1, c, n)
+            val = input[ix_1, iy_0, iz_1, c, n]
+            gix += val * wy_1 * wz_0 * g_out
+            giy -= val * wx_0 * wz_0 * g_out
+            giz += val * wx_0 * wy_1 * g_out
+        end
+
+        if in_bounds(iy_1, ix_1, iz_0, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_110, ix_1, iy_1, iz_0, c, n)
+            val = input[ix_1, iy_1, iz_0, c, n]
+            gix += val * wy_0 * wz_1 * g_out
+            giy += val * wx_0 * wz_1 * g_out
+            giz -= val * wx_0 * wy_0 * g_out
+        end
+        
+        if in_bounds(iy_1, ix_1, iz_1, iH, iW, iD)
+            _safe_add!(dx, g_out * weight_111, ix_1, iy_1, iz_1, c, n)
+            val = input[ix_1, iy_1, iz_1, c, n]
+            gix += val * wy_0 * wz_0 * g_out
+            giy += val * wx_0 * wz_0 * g_out
+            giz += val * wx_0 * wy_0 * g_out
+        end
+    end
+    
+    @inbounds dgrid[1, w, h, d, n] = gix_mult * gix
+    @inbounds dgrid[2, w, h, d, n] = giy_mult * giy
+    @inbounds dgrid[3, w, h, d, n] = giz_mult * giz
+end
+
 @inline function _safe_add!(dx, value, ix, iy, c, n)
     @inbounds dx[ix, iy, c, n] += value
+end
+
+@inline function _safe_add!(dx, value, ix, iy, iz, c, n)
+    @inbounds dx[ix, iy, iz, c, n] += value
 end
 
 function rrule(::typeof(grid_sample), x, grid; padding_mode)

--- a/test/ext_cuda/sampling.jl
+++ b/test/ext_cuda/sampling.jl
@@ -51,3 +51,69 @@ end
         gputest(grid_sample, input, grid; atol=1e-6, padding_mode=padding_mode)
     end
 end
+
+@testset "Grid Sampling 3D" begin
+    for T in (Float32, Float64)
+        x = ones(T, (2, 2, 2, 1, 1))  # 3D input with depth=2
+        grid = Array{T}(undef, 3, 2, 2, 2, 1)  # 3D grid with depth=2
+        grid[:, 1, 1, 1, 1] .= (-1, -1, -1)
+        grid[:, 2, 1, 1, 1] .= (1, -1, -1)
+        grid[:, 1, 2, 1, 1] .= (-1, 1, -1)
+        grid[:, 2, 2, 1, 1] .= (1, 1, -1)
+        grid[:, 1, 1, 2, 1] .= (-1, -1, 1)
+        grid[:, 2, 1, 2, 1] .= (1, -1, 1)
+        grid[:, 1, 2, 2, 1] .= (-1, 1, 1)
+        grid[:, 2, 2, 2, 1] .= (1, 1, 1)
+
+        ∇grid_true = Array{T}(undef, size(grid))
+        ∇grid_true[:, 1, 1, 1, 1] .= (0.0, 0.0, 0.0)
+        ∇grid_true[:, 2, 1, 1, 1] .= (-0.5, 0.0, 0.0)
+        ∇grid_true[:, 1, 2, 1, 1] .= (0.0, -0.5, 0.0)
+        ∇grid_true[:, 2, 2, 1, 1] .= (-0.5, -0.5, 0.0)
+        ∇grid_true[:, 1, 1, 2, 1] .= (0.0, 0.0, -0.5)
+        ∇grid_true[:, 2, 1, 2, 1] .= (-0.5, 0.0, -0.5)
+        ∇grid_true[:, 1, 2, 2, 1] .= (0.0, -0.5, -0.5)
+        ∇grid_true[:, 2, 2, 2, 1] .= (-0.5, -0.5, -0.5)
+
+
+        x_gpu, grid_gpu = CuArray(x), CuArray(grid)
+
+        padding_mode = :zeros
+        y_gpu = grid_sample(x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(y_gpu)
+        @test eltype(y_gpu) == T
+
+        external_grad = CUDA.ones(T, size(y_gpu))
+        ∇input, ∇grid = ∇grid_sample(external_grad, x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(∇input)
+        @test ∇grid_true == collect(∇grid)
+        @test eltype(∇input) == T
+        @test eltype(∇grid) == T
+
+        padding_mode = :border
+        fill!(∇grid_true, 0.0)
+        sampled = grid_sample(x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(sampled)
+        @test eltype(sampled) == T
+
+        ∇input, ∇grid = ∇grid_sample(external_grad, x_gpu, grid_gpu; padding_mode=padding_mode)
+        @test x == collect(∇input)
+        @test ∇grid_true == collect(∇grid)
+        @test eltype(∇input) == T
+        @test eltype(∇grid) == T
+    end
+end
+
+@testset "Compare grid sampling with NNlib 3D" begin
+    w, h, d, c, n = 16, 16, 16, 2, 4  # Added depth dimension `d`
+    input = rand(Float64, w, h, d, c, n)
+    grid = zeros(Float64, 3, w, h, d, n)  # 3D grid with depth `d`
+    @inbounds for xi in 1:w, yi in 1:h, zi in 1:d, ni in 1:n
+        grid[1, xi, yi, zi, ni] = (xi / w) * 2.0 - 1.0 + 0.01
+        grid[2, xi, yi, zi, ni] = (yi / h) * 2.0 - 1.0
+        grid[3, xi, yi, zi, ni] = (zi / d) * 2.0 - 1.0
+    end
+    for padding_mode in (:zeros, :border)
+        gputest(grid_sample, input, grid; atol=1e-6, padding_mode=padding_mode)
+    end
+end

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -61,3 +61,88 @@ end
     y_true = ones(Float64, size(y))
     @test y_true == y
 end
+
+@testset "Known gradients 3D" begin
+    x = ones(Float64, (2, 2, 2, 1, 1))  # 3D input with depth=2
+    grid = Array{Float64}(undef, 3, 2, 2, 2, 1)  # 3D grid with depth=2
+    grid[:, 1, 1, 1, 1] .= (-1, -1, -1)
+    grid[:, 2, 1, 1, 1] .= (1, -1, -1)
+    grid[:, 1, 2, 1, 1] .= (-1, 1, -1)
+    grid[:, 2, 2, 1, 1] .= (1, 1, -1)
+    grid[:, 1, 1, 2, 1] .= (-1, -1, 1)
+    grid[:, 2, 1, 2, 1] .= (1, -1, 1)
+    grid[:, 1, 2, 2, 1] .= (-1, 1, 1)
+    grid[:, 2, 2, 2, 1] .= (1, 1, 1)
+
+    ∇grid_true = Array{Float64}(undef, size(grid))
+    ∇grid_true[:, 1, 1, 1, 1] .= (0.0, 0.0, 0.0)
+    ∇grid_true[:, 2, 1, 1, 1] .= (-0.5, 0.0, 0.0)
+    ∇grid_true[:, 1, 2, 1, 1] .= (0.0, -0.5, 0.0)
+    ∇grid_true[:, 2, 2, 1, 1] .= (-0.5, -0.5, 0.0)
+    ∇grid_true[:, 1, 1, 2, 1] .= (0.0, 0.0, -0.5)
+    ∇grid_true[:, 2, 1, 2, 1] .= (-0.5, 0.0, -0.5)
+    ∇grid_true[:, 1, 2, 2, 1] .= (0.0, -0.5, -0.5)
+    ∇grid_true[:, 2, 2, 2, 1] .= (-0.5, -0.5, -0.5)
+
+    # ∇grid_true[:, :, :, 1, 1] = [
+    #     [[0.0, 0.0, 0.0], [-0.5, 0.0, 0.0]],
+    #     [[0.0, -0.5, 0.0], [-0.5, -0.5, 0.0]]
+    # ]
+    # ∇grid_true[:, :, :, 2, 1] = [
+    #     [[0.0, 0.0, -0.5], [-0.5, 0.0, -0.5]]
+    #     [[0.0, -0.5, -0.5], [-0.5, -0.5, -0.5]]
+    # ]
+
+    padding_mode = :zeros
+    sampled = grid_sample(x, grid; padding_mode=padding_mode)
+    @test x == sampled
+    @test eltype(sampled) == Float64
+    external_grad = ones(size(sampled))
+    ∇input, ∇grid = ∇grid_sample(external_grad, x, grid; padding_mode=padding_mode)
+    @test ∇input == x
+    @test ∇grid == ∇grid_true
+    @test eltype(∇input) == Float64
+    @test eltype(∇grid) == Float64
+
+    # ∇grid from FiniteDifferences is incorrect in case when 0-padding.
+    # gradtest(grid_sample, x, grid; fkwargs=(padding_mode=padding_mode,))
+
+    padding_mode = :border
+    fill!(∇grid_true, 0.0)
+    sampled = grid_sample(x, grid; padding_mode=padding_mode)
+    @test x == sampled
+    @test eltype(sampled) == Float64
+    external_grad = ones(size(sampled))
+    ∇input, ∇grid = ∇grid_sample(external_grad, x, grid; padding_mode=padding_mode)
+    @test ∇input == x
+    @test ∇grid == ∇grid_true
+    @test eltype(∇input) == Float64
+    @test eltype(∇grid) == Float64
+
+    gradtest(grid_sample, x, grid; fkwargs=(padding_mode=padding_mode,))
+end
+
+@testset "Test out-of-bounds for different paddings 3D" begin
+    x = ones(Float64, (2, 2, 2, 1, 1))  # 3D input with depth=2
+    grid = Array{Float64}(undef, 3, 2, 2, 2, 1)  # 3D grid with depth=2
+    grid[:, 1, 1, 1, 1] .= (-3, -1, -1)
+    grid[:, 2, 1, 1, 1] .= (0, -1, -1)
+    grid[:, 1, 2, 1, 1] .= (-1, 3, -1)
+    grid[:, 2, 2, 1, 1] .= (0, 1, -1)
+    grid[:, 1, 1, 2, 1] .= (-1, -1, 3)
+    grid[:, 2, 1, 2, 1] .= (0, -1, 3)
+    grid[:, 1, 2, 2, 1] .= (-1, 1, 3)
+    grid[:, 2, 2, 2, 1] .= (0, 1, 3)
+
+    # With 0-padding, out-of-bound values will contribute nothing to
+    # the output values, because they are too far from any bound.
+    y = grid_sample(x, grid; padding_mode=:zeros)
+    y_true = reshape(Float64[[0, 1] [0, 1] [0, 0] [0, 0]], size(y))
+    @test y_true == y
+
+    # With border-padding, out-of-bound values simply become border values
+    # and the result should be all ones.
+    y = grid_sample(x, grid; padding_mode=:border)
+    y_true = ones(Float64, size(y))
+    @test y_true == y
+end


### PR DESCRIPTION
[Current `grid_sampling` function only accept 4D input, which is suitable for 2D images. Adding function for 5D input to support 3D images.]

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
