### PR TITLE
Support N-D arrays in batched_mul! (#529)

### DIFF
--- a/src/batched/batchedmul.jl
+++ b/src/batched/batchedmul.jl
@@ -241,6 +241,18 @@ function batched_mul!(C::AbstractArray{T,3}, A::AbstractArray{<:Any,3}, B::Abstr
     C
 end
 
+function batched_mul!(C::AbstractArray{T,N}, A::AbstractArray{<:Any,N}, B::AbstractArray{<:Any,N},
+        α::Number=one(T), β::Number=zero(T)) where {T,N}
+    batch_size = size(C)[3:end]
+    size(A)[3:end] == batch_size || throw(DimensionMismatch("batch size of A must match C"))
+    size(B)[3:end] == batch_size || throw(DimensionMismatch("batch size of B must match C"))
+    C2 = reshape(C, size(C, 1), size(C, 2), :)
+    A2 = reshape(A, size(A, 1), size(A, 2), :)
+    B2 = reshape(B, size(B, 1), size(B, 2), :)
+    batched_mul!(C2, A2, B2, α, β)
+    return C
+end
+
 _batched_mul!(::Type, C, A, B, α::Number, β::Number) = batched_mul_generic!(C, A, B, α, β)
 
 _batched_mul!(::Type{DT}, C, A, B, α::Number, β::Number) where {DT<:DenseArray{T}} where {T<:BlasFloat} =

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -331,5 +331,30 @@ end
     # Test dimension mismatch errors
     @test_throws DimensionMismatch batched_vec(randn(3, 4, 2), randn(4, 3))  # ndims mismatch
     @test_throws DimensionMismatch batched_vec(randn(3, 4, 2, 3), randn(4, 2, 2))  # batch size mismatch
-    
+
+end
+
+@testset "batched_mul!: N-D batches" begin
+    # 4D case, issue #529
+    A = randn(3, 4, 5, 6)
+    B = randn(4, 2, 5, 6)
+    C = similar(A, 3, 2, 5, 6)
+    @test batched_mul!(C, A, B) === C
+    @test C ≈ batched_mul(A, B)
+
+    # 5-arg form with α, β
+    α, β = 2.0, 3.0
+    D = randn(3, 2, 5, 6)
+    C .= D
+    @test batched_mul!(C, A, B, α, β) ≈ α .* batched_mul(A, B) .+ β .* D
+
+    # 5D case
+    A5 = randn(3, 4, 2, 3, 2)
+    B5 = randn(4, 2, 2, 3, 2)
+    C5 = similar(A5, 3, 2, 2, 3, 2)
+    @test batched_mul!(C5, A5, B5) ≈ batched_mul(A5, B5)
+
+    # batch size mismatch errors
+    @test_throws DimensionMismatch batched_mul!(similar(A, 3, 2, 5, 7), A, B)
+    @test_throws DimensionMismatch batched_mul!(C, A, randn(4, 2, 5, 7))
 end


### PR DESCRIPTION
Fixes #529.

`batched_mul` already supported arrays with more than 3 dimensions by reshaping the trailing batch dimensions into a single one and dispatching to the 3D implementation. However, `batched_mul!` only had a 3D method, so the in-place form failed for N-D arrays.

This adds a generic N-D `batched_mul!` method that reshapes `A`, `B`, and `C` to 3D (sharing the same underlying data, no copy) before dispatching to the existing 3D `batched_mul!`. Batch sizes are validated, throwing `DimensionMismatch` on a mismatch.

The implementation follows the approach suggested by @AntonOresten in the issue thread.

Added tests cover 4D/5D arrays, the 5-arg `α`/`β` form, and dimension-mismatch errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)