### PR TITLE
Add count_include_pad option to meanpool (#218)

### DIFF
--- a/ext/NNlibCUDACUDNNExt/pooling.jl
+++ b/ext/NNlibCUDACUDNNExt/pooling.jl
@@ -1,5 +1,6 @@
 using cuDNN: cudnnPoolingMode_t, CUDNN_POOLING_MAX,
              CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,
+             CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING,
              cudnnPoolingForward!, pooldims, cudnnPoolingBackward
 
 import NNlib: maxpool!, ∇maxpool!, meanpool!, ∇meanpool!
@@ -24,14 +25,20 @@ function ∇maxpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T
     return dx
 end
 
-function meanpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
-    d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
+meanpool_mode(count_include_pad::Bool) = count_include_pad ?
+    CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING :
+    CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING
+
+function meanpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
+                   count_include_pad::Bool=true) where T<:CUDNNFloat
+    d = cudnnPoolingDescriptor(pdims, x, meanpool_mode(count_include_pad))
     cudnnPoolingForward!(y, x, d)
 end
 
-function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
+function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
+                    count_include_pad::Bool=true) where T<:CUDNNFloat
     xDesc, yDesc = cudnnTensorDescriptor.((x, y))
-    d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
+    d = cudnnPoolingDescriptor(pdims, x, meanpool_mode(count_include_pad))
     alpha, beta = scalingParameter(T,1), scalingParameter(T,0)
     cudnnPoolingBackward(handle(), d, alpha, yDesc, y, yDesc, dy, xDesc, x, beta, xDesc, dx)
     return dx
@@ -55,8 +62,9 @@ function maxpool!(y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) w
     return y
 end
 
-function meanpool!(y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
-    meanpool!(add1d(y), add1d(x), fix_pooldims_1d(pdims))
+function meanpool!(y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims;
+                   count_include_pad::Bool=true) where T<:CUDNNFloat
+    meanpool!(add1d(y), add1d(x), fix_pooldims_1d(pdims); count_include_pad)
     return y
 end
 
@@ -65,8 +73,9 @@ function ∇maxpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArr
     return dx
 end
 
-function ∇meanpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
-    ∇meanpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims))
+function ∇meanpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims;
+                    count_include_pad::Bool=true) where T<:CUDNNFloat
+    ∇meanpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims); count_include_pad)
     return dx
 end
 

--- a/src/impl/pooling_direct.jl
+++ b/src/impl/pooling_direct.jl
@@ -17,7 +17,7 @@ for name in (:max, :mean, :lpnorm)
         pdims::PoolDims,
         # kernel size, channels out, padding, dilation, stride
         ::Val{K}, ::Val{C}, ::Val{P}, ::Val{D}, ::Val{S};
-        alpha=1, beta=0, kwargs...
+        alpha=1, beta=0, count_include_pad::Bool=true, kwargs...
     ) where {T, K, C, P, D, S}
         @assert iszero(beta) "beta not supported yet"
         check_dims(size(x), size(y), pdims)
@@ -121,25 +121,25 @@ for name in (:max, :mean, :lpnorm)
                 for w in w_region
                 pw = project(w, stride_w, pad_w_lo)
                 m = m_init
+                # For mean pooling with `count_include_pad=false` we divide by the number
+                # of in-bounds (non-padding) elements actually visited in this window.
+                kernel_count = 0
 
                 for kd in 1:kernel_d
                     input_kd = pd + (kd - 1) * dil_d
                     if input_kd <= 0 || input_kd > depth
-                        # add here condition for handling options for paded value handling
                         continue
                     end
 
                     for kh in 1:kernel_h
                         input_kh = ph + (kh - 1) * dil_h
                         if input_kh <= 0 || input_kh > height
-                            # add here condition for handling options for paded value handling
                             continue
                         end
 
                         for kw in 1:kernel_w
                             input_kw = pw + (kw - 1) * dil_w
                             if input_kw <= 0 || input_kw > width
-                                # add here condition for handling options for paded value handling
                                 continue
                             end
 
@@ -150,6 +150,7 @@ for name in (:max, :mean, :lpnorm)
                                 end
                             elseif $(name == :mean)
                                 m += x[input_kw, input_kh, input_kd, c, batch_idx]
