### PR TITLE
Extending scatter! to work with CUDA sparse arrays

### DIFF
--- a/ext/NNlibCUDAExt/scatter.jl
+++ b/ext/NNlibCUDAExt/scatter.jl
@@ -1,5 +1,5 @@
 # supported op: +, -, *, /, max, min, &, |, mean
-import CUDA: CUDA.CUSPARSE.AbstractcuSparseArray
+import CUDA.CUSPARSE: AbstractCuSparseArray
 
 function scatter_kernel!(op::OP, dst, src, idx) where OP
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x

--- a/ext/NNlibCUDAExt/scatter.jl
+++ b/ext/NNlibCUDAExt/scatter.jl
@@ -24,7 +24,7 @@ function scatter_kernel!(op::OP, dst, src, idx, max_idx, max_dims_idx, dims_size
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 
     @inbounds if index <= max_idx
-        j, k = divrem(index - 1, max_dims_idx)
+        j, k = divrem(index-1, max_dims_idx)
         dims_i = CartesianIndices(dims_size)[k+1]
         CUDA.@atomic dst[Tuple(dims_i)..., idx[j+1]...] = op(dst[Tuple(dims_i)..., idx[j+1]...], src[index])
     end
@@ -32,11 +32,11 @@ function scatter_kernel!(op::OP, dst, src, idx, max_idx, max_dims_idx, dims_size
 end
 
 function scatter_kernel!(op::OP, dst, src, idx::CUDA.CuDeviceArray{<:CartesianIndex},
-    max_idx, max_dims_idx, dims_size) where OP
+            max_idx, max_dims_idx, dims_size) where OP
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 
     @inbounds if index <= max_idx
-        j, k = divrem(index - 1, max_dims_idx)
+        j, k = divrem(index-1, max_dims_idx)
         dims_i = CartesianIndices(dims_size)[k+1]
         li = Base._to_linear_index(dst, Tuple(dims_i)..., Tuple(idx[j+1])...)
         CUDA.@atomic dst[li] = op(dst[li], src[index])
@@ -59,7 +59,7 @@ function NNlib.scatter!(op::OP, dst::Union{AnyCuArray,AbstractCuSparseArray},
         op, dst, src, idx, max_idx, max_dims_idx, dims_size
     end
 
-    kernel = @cuda launch = false scatter_kernel!(args...)
+    kernel = @cuda launch=false scatter_kernel!(args...)
     config = launch_configuration(kernel.fun; max_threads=256)
     threads = min(max_idx, config.threads)
     blocks = cld(max_idx, threads)
@@ -99,7 +99,7 @@ function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx,
 end
 
 function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx::CUDA.CuDeviceArray{<:CartesianIndex},
-    rev_idx, max_idx, T::Type{TT}) where {OP,TT}
+            rev_idx, max_idx, T::Type{TT}) where {OP,TT}
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 
     @inbounds if index <= max_idx
@@ -142,7 +142,7 @@ function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx,
 end
 
 function ∇scatter_src_kernel!(op::OP, Δsrc, src, idx::CUDA.CuDeviceArray{<:CartesianIndex},
-    rev_idx, pre_cart_idx, max_dims_idx, max_idx, T::Type{TT}) where {OP,TT}
+                rev_idx, pre_cart_idx, max_dims_idx, max_idx, T::Type{TT}) where {OP,TT}
     index = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 
     @inbounds if index <= max_idx
@@ -182,7 +182,7 @@ function NNlib.∇scatter_src(op::Union{typeof(*),typeof(/)}, Δ, dst,
         args = op, Δsrc, src, idx, rev_idx, pre_cart_idx, max_dims_idx, max_idx, Tsrc
     end
 
-    kernel = @cuda launch = false ∇scatter_src_kernel!(args...)
+    kernel = @cuda launch=false ∇scatter_src_kernel!(args...)
     config = launch_configuration(kernel.fun; max_threads=256)
     threads = min(max_idx, config.threads)
     blocks = cld(max_idx, threads)

--- a/ext/NNlibCUDAExt/scatter.jl
+++ b/ext/NNlibCUDAExt/scatter.jl
@@ -46,8 +46,8 @@ end
 
 
 function NNlib.scatter!(op::OP, dst::Union{AnyCuArray,AbstractCuSparseArray},
-    src::Union{SpAnyCuArray,AbstractCuSparseArray},
-    idx::Union{SpAnyCuArray,AbstractCuSparseArray}) where OP
+    src::Union{AnyCuArray,AbstractCuSparseArray},
+    idx::Union{AnyCuArray,AbstractCuSparseArray}) where OP
     dims = NNlib.scatter_dims(dst, src, idx)
     args = if dims == 0
         max_idx = length(idx)
@@ -68,7 +68,8 @@ function NNlib.scatter!(op::OP, dst::Union{AnyCuArray,AbstractCuSparseArray},
 end
 
 function NNlib.scatter!(op::typeof(mean), dst::Union{AnyCuArray,AbstractCuSparseArray},
-    src::Union{AnyCuArray,AbstractCuArray}, idx::Union{AnyCuArray,AbstractCuArray})
+        src::Union{AnyCuArray,AbstractCuSparseArray},
+        idx::Union{AnyCuArray,AbstractCuSparseArray})
     Ns = NNlib.scatter!(+, zero(dst), one.(src), idx)
     dst_ = NNlib.scatter!(+, zero(dst), src, idx)
     dst .+= NNlib.safe_div.(dst_, Ns)

--- a/test/ext_cuda/runtests.jl
+++ b/test/ext_cuda/runtests.jl
@@ -4,6 +4,7 @@ using Zygote
 using ForwardDiff: Dual
 using Statistics: mean
 using CUDA, cuDNN
+import CUDA.CUSPARSE: CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO
 using NNlib: batchnorm, ∇batchnorm
 CUDA.allowscalar(false)
 

--- a/test/ext_cuda/scatter.jl
+++ b/test/ext_cuda/scatter.jl
@@ -21,7 +21,7 @@ idxs = [
         (3,) (5,) (5,) (3,)])),  # CartesianIndex index
 ]
 
-types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}]
+types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}, CuSparseMatrixCSC{Float32}, CuSparseMatrixCSR{Float32}, CuSparseMatrixCOO{Float32}]
 
 
 @testset "scatter" begin
@@ -70,7 +70,7 @@ types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}]
     end
 
 
-    for T = [CuArray{Float32}, CuArray{Float64}]
+    for T = [CuArray{Float32}, CuArray{Float64}, Sparse, CuSparseMatrixCSC{Float32}, CuSparseMatrixCSR{Float32}, CuSparseMatrixCOO{Float32}]
         @testset "$(T)" begin
             @testset "*" begin
                 for idx = idxs, dims = [0, 1]


### PR DESCRIPTION
Aims to fix #647 by extending the signature of `scatter!` to work with `AbstractCuSparseArray`, a CUDA array type notably excluded by the original method. With the proposed patch, calling `scatter!` with sparse arrays from `CUDA.CUSPARSE` will correctly call the CUDA-specialized method instead of calling the generic CPU method, which triggered a scalar indexing error. In my testing the existing CUDA kernels work perfectly fine with `CuSparseArrayCSC`.

The proposed implementation, perhaps inelegantly, just expands the types in the signature with `Union{...}`. I am open to discussing more beautiful ways of implementing this. Ideally, `AbstractCuSparseArray` would be a subtype of `AnyCuArray`.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
