### PR TITLE
revert 648 (extend scatter to CUDA sparse)

### DIFF
--- a/test/ext_cuda/scatter.jl
+++ b/test/ext_cuda/scatter.jl
@@ -21,7 +21,7 @@ idxs = [
         (3,) (5,) (5,) (3,)])),  # CartesianIndex index
 ]
 
-types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}, CuSparseMatrixCSC{Float32}, CuSparseMatrixCSR{Float32}, CuSparseMatrixCOO{Float32}]
+types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}]
 
 
 @testset "scatter" begin
@@ -70,7 +70,7 @@ types = [CuArray{Int32}, CuArray{Int64}, CuArray{Float32}, CuArray{Float64}, CuS
     end
 
 
-    for T = [CuArray{Float32}, CuArray{Float64}, Sparse, CuSparseMatrixCSC{Float32}, CuSparseMatrixCSR{Float32}, CuSparseMatrixCOO{Float32}]
+    for T = [CuArray{Float32}, CuArray{Float64}]
         @testset "$(T)" begin
             @testset "*" begin
                 for idx = idxs, dims = [0, 1]


### PR DESCRIPTION
Tests introduced in #648 were failing, so it shouldn't have been merged.

Also fixes #669 
