### PR TITLE
conv/pool: reject negative padding instead of corrupting memory

### DIFF
--- a/src/dim_helpers/ConvDims.jl
+++ b/src/dim_helpers/ConvDims.jl
@@ -134,8 +134,11 @@ function check_spdf(x_size::NTuple{N}, w_size::NTuple{N}, stride, padding, dilat
     return pstride, ppadding_expanded, pdilation
 end
 
-# Assert that kernel size * dilation is <= padded input size
+# Assert that padding is non-negative and kernel size * dilation is <= padded input size
 function _validate_padding(x_size::NTuple{N}, w_size::NTuple{N}, padding, dilation) where N
+    if any(<(0), padding)
+        throw(ArgumentError("Negative padding $(padding) is not supported."))
+    end
     for idx in 1:(N - 2)
         Is = x_size[idx]
         Ks = w_size[idx]

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -64,6 +64,10 @@ using Random: AbstractRNG, SamplerType
             @test_throws DimensionMismatch T(x, w; dilation=(1, 1, 1))
             # Dilation will cause us to reach beyond the end of input + padding here:
             @test_throws DimensionMismatch T(x, w; dilation=(1, 5))
+            # Negative padding is not supported (https://github.com/FluxML/NNlib.jl/issues/123):
+            @test_throws ArgumentError T(x, w; padding=-1)
+            @test_throws ArgumentError T(x, w; padding=(-1, -1))
+            @test_throws ArgumentError T(x, w; padding=(0, -1, 0, 0))
             # Channel mismatch:
             if T == DenseConvDims
                 @test_throws DimensionMismatch T(x, w[:,:,1:1,:])


### PR DESCRIPTION
Fixes #123.

Negative padding values flowed unchecked into the im2col/BLAS path, producing incorrectly-sized buffers that caused segfaults and heap corruption (e.g. `Conv((2,2), 1=>1, pad=(-1,-1))` on a 20×20 `Float32` input).

## Change
Added a non-negativity check at the top of `_validate_padding` in `src/dim_helpers/ConvDims.jl`:

```julia
if any(<(0), padding)
    throw(ArgumentError("Negative padding $(padding) is not supported."))
end
```

`_validate_padding` is reached via `check_spdf` from `DenseConvDims`, `DepthwiseConvDims`, and `PoolDims`, so this single check covers conv, depthwise conv, and pooling.

## Tests
Added `@test_throws ArgumentError` cases (integer, symmetric-tuple, asymmetric-tuple forms) to the dims test loop in `test/conv.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)