+                                kernel_count += 1
                             elseif $(name == :lpnorm)
                                 m += x[input_kw, input_kh, input_kd, c, batch_idx]^p
                             else
@@ -158,8 +159,14 @@ for name in (:max, :mean, :lpnorm)
                         end
                     end
                 end
-                $(name == :lpnorm) && (m = m^(T(1) / p))
-                y[w, h, d, c, batch_idx] = _alpha * m # + _beta * y[w, h, d, c, batch_idx]
+                if $(name == :mean) && !count_include_pad
+                    # Divide by the number of non-padding elements in the window.
+                    win_alpha = kernel_count == 0 ? T(0) : T(alpha) / T(kernel_count)
+                    y[w, h, d, c, batch_idx] = win_alpha * m
+                else
+                    $(name == :lpnorm) && (m = m^(T(1) / p))
+                    y[w, h, d, c, batch_idx] = _alpha * m # + _beta * y[w, h, d, c, batch_idx]
+                end
                 end
                 end
                 end
@@ -184,7 +191,7 @@ for name in (:max, :mean, :lpnorm)
                     dx::AbstractArray{T,5}, dy::AbstractArray{<:Any,5},
                     y::AbstractArray{<:Any,5}, x::AbstractArray{<:Any,5},
                     pdims::PoolDims, ::Val{K}; # == kernel_size(pdims)
-                    alpha=1, beta=0, kwargs...) where {T, K}
+                    alpha=1, beta=0, count_include_pad::Bool=true, kwargs...) where {T, K}
         check_dims(size(x), size(dy), pdims)
 
         width, height, depth = input_size(pdims)
@@ -290,6 +297,28 @@ for name in (:max, :mean, :lpnorm)
                 dy_idx = dy[w, h, d, c, batch_idx]
                 maxpool_already_chose = false
 
+                # For mean pooling with `count_include_pad=false` the divisor is the
+                # number of non-padding elements in this window, so we count them up front
+                # to get the per-window scaling factor.
+                win_alpha = _alpha
+                if $(name == :mean) && !count_include_pad
+                    kernel_count = 0
+                    for kd in 1:kernel_d
+                        ikd = pd + (kd - 1) * dil_d
+                        (ikd <= 0 || ikd > depth) && continue
+                        for kh in 1:kernel_h
+                            ikh = ph + (kh - 1) * dil_h
+                            (ikh <= 0 || ikh > height) && continue
+                            for kw in 1:kernel_w
+                                ikw = pw + (kw - 1) * dil_w
+                                (ikw <= 0 || ikw > width) && continue
+                                kernel_count += 1
+                            end
+                        end
+                    end
+                    win_alpha = kernel_count == 0 ? T(0) : T(alpha) / T(kernel_count)
+                end
+
                 # In these loops, we have to check that we're not reaching off the edge,
                 # we do so by putting in a bunch of conditionals.  :/
                 for kd in 1:kernel_d
@@ -325,7 +354,7 @@ for name in (:max, :mean, :lpnorm)
                                 #    dx[x_idxs...] = T(0) + beta*dx[x_idxs...]
                                 end
                             elseif $(name == :mean)
-                                dx[input_kw, input_kh, input_kd, c, batch_idx] += dy_idx * _alpha #+ _beta * dx[x_idxs...]
+                                dx[input_kw, input_kh, input_kd, c, batch_idx] += dy_idx * win_alpha #+ _beta * dx[x_idxs...]
                             elseif $(name == :lpnorm)
                                 grad = x[input_kw, input_kh, input_kd, c, batch_idx]^(p-1) * y_idx^(1-p)
                                 dx[input_kw, input_kh, input_kd, c, batch_idx] += dy_idx * grad

