### PR TITLE
Remove obsolete TODO comment in test_utils (#428)

### DIFF
--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -15,8 +15,6 @@ function gradtest(
     check_rrule = false, fdm = :central, check_broadcast = false,
     skip = false, broken = false,
 )
-    # TODO: revamp when https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/166
-    # is merged
     if check_rrule
         test_rrule(f, xs...; fkwargs = fkwargs)
     end


### PR DESCRIPTION
Fixes #428.

The TODO comment in `test/test_utils.jl` referenced [ChainRulesTestUtils.jl#166](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/166), which has since been merged. As suggested in the issue, this just removes the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)