### PR TITLE
Support complex inputs in activation functions

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -56,6 +56,14 @@ function σ(x)
     ifelse(x ≥ 0, inv(1 + t), t / (1 + t))
 end
 
+# Complex inputs (e.g. complex-valued networks): σ is holomorphic, so we compute the
+# same function via the overflow-safe rearrangement. `1/(1+exp(-z))` and
+# `exp(z)/(1+exp(z))` are equal everywhere; we branch on `real(z)` to pick the one
+# whose `exp` cannot overflow (overflow depends only on the real part).
+function σ(z::Complex)
+    real(z) ≥ 0 ? inv(1 + exp(-z)) : (t = exp(z); t / (1 + t))
+end
+
 const sigmoid = σ
 
 """
@@ -687,6 +695,12 @@ julia> softplus(16f0)
 """
 softplus(x) = x < zero(x) ? log1p(exp(x)) : x + log1p(exp(-x))
 
+# Complex inputs: softplus(z) = log(1 + exp(z)) on the principal branch. As in the real
+# method we branch on `real(z)` to avoid overflow of `exp`. Note the two rearrangements
+# agree only for `abs(imag(z)) ≤ π` (the principal log's branch cut), which covers
+# typical complex-valued-network use.
+softplus(z::Complex) = real(z) < 0 ? log1p(exp(z)) : z + log1p(exp(-z))
+
 """
     logcosh(x)
 
@@ -917,7 +931,10 @@ this replacement for some array or element types.
 
 UNARY_ACTS = [ # f, dfdx
     ## In the same order as above!
-    (:σ,            :(conj(Ω * (1 - Ω)))),
+    ## Derivatives are the plain (un-conjugated) f'; the broadcasted rrule below applies
+    ## `conj`, and the scalar `@scalar_rule` conjugates internally, so both paths yield the
+    ## ChainRules-convention `conj(f')` needed for correct complex (holomorphic) gradients.
+    (:σ,            :(Ω * (1 - Ω))),
     (:hardσ,        :(ifelse((Ω>0)&(Ω<1), oftf(Ω, 1/6), oftf(Ω, 1)))),
     (:logσ,         :(sigmoid_fast(-x))),
     (:hardtanh,     :((Ω>-1) & (Ω<1))),
@@ -943,8 +960,8 @@ UNARY_ACTS = [ # f, dfdx
     (:tanhshrink,    :((x - Ω)^2)),
     (:softshrink,    :(Ω != 0)),
     ## Fast variants are the same!
-    (:tanh_fast,    :(conj(1 - Ω^2))),
-    (:sigmoid_fast, :(conj(Ω * (1 - Ω)))),
+    (:tanh_fast,    :(1 - Ω^2)),
+    (:sigmoid_fast, :(Ω * (1 - Ω))),
 ]
 
 for (f, dfdx) in UNARY_ACTS
@@ -956,8 +973,8 @@ for (f, dfdx) in UNARY_ACTS
         Ω = $f.(x)
         function $pullback(dΩ)
             x_thunk = InplaceableThunk(
-                dx -> @.(dx += dΩ * $dfdx),
-                @thunk @.(dΩ * $dfdx)
+                dx -> @.(dx += dΩ * conj($dfdx)),
+                @thunk @.(dΩ * conj($dfdx))
             )
             NoTangent(), NoTangent(), x_thunk
         end
@@ -986,7 +1003,7 @@ for (f, dfdx1, dfdx2) in BINARY_ACTS
                          x1::Union{Numeric, Broadcast.Broadcasted}, x2::Number)
         Ω = $f.(x1, x2)
         ## Allowing x2::Array would allow size(Ω) != size(x1), which is not handled here:
-        $pullback(dΩ) = (NoTangent(), NoTangent(), @.(dΩ * $dfdx1), NO_ACT_GRAD)
+        $pullback(dΩ) = (NoTangent(), NoTangent(), @.(dΩ * conj($dfdx1)), NO_ACT_GRAD)
         return Ω, $pullback
     end
 end

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -693,10 +693,12 @@ julia> softplus(16f0)
 16.0f0
 ```
 """
