### PR TITLE
Fixed the lpnormpool implementation

### DIFF
--- a/src/impl/pooling_direct.jl
+++ b/src/impl/pooling_direct.jl
@@ -95,14 +95,14 @@ for name in (:max, :mean, :lpnorm)
                 elseif $(name == :mean)
                     m += x[input_kw, input_kh, input_kd, c, batch_idx]
                 elseif $(name == :lpnorm)
-                    # y = (∑ᵢ xᵢ^p)^(1 / p), here to calculate ∑ᵢ xᵢ^p
+                    # y = (∑ᵢ |xᵢ|^p)^(1 / p), here to calculate ∑ᵢ |xᵢ|^p
                     m += abs(x[input_kw, input_kh, input_kd, c, batch_idx])^p
                 else
                     error("Unimplemented codegen path")
                 end
             end
 
-            # for lpnormpool, y = (∑ᵢ xᵢ^p)^(1 / p)
+            # for lpnormpool, y = (∑ᵢ |xᵢ|^p)^(1 / p)
             m = $(name == :lpnorm) ? m^(T(1) / p) : m
 
             y[w, h, d, c, batch_idx] = _alpha * m # + _beta * y[w, h, d, c, batch_idx]
@@ -263,7 +263,7 @@ for name in (:max, :mean, :lpnorm)
                     # Either does meanpool :(
                     dx[input_kw, input_kh, input_kd, c, batch_idx] += dy_idx * _alpha
                 elseif $(name == :lpnorm)
-                    # y = (∑ᵢ xᵢ^p)^(1 / p), ∂y/∂xᵢ = xᵢ^(p-1) × y^(1-p)
+                    # y = (∑ᵢ |xᵢ|^p)^(1 / p), ∂y/∂xᵢ = |xᵢ|^(p-1) × y^(1-p) × sign(xᵢ)
                     xv = x[input_kw, input_kh, input_kd, c, batch_idx]
                     grad = abs(xv)^(p-1) * y_idx^(1-p) * sign(xv)
                     dx[input_kw, input_kh, input_kd, c, batch_idx] += dy_idx * grad


### PR DESCRIPTION
The lpnormpool implementation was wrong. The existing implementation is `y = (∑ᵢ xᵢ^p)^(1 / p)`, whereas the true Lp norm shuld be `y = (∑ᵢ |xᵢ|^p)^(1 / p)`, where `|x|` is `abs(x)`. This also affects the gradient, which should be `∂y/∂xᵢ = |xᵢ|^(p-1) × y^(1-p) × sign(xᵢ)` instead of `∂y/∂xᵢ = xᵢ^(p-1) × y^(1-p)`. The necessary changes should go into `src/impl/pooling_direct.jl` which is what this PR achieves.

The existing implementation is exact only for the input array `x` such that `xᵢ >= 0 ∀ xᵢ ∈ x`. This will not generally be the case. For example, when the input to the pooling layer comes from a layer which had leaky ReLU activation, then the problem of the implementation would manifest.

MWE of the problem:
```julia
x = randn(4, 4, 4, 4)
lpnormpool(x, 0.5, (2, 2))
> ERROR: DomainError with -0.21106262688542637:
> Exponentiation yielding a complex result requires a complex argument.
> Replace x^y with (x+0im)^y, Complex(x)^y, or similar.
```
