### PR TITLE
Fix CUDA.adapt and centralize imports in NNlibCUDAExt

### DIFF
--- a/ext/NNlibCUDAExt/NNlibCUDAExt.jl
+++ b/ext/NNlibCUDAExt/NNlibCUDAExt.jl
@@ -1,8 +1,13 @@
 module NNlibCUDAExt
 
 using NNlib
+using NNlib: BatchedAdjoint, BatchedTranspose, BatchedAdjOrTrans
 using CUDA
 using Random, Statistics
+using Adapt
+using Adapt: WrappedArray
+
+import NNlib: ctc_loss, ctc_alpha, ∇ctc_loss
 
 include("sampling.jl")
 include("activations.jl")

--- a/ext/NNlibCUDAExt/batchedadjtrans.jl
+++ b/ext/NNlibCUDAExt/batchedadjtrans.jl
@@ -1,7 +1,3 @@
-using NNlib: BatchedAdjoint, BatchedTranspose, BatchedAdjOrTrans
-using Adapt
-using Adapt: WrappedArray
-
 const CuBatchedAdjoint{T} = BatchedAdjoint{T, <: CuArray{T}}
 const CuBatchedTranspose{T} = BatchedTranspose{T, <: CuArray{T}}
 const CuBatchedAdjOrTrans{T} = Union{CuBatchedAdjoint{T}, CuBatchedTranspose{T}}

--- a/ext/NNlibCUDAExt/ctc.jl
+++ b/ext/NNlibCUDAExt/ctc.jl
@@ -1,6 +1,3 @@
-# CTC loss moved from Flux.jl to NNlib
-
-import NNlib: ctc_loss, ctc_alpha, ∇ctc_loss
 
 ## GPU implementation
 
@@ -209,7 +206,7 @@ function ctc_alpha(ŷ::CuArray, y)
   T = size(ŷ, 2)
   U′ = 2*length(y) + 1
   alphas = CUDA.fill(log(zero(eltype(ŷ))), U′,T)
-  nRepeats = count_repeats(CUDA.adapt(Array, y))
+  nRepeats = count_repeats(Adapt.adapt(Array, y))
   nThreads = min(U′, MAX_THREADS)
   @cuda blocks=1 threads=nThreads compute_alpha_kernel(ŷ, length(y), T, nRepeats, ycu, z′, alphas, blank)
   return (loss=-1 * logsumexp(alphas[end-1:end]), alpha=alphas, z′=z′, yhat=ŷ, nRepeats=nRepeats)


### PR DESCRIPTION
## Summary
- Replace the removed `CUDA.adapt` with `Adapt.adapt` in `ctc.jl`
- Centralize all `using`/`import` statements in the module file `NNlibCUDAExt.jl` as a good code practice (moved them out of `batchedadjtrans.jl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)