### PR TITLE
Mark non-exported public API with `public` keyword

### DIFF
--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -124,4 +124,10 @@ include("audio/spectrogram.jl")
 include("audio/mel.jl")
 export stft, istft, hann_window, hamming_window, spectrogram, melscale_filterbanks
 
+# Mark the documented but non-exported API with the `public` keyword.
+# `public` is only valid syntax on Julia 1.11+, so parse it lazily.
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("public gather, gather!, scatter, scatter!, fold, unfold, glu, within_gradient"))
+end
+
 end # module NNlib


### PR DESCRIPTION
Fixes #624.

Marks the documented but non-exported API with the `public` keyword: `gather`, `gather!`, `scatter`, `scatter!`, `fold`, `unfold`, `glu`, `within_gradient` (the `NNlib.`-prefixed entries in the reference docs).

Since `public` is only valid syntax on Julia 1.11+ (and compat is `julia = "1.10"`), the statement is parsed lazily via `Meta.parse` + `eval` inside a `@static if`.

Verified on Julia 1.12 that all eight symbols report `Base.ispublic == true` and `Base.isexported == false`, and the package precompiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)