-softplus(x) = real(x) < zero(real(x)) ? log1p(exp(x)) : x + log1p(exp(-x))
-# Branching on `real(x)` keeps `exp` from overflowing and also makes this work for
-# complex inputs: softplus(z) = log(1 + exp(z)) on the principal branch (the two
-# rearrangements agree for `abs(imag(z)) ≤ π`, which covers typical use).
+function softplus(x)
+    # Branching on `real(x)` keeps `exp` from overflowing and also makes this work for
+    # complex inputs: softplus(z) = log(1 + exp(z)) on the principal branch (the two
+    # rearrangements agree for `abs(imag(z)) ≤ π`, which covers typical use).
+    real(x) < zero(real(x)) ? log1p(exp(x)) : x + log1p(exp(-x))
+end
 
 """
     logcosh(x)

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -693,13 +693,10 @@ julia> softplus(16f0)
 16.0f0
 ```
 """
-softplus(x) = x < zero(x) ? log1p(exp(x)) : x + log1p(exp(-x))
-
-# Complex inputs: softplus(z) = log(1 + exp(z)) on the principal branch. As in the real
-# method we branch on `real(z)` to avoid overflow of `exp`. Note the two rearrangements
-# agree only for `abs(imag(z)) ≤ π` (the principal log's branch cut), which covers
-# typical complex-valued-network use.
-softplus(z::Complex) = real(z) < 0 ? log1p(exp(z)) : z + log1p(exp(-z))
+# Branching on `real(x)` keeps `exp` from overflowing and also makes this work for
+# complex inputs: softplus(z) = log(1 + exp(z)) on the principal branch (the two
+# rearrangements agree for `abs(imag(z)) ≤ π`, which covers typical use).
+softplus(x) = real(x) < zero(real(x)) ? log1p(exp(x)) : x + log1p(exp(-x))
 
 """
     logcosh(x)

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -899,6 +899,13 @@ end
 
 sigmoid_fast(x::Float16) = sigmoid(x)  # sigmoid_fast is extremely badly behaved at large x
 
+# Complex inputs: the `_fast` clamped approximation is real-only, so fall back to the
+# holomorphic `σ` (which has its own overflow-safe complex method). This keeps `swish`,
+# `logσ`, and the `softplus`/`logσ` gradients holomorphic and GPU-compilable; using a
+# plain method (rather than the deprecation path below) avoids the `depwarn` string
+# interpolation that cannot compile in a GPU kernel.
+sigmoid_fast(x::Complex) = σ(x)
+
 function sigmoid_fast(x::Number)
     Base.depwarn("sigmoid only makes sense on real numbers, got $(typeof(x))", :sigmoid_fast)
     sigmoid(x)

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -693,10 +693,10 @@ julia> softplus(16f0)
 16.0f0
 ```
 """
+softplus(x) = real(x) < zero(real(x)) ? log1p(exp(x)) : x + log1p(exp(-x))
 # Branching on `real(x)` keeps `exp` from overflowing and also makes this work for
 # complex inputs: softplus(z) = log(1 + exp(z)) on the principal branch (the two
 # rearrangements agree for `abs(imag(z)) ≤ π`, which covers typical use).
