### PR TITLE
Fix type instability in pad_constant/pad_zeros (#409)

### DIFF
--- a/src/padding.jl
+++ b/src/padding.jl
@@ -96,9 +96,9 @@ Stacktrace:
 ```
 """
 pad_constant(x::AbstractArray{T,N}, pad::Int, val = 0; dims = :) where {T,N} =
-  pad_constant(x, gen_pad(pad, dims isa Colon ? dims : (dims...,), N), val)
+  pad_constant(x, gen_pad(pad, dims isa Colon ? dims : (dims...,), Val(N)), val)
 pad_constant(x::AbstractArray{T,N}, pad::Tuple, val = 0; dims = :) where {T,N} =
-  pad_constant(x, gen_pad(pad, dims isa Colon ? dims : (dims...,), N), val)
+  pad_constant(x, gen_pad(pad, dims isa Colon ? dims : (dims...,), Val(N)), val)
 
 function pad_idx(pad, dims, N)
   is = zip( (2 .* dims) .- 1, (2 .* dims))
@@ -108,13 +108,13 @@ end
 @inline tuplejoin(x, y) = (x..., y...)
 @inline tuplejoin(x, y, z...) = tuplejoin(tuplejoin(x, y), z...)
 
-gen_pad(pad::Int, dims, N) = gen_pad(ntuple(_ -> pad, length(dims)), dims, N)
-gen_pad(pad::Int, dims::Colon, N) = ntuple(_ -> (pad, pad), N)
-gen_pad(pad, dims::Colon, N) = gen_pad(pad, ntuple(identity, N), N)
-gen_pad(pad, dims::Int, N) = gen_pad(pad, (dims,), N)
-gen_pad(pad::Int, dims::Int, N) = gen_pad((pad,pad), (dims,), N)
-function gen_pad(pad::NTuple{L,Int}, dims::NTuple{D,Int}, N) where {L,D}
-  ntuple(N) do d
+gen_pad(pad::Int, dims, ::Val{N}) where {N} = gen_pad(ntuple(_ -> pad, length(dims)), dims, Val(N))
+gen_pad(pad::Int, dims::Colon, ::Val{N}) where {N} = ntuple(_ -> (pad, pad), Val(N))
+gen_pad(pad, dims::Colon, ::Val{N}) where {N} = gen_pad(pad, ntuple(identity, Val(N)), Val(N))
+gen_pad(pad, dims::Int, ::Val{N}) where {N} = gen_pad(pad, (dims,), Val(N))
+gen_pad(pad::Int, dims::Int, ::Val{N}) where {N} = gen_pad((pad,pad), (dims,), Val(N))
+function gen_pad(pad::NTuple{L,Int}, dims::NTuple{D,Int}, ::Val{N}) where {L,D,N}
+  ntuple(Val(N)) do d
    if d in dims
      if L == D
        ix = findfirst(==(d), dims)
@@ -151,7 +151,7 @@ function rrule(::typeof(pad_constant), x::AbstractArray{T,N},
                pad, val; dims = :) where {T,N}
   y = pad_constant(x, pad, val; dims = dims)
   function pad_constant_pullback(Δ)
-    p = gen_pad(pad, dims, N)
+    p = gen_pad(pad, dims, Val(N))
     outsize, center = size_and_center(x, p)
     (NoTangent(), @thunk(unthunk(Δ)[center...]), NoTangent(), NoTangent(),)
   end

--- a/test/padding.jl
+++ b/test/padding.jl
@@ -3,21 +3,21 @@ using NNlib: pad_constant, pad_repeat, pad_zeros, pad_reflect, pad_symmetric, pa
 @testset "padding constant" begin
     x = rand(2, 2, 2)
 
-    p = NNlib.gen_pad((1,2,3,4,5,6), (1,2,3), 4)
+    p = NNlib.gen_pad((1,2,3,4,5,6), (1,2,3), Val(4))
     @test p == ((1, 2), (3, 4), (5, 6), (0, 0))
 
-    @test_throws ArgumentError NNlib.gen_pad((1,2,3,4,5,), (1,2,3), 4)
+    @test_throws ArgumentError NNlib.gen_pad((1,2,3,4,5,), (1,2,3), Val(4))
 
-    p = NNlib.gen_pad((1,3), (1,3), 4)
+    p = NNlib.gen_pad((1,3), (1,3), Val(4))
     @test p == ((1, 1), (0, 0), (3, 3), (0, 0))
 
-    p = NNlib.gen_pad(1, (1,2,3), 4)
+    p = NNlib.gen_pad(1, (1,2,3), Val(4))
     @test p == ((1, 1), (1, 1), (1, 1), (0, 0))
 
-    p = NNlib.gen_pad(3, :, 2)
+    p = NNlib.gen_pad(3, :, Val(2))
     @test p == ((3, 3), (3, 3))
 
-    p = NNlib.gen_pad((1,0), 1, 2)
+    p = NNlib.gen_pad((1,0), 1, Val(2))
     @test p == ((1,0), (0,0))
 
     y = pad_constant(x, (3, 2, 4))


### PR DESCRIPTION
Fixes #409.

`pad_zeros` / `pad_constant` were type-unstable when called with a `Tuple` pad and the default `dims = :`:

```julia
x = rand(Float32, 100, 1, 1, 8)
@code_warntype NNlib.pad_zeros(x, (0, size(x)[1] % 2, 0, 0, 0, 0, 0, 0))
# Body::Any
```

## Cause

In `gen_pad`, the dimension count `N` was passed as a plain runtime `Int`, so `ntuple(identity, N)` and `ntuple(N) do ... end` inferred to `Tuple{Vararg{...}}` instead of a fixed-length tuple, poisoning the whole call to `Any`. (Root cause identified by @ToucheSir in the issue.)

## Fix

Thread `N` through as `Val{N}`:

- The `pad_constant` entry methods call `gen_pad(..., Val(N))` (`N` is a type parameter there, so this is free).
- All `gen_pad` methods take `::Val{N}` and use `ntuple(..., Val(N))`, which infers to a concrete `NTuple`.
- The `rrule` pullback's `gen_pad` call updated accordingly.
- Updated the internal-API calls in `test/padding.jl` to pass `Val(...)`.

This is purely an inference fix — values and behavior are unchanged.

## Verification

- `@code_warntype` on the example from the issue now infers `Body::Array{Float32, 4}`.
- All padding tests pass; manually checked every `gen_pad` branch returns identical values, the `ArgumentError` branch still throws, and the `pad_constant` rrule still produces correct gradients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)