--- a/src/pooling.jl
+++ b/src/pooling.jl
@@ -156,7 +156,7 @@ end
 
 
 """
-    meanpool(x, k::NTuple{N, Integer}; pad=0, stride=k)
+    meanpool(x, k::NTuple{N, Integer}; pad=0, stride=k, count_include_pad=true)
 
 Perform mean pool operation with window size `k` on input tensor `x`.
 
@@ -165,12 +165,17 @@ Arguments:
 * `x` and `k`: Expects `ndim(x) ∈ 3:5`, and always `length(k) == ndim(x) - 2`
 * `pad`: See [`pad_zeros`](@ref) for details.
 * `stride`: Either a tuple with the same length as `k`, or one integer for all directions. Default is `k`.
+* `count_include_pad`: When `true` (the default), padding (zero) elements are included in the
+  averaging denominator, so each output element divides by the full window size `prod(k)`.
+  When `false`, only the in-bounds (non-padding) elements are counted, matching cuDNN's
+  `CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING` and PyTorch's `count_include_pad=false`.
+  Has no effect when `pad == 0`.
 """
-function meanpool(x, k::NTuple{N, Integer}; pad=0, stride=k) where N
+function meanpool(x, k::NTuple{N, Integer}; pad=0, stride=k, count_include_pad=true) where N
     pad = expand(Val(N), pad)
     stride = expand(Val(N), stride)
     pdims = PoolDims(x, k; padding=pad, stride=stride)
-    return meanpool(x, pdims)
+    return meanpool(x, pdims; count_include_pad)
 end
 
 

--- a/test/ext_cuda/pooling.jl
+++ b/test/ext_cuda/pooling.jl
@@ -15,5 +15,16 @@
         gputest((dy, y, x) -> ∇maxpool(dy, y, x, pdims), dy, y, x, checkgrad=false)
         gputest(x -> maxpool(x, pdims), x)
         gputest((dy, y, x) -> ∇maxpool(dy, y, x, pdims), dy, y, x, checkgrad=false)