-softplus(x) = real(x) < zero(real(x)) ? log1p(exp(x)) : x + log1p(exp(-x))
 
 """
     logcosh(x)

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -436,3 +436,54 @@ end
         @test H ≈ Zygote.hessian_reverse(x -> sum(abs2, f.(x .+ 0.1, 0.3)), x)
     end
 end
+
+@testset "complex" begin
+    ## https://github.com/FluxML/NNlib.jl/issues/132
+    ## Holomorphic activations are well-defined on ℂ. Each is checked against a naive
+    ## elementary formula for (a) the forward value and (b) the gradient. Gradients of
+    ## both `f` and the naive version are taken with Zygote, so whatever complex-gradient
+    ## convention Zygote uses cancels, and the test isolates the correctness of NNlib's
+    ## hand-written rules (in particular the `conj` needed for the ChainRules convention).
+    holo = [
+        (σ,          z -> 1 / (1 + exp(-z))),
+        (swish,      z -> z / (1 + exp(-z))),
+        (softplus,   z -> log(1 + exp(z))),
+        (logσ,       z -> -log(1 + exp(-z))),
+        (mish,       z -> z * tanh(log(1 + exp(z)))),
+        (logcosh,    z -> log(cosh(z))),
+        (tanh_fast,  z -> tanh(z)),
+        (lisht,      z -> z * tanh(z)),
+        (tanhshrink, z -> z - tanh(z)),
+    ]
+    zs = ComplexF64[0.4 + 0.6im, -0.7 + 0.2im, 1.2 - 0.9im, -0.3 - 1.1im]
+
+    @testset "$f" for (f, naive) in holo
+        for z in zs
+            @test f(z) ≈ naive(z)                                   # forward
+            @test gradient(z -> abs2(f(z)), z)[1] ≈
+                  gradient(z -> abs2(naive(z)), z)[1]               # scalar gradient
+        end
+        @test gradient(z -> sum(abs2, f.(z)), zs)[1] ≈
+              gradient(z -> sum(abs2, naive.(z)), zs)[1]            # broadcasted gradient
+    end
+
+    @testset "numerical stability" begin
+        ## must stay finite where the naive formula overflows / loses the phase
+        for z in (600 + 2im, -600 + 2im, 80 - 50im, -80 + 50im)
+            @test isfinite(σ(z))
+            @test isfinite(softplus(z))
+            @test isfinite(swish(z))
+        end
+        @test σ(-800 + 0im) ≈ 0 atol = 1e-12
+        @test real(softplus(800 + 1im)) ≈ 800
+    end
+
+    @testset "piecewise activations reject complex" begin
+        ## Order-defined activations have no canonical complex extension; they should
+        ## throw rather than silently pick one (e.g. CReLU/modReLU/zReLU).
+        for f in (relu, leakyrelu, relu6, elu, selu, celu,
+                  hardσ, hardtanh, hardswish, trelu, softshrink)
+            @test_throws MethodError f(1.0 + 1.0im)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ end
 
 cpu(x) = adapt(CPU(), x)
 
+include("testsuite/activations.jl")
 include("testsuite/gather.jl")
 include("testsuite/scatter.jl")
 include("testsuite/upsample.jl")
@@ -52,6 +53,9 @@ include("testsuite/spectral.jl")
 include("testsuite/fold.jl")
 
 function nnlib_testsuite(Backend; skip_tests = Set{String}())
+    @conditional_testset "Activations" skip_tests begin
+        activations_testsuite(Backend)
+    end
     @conditional_testset "Upsample" skip_tests begin
         upsample_testsuite(Backend)
     end

--- a/test/testsuite/activations.jl
+++ b/test/testsuite/activations.jl
@@ -1,0 +1,44 @@
+using NNlib
+using NNlib: σ, swish, softplus, logσ, mish, logcosh, tanh_fast, sigmoid_fast,
+             lisht, tanhshrink
+
+# Holomorphic activations that accept complex inputs (see `test/activations.jl`).
+const COMPLEX_ACTS = [σ, swish, softplus, logσ, mish, logcosh,
+                      tanh_fast, sigmoid_fast, lisht, tanhshrink]
+
+function activations_testsuite(Backend)
+    cpu(x) = adapt(CPU(), x)
+    device(x) = adapt(Backend(), x)
+
+    # A spread of points in ℂ: both signs of the real part exercise the
+    # overflow-safe branches in σ/softplus, and nonzero imaginary parts make
+    # sure the gradient `conj` convention is correct on the device.
+    zs = ComplexF32[0.4f0 + 0.6f0im, -0.7f0 + 0.2f0im,
+                    1.2f0 - 0.9f0im, -0.3f0 - 1.1f0im]
+
+    @testset "complex $f" for f in COMPLEX_ACTS
+        x = device(zs)
+
+        # Forward: device result must match the CPU result elementwise.
+        y = f.(x)
+        @test y isa AbstractArray{ComplexF32}
+        @test cpu(y) ≈ f.(zs)
+
+        # Gradient: take a real loss (`abs2`) so Zygote is happy with the
+        # complex output, then compare the device gradient against the CPU one.
+        loss(x) = sum(abs2, f.(x))
+        g = gradient(loss, x)[1]
+        g_cpu = gradient(loss, zs)[1]
+        @test g isa AbstractArray{ComplexF32}
+        @test cpu(g) ≈ g_cpu
+    end
+
+    # The numerically-stable branches must stay finite on the device where the
+    # naive formula would overflow.
+    @testset "numerical stability" begin
+        big = device(ComplexF32[600 + 2im, -600 + 2im, 80 - 50im, -80 + 50im])
+        for f in (σ, softplus, swish)
+            @test all(isfinite, cpu(f.(big)))
+        end
+    end
+end


### PR DESCRIPTION
Closes #132.

Generalizes the holomorphic activation functions to complex inputs, with numerically stable forward passes and correct complex gradients.

## Forward

Adds `σ(::Complex)` and `softplus(::Complex)`. These are the only two methods needed — every other smooth activation defined in terms of them (`swish`, `mish`, `logσ`, `logcosh`, `gelu_sigmoid`, `sigmoid_fast`) starts working automatically, alongside the ones that already did (`tanh_fast`, `lisht`, `tanhshrink`, `gelu_tanh`).

Both methods branch on `real(z)` to select the overflow-safe algebraic rearrangement (e.g. `1/(1+exp(-z))` vs `exp(z)/(1+exp(z))` for `σ`). The two rearrangements are equal everywhere, so unlike the piecewise activations no discontinuity is introduced. The existing `::Real` fast paths are left untouched, so there is no performance change for real inputs.

## Gradients

This also fixes complex gradients, which were silently wrong before. The hand-written broadcasted `rrule`s computed a literal `dΩ * f'`, but the ChainRules convention for a holomorphic `f` is `x̄ = conj(f') * dΩ`. The previously-present explicit `conj()` on `σ`/`tanh_fast`/`sigmoid_fast` patched the broadcast path but *double*-conjugated the scalar `@scalar_rule` path (which conjugates internally), so the two AD paths disagreed.

Now the stored derivatives are the plain `f'` everywhere, with `conj` applied once in the broadcasted pullbacks. Both paths then agree and match finite differences. `conj` is identity on reals, so **real gradients are unchanged**.

## Out of scope

Order-defined activations (`relu`, `leakyrelu`, `relu6`, `elu`, `selu`, `celu`, `hardσ`, `hardtanh`, `hardswish`, `trelu`, `softshrink`) have no canonical complex extension — the literature uses several incompatible conventions (CReLU, modReLU, zReLU) — so they continue to throw rather than silently pick one. `softsign` (non-holomorphic, uses `abs`) and `gelu_erf` (needs a complex `erf` in the SpecialFunctions extension) are also left for follow-up.

## Tests

A new `complex` testset checks, for the holomorphic set:
- forward values against naive elementary formulas;
- gradients via **Zygote** (scalar and broadcast) against the same naive formulas — both are differentiated with Zygote so the complex-gradient convention cancels and the test isolates the correctness of NNlib's rules;
- numerical stability (finite output at large `|real|` where naive formulas overflow);
- that piecewise activations reject complex input.

Existing real-input tests (including the second-derivative suite that exercises both modified `rrule` paths) continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)