### PR TITLE
Add multi-index gather! method (fixes #626)

### DIFF
--- a/src/gather.jl
+++ b/src/gather.jl
@@ -109,6 +109,37 @@ function gather!(dst::AbstractArray, src::AbstractArray, idx::AbstractArray)
     return dst
 end
 
+"""
+    gather!(dst, src, IJK...)
+
+Convert the tuple of integer vectors `IJK` to a tuple of `CartesianIndex` and
+call `gather!` on it: `gather!(dst, src, CartesianIndex.(IJK...))`.
+
+# Examples
+
+```jldoctest
+julia> src = reshape([1:15;], 3, 5)
+3×5 Matrix{Int64}:
+ 1  4  7  10  13
+ 2  5  8  11  14
+ 3  6  9  12  15
+
+julia> dst = zeros(Int, 2);
+
+julia> NNlib.gather!(dst, src, [1, 2], [2, 4])
+2-element Vector{Int64}:
+  4
+ 11
+```
+"""
+function gather!(
+    dst::AbstractArray, src::AbstractArray,
+    I::AbstractVector{<:Integer}, J::AbstractVector{<:Integer},
+    Ks::AbstractVector{<:Integer}...,
+)
+    return gather!(dst, src, to_cartesian_index(I, J, Ks...))
+end
+
 function gather!(dst::AnyGPUArray, src::AnyGPUArray, idx::AnyGPUArray)
     isempty(dst) && return dst
     n_dims = scatter_dims(src, dst, idx)

--- a/test/testsuite/gather.jl
+++ b/test/testsuite/gather.jl
@@ -201,5 +201,14 @@ function gather_testsuite(Backend)
             2 5
             3 6]
     end
+
+    @testset "gather!(dst, src, IJK...)" begin
+        x = device(reshape([1:15;], 3, 5))
+        i, j = device([1,2]), device([2,4])
+        dst = device(zeros(Int, 2))
+        y = gather!(dst, x, i, j)
+        @test y === dst
+        @test cpu(y) == [4, 11]
+    end
 end
 


### PR DESCRIPTION
Fixes #626.

`gather` has a multi-index method `gather(src, IJK...)`, but the mutating `gather!` was missing the equivalent overload, so `gather!(dst, src, I, J, ...)` raised a `MethodError`.

This adds `gather!(dst, src, IJK...)`, which converts the integer index vectors to `CartesianIndex` (via `to_cartesian_index`) and dispatches to the regular `gather!`, mirroring `gather(src, IJK...)`. Includes a docstring example and a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)