+
+        # meanpool count_include_pad (issue #218): with padding the two modes differ,
+        # check both agree with cuDNN (forward and backward).
+        pdims_pad = PoolDims(x, 2; padding=1, stride=2)
+        for cip in (true, false)
+            ym = meanpool(x, pdims_pad; count_include_pad=cip)
+            dym = ones(size(ym))
+            gputest(x -> meanpool(x, pdims_pad; count_include_pad=cip), x)
+            gputest((dy, y, x) -> ∇meanpool(dy, y, x, pdims_pad; count_include_pad=cip),
+                    dym, ym, x, checkgrad=false)
+        end
     end
 end

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -932,6 +932,63 @@ maxpool_answer_nature = Dict(
     @test all(==(0.25), RD.gradient(_x -> only(meanpool(_x,(2,2))), x))
 end
 
+@testset "meanpool count_include_pad (issue #218)" begin
+    # Brute-force reference: average over the window, optionally excluding padding.
+    function ref_meanpool(x, k; pad, stride, count_include_pad)
+        N = ndims(x) - 2
+        pdims = PoolDims(x, k; padding=NNlib.expand(Val(N), pad), stride=NNlib.expand(Val(N), stride))
+        out = NNlib.meanpool(x, pdims)  # used only for output sizing/type
+        osz = size(out)
+        kk = NNlib.kernel_size(pdims)
+        P = NNlib.padding(pdims)        # (w_lo, w_hi, h_lo, h_hi, d_lo, d_hi)
+        S = NNlib.stride(pdims)
+        isz = size(x)[1:N]
+        for batch in 1:size(x, ndims(x)), c in 1:size(x, ndims(x)-1)
+            for oidx in CartesianIndices(osz[1:N])
+                acc = zero(eltype(x)); cnt = 0
+                for kidx in CartesianIndices(kk)
+                    iin = ntuple(N) do d
+                        (Tuple(oidx)[d] - 1) * S[d] - P[2d-1] + Tuple(kidx)[d]
+                    end
+                    valid = all(d -> 1 <= iin[d] <= isz[d], 1:N)
+                    if valid
+                        acc += x[iin..., c, batch]; cnt += 1
+                    end
+                end
+                denom = count_include_pad ? prod(kk) : cnt
+                out[Tuple(oidx)..., c, batch] = denom == 0 ? zero(eltype(x)) : acc / denom
+            end
+        end
+        return out
+    end
+
+    # Known small example (2x2, pad=1, stride=2), verified by hand
+    x = reshape(Float64.(1:16), 4, 4, 1, 1)
+    ye = meanpool(x, (2,2); pad=1, stride=2, count_include_pad=false)
+    @test ye[:,:,1,1] ≈ [1.0 7.0 13.0; 2.5 8.5 14.5; 4.0 10.0 16.0]
+
+    # Default is unchanged (include padding) — non-breaking
+    @test meanpool(x, (2,2); pad=1, stride=2) ==
+          meanpool(x, (2,2); pad=1, stride=2, count_include_pad=true)
+
+    # With no padding the two modes coincide
+    xn = rand(8, 8, 2, 2)
+    @test meanpool(xn, (2,2)) == meanpool(xn, (2,2); count_include_pad=false)
+
+    # Match the brute-force reference across spatial ranks and configs
+    for T in (Float32, Float64), nsd in (1, 2, 3)
+        x = rand(T, fill(7, nsd)..., 2, 2)
+        for (k, pad, stride) in ((2, 1, 2), (3, 1, 1), (3, 2, 2))
+            kt = ntuple(_ -> k, nsd)
+            for cip in (true, false)
+                y = meanpool(x, kt; pad=pad, stride=stride, count_include_pad=cip)
+                yref = ref_meanpool(x, kt; pad=pad, stride=stride, count_include_pad=cip)
+                @test y ≈ yref
+            end
+        end
+    end
+end
+
 @testset "AutoDiff: spatial_rank=$spatial_rank" for spatial_rank in (1, 2)
   x = rand(rng, repeat([10], spatial_rank)..., 3, 2)
   pdims = PoolDims(x, 2)
@@ -946,6 +1003,13 @@ end
   gradtest(x -> meanpool(x, k), x)
   gradtest(x -> sum(maxpool(x, k)), x, skip = spatial_rank==2)
   gradtest(x -> sum(meanpool(x, k)), x)
+
+  # count_include_pad=false (issue #218), with padding so the modes differ
+  k1 = ntuple(_ -> 2, spatial_rank)
+  xp = rand(rng, repeat([7], spatial_rank)..., 3, 2)
+  pdims_p = PoolDims(xp, 2; padding=1, stride=2)
+  gradtest(z -> meanpool(z, pdims_p; count_include_pad=false), xp)
+  gradtest(z -> sum(meanpool(z, k1; pad=1, stride=2, count_include_pad=false)), xp)
 end
 
 @static if Test_Enzyme


### PR DESCRIPTION
Closes #218.

cuDNN exposes two average-pooling modes (`cudnnPoolingMode_t`): one that includes padding zeros in the averaging denominator (`CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING`) and one that excludes them (`..._EXCLUDE_PADDING`). NNlib's `meanpool` only implemented the include-padding mode.

This PR adds a `count_include_pad` keyword to `meanpool`:

- **`true` (default)** — padding elements are counted, dividing each output by the full window size `prod(k)`. This is the existing behavior, so the change is **non-breaking**.
- **`false`** — only the in-bounds (non-padding) elements are counted, matching cuDNN's exclude-padding mode and PyTorch's `count_include_pad=false`. Has no effect when `pad == 0`.

### Implementation
- **CPU** ([`meanpool_direct!`](src/impl/pooling_direct.jl) and `∇meanpool_direct!`): handled per-window in the padded regions only. The central region (windows that never touch padding) is unchanged, so the hot path has no overhead. An empty-window guard returns `0` rather than `NaN`.
- **CUDA** ([NNlibCUDACUDNNExt](ext/NNlibCUDACUDNNExt/pooling.jl)): selects the cuDNN pooling mode from the keyword (including the 1D→2D reshape path).
- Only `meanpool` is affected — `maxpool` already ignores padding and `lpnormpool` has no averaging denominator (matches cuDNN/PyTorch).

### Testing
- **CPU**: forward checked against a hand-computed example and a brute-force reference across spatial ranks 1–3 / `Float32`+`Float64`; gradients checked via `gradtest`. Full `pooling.jl` suite passes (1087 pass, 4 pre-existing broken).
- **GPU**: CPU-vs-cuDNN agreement for both modes (forward + backward), run on a local TITAN RTX — `ext_cuda/pooling.jl` 36 pass. CPU and cuDNN match to ~1e-16 and the two modes genuinely differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)