### PR TITLE
Fix softplus to be smooth at the origin (#671)

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -685,7 +685,7 @@ julia> softplus(16f0)
 16.0f0
 ```
 """
-softplus(x) = log1p(exp(-abs(x))) + relu(x)
+softplus(x) = x < zero(x) ? log1p(exp(x)) : x + log1p(exp(-x))
 
 """
     logcosh(x)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -21,6 +21,10 @@ BINARY_ACTIVATIONS = filter(f -> hasmethod(f, Tuple{Float64, Float64}), ACTIVATI
 @test softplus(0.0) ≈ log(2.0)
 @test softplus(1e8) ≈ 1e8
 @test softplus(-1e8) ≈ 0.0
+# https://github.com/FluxML/NNlib.jl/issues/671: softplus must be smooth at the
+# origin so that derivatives (computed e.g. by ForwardDiff for Hessians) are correct there.
+@test ForwardDiff.derivative(softplus, 0.0) ≈ 0.5
+@test ForwardDiff.derivative(x -> ForwardDiff.derivative(softplus, x), 0.0) ≈ 0.25
 @test softsign(0.0) == 0.0
 @test selu(0.0) == 0.0
 @test celu(0.0) == 0.0


### PR DESCRIPTION
Fixes #671.

## Problem

`softplus` was defined as:

```julia
softplus(x) = log1p(exp(-abs(x))) + relu(x)
```

Both `abs` and `relu` have a kink at `x = 0`. The function *value* and *first derivative away from 0* are correct, but when AD differentiates the source **exactly at the origin** (e.g. ForwardDiff computing Hessians for Input-Convex NNs, as in [this Discourse thread](https://discourse.julialang.org/t/input-convex-neural-network-is-not-convex-at-origin-in-lux-jl/133565/2)), it returns a wrong gradient:

```julia
ForwardDiff.derivative(softplus, 0.0)   # -0.5, should be +0.5
```

This is what made the ICNN's Hessian non-SPD at the origin.

## Fix

```julia
softplus(x) = x < zero(x) ? log1p(exp(x)) : x + log1p(exp(-x))
```

This is the `logaddexp(x, 0)` formulation used by JAX. Branching on the sign of `x` makes each branch a smooth, analytic expression, so AD gets correct derivatives everywhere — while keeping the same values and numerical stability (no `exp` overflow for large `|x|`).

Note: JAX's `logaddexp(x, 0)` is algebraically identical to the old NNlib formula; JAX avoids the kink via a custom JVP. Since NNlib relies on AD differentiating the source directly, the branch form is what actually fixes it here.

## Verification

- Values unchanged across a wide range; `softplus(16f0) === 16f0`, `softplus(0.0) ≈ log(2)`, type-stable.
- `ForwardDiff.derivative(softplus, 0.0) ≈ 0.5` and second derivative `≈ 0.25` (added as regression tests).
- Zygote (via the unchanged `sigmoid_fast` rrule) and ForwardDiff gradients agree on scalars and broadcasted arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)