### PR TITLE
Thread CPU conv within a single image at small batch (#234)

### DIFF
--- a/benchmark/conv_vs_pytorch/README.md
+++ b/benchmark/conv_vs_pytorch/README.md
@@ -1,8 +1,10 @@
 # NNlib vs PyTorch conv on CPU (issue #234)
 
 Compares forward `conv` performance between NNlib and PyTorch on CPU,
-reproducing [FluxML/NNlib.jl#234](https://github.com/FluxML/NNlib.jl/issues/234).
-Both run with **4 threads** and `Float32`.
+reproducing [FluxML/NNlib.jl#234](https://github.com/FluxML/NNlib.jl/issues/234)
+and measuring the effect of the within-image threading added in
+[#697](https://github.com/FluxML/NNlib.jl/pull/697). Both run with **4 threads**
+and `Float32`.
 
 ## Setup
 
@@ -25,108 +27,121 @@ uv run --project . python bench_torch.py
 julia --threads=4 --project=. bench_nnlib.jl
 ```
 
+## Methodology
+
+NNlib's CPU conv parallelism is Julia-task based, so a fair "4 threads" run is
+`julia --threads=4` with **BLAS pinned to 1 thread** (`BLAS.set_num_threads(1)`);
+otherwise `julia_threads × blas_threads` oversubscribes. PyTorch uses
+`torch.set_num_threads(4)`.
+
+The box is a 64-core Threadripper 2990WX (AVX2, no AVX512), often shared. Because
+contention only *adds* time, all numbers below are the **minimum over 6 process
+runs of 80 samples each** — the best estimate of uncontended time. Times are
+**per image** (ms/img) so batch sizes are comparable.
+
 ## Results
 
-Median forward time, 4 threads, `Float32`. Measured on a 64-core box; because
-the machine was shared, the **minimum** across repeated runs is reported as the
-best estimate of uncontended time (contention only adds time). Numbers below
-were stable across 3 consecutive runs.
+Per-image forward time (ms/img), 4 threads, `Float32`. `master` is the previous
+batch-only threading; **#697** adds within-image threading.
 
-| case               | shape (in→out, k, s, p, HxW, batch) | PyTorch (ms) | NNlib (ms) | NNlib / PyTorch |
-|--------------------|-------------------------------------|-------------:|-----------:|----------------:|
-| issue234 7x7 s2 p3 | 3→64, 7, s2, p3, 224x224, b2        | ~5.0         | ~10.5      | **2.1x**        |
-| 3x3 s1 p1 c64      | 64→64, 3, s1, p1, 56x56, b2         | ~2.5         | ~8.4       | **3.4x**        |
-| 3x3 s1 p1 c128     | 128→128, 3, s1, p1, 28x28, b2       | ~2.5         | ~6.9       | **2.8x**        |
-| 1x1 s1 p0 c256     | 256→256, 1, s1, p0, 14x14, b2       | ~0.48        | ~0.61      | **1.3x**        |
+**issue #234 shape — 7×7, stride 2, pad 3, 3→64, 224×224**
+
+| batch | master | **#697** | PyTorch | #697 vs master | #697 vs PyTorch |
+|------:|-------:|---------:|--------:|---------------:|----------------:|
+| 1 | 6.73 | **3.45** | 1.23 | **1.95× faster** | 2.8× slower |
+| 2 | 4.98 | **3.28** | 1.58 | 1.52× faster | 2.1× slower |
+| 4 | 2.57 | **2.17** | 1.29 | 1.19× faster | 1.7× slower |
+| 8 | 1.91 | 1.97 | 1.27 | ~neutral | 1.6× slower |
+
+**3×3, stride 1, pad 1, 64→64, 56×56**
+
+| batch | master | **#697** | PyTorch | #697 vs master | #697 vs PyTorch |
+|------:|-------:|---------:|--------:|---------------:|----------------:|
+| 1 | 7.13 | **3.67** | 1.11 | **1.95× faster** | 3.3× slower |
+| 2 | 3.84 | **3.46** | 1.02 | 1.11× faster | 3.4× slower |
+| 4 | 2.77 | **2.16** | 0.97 | 1.28× faster | 2.2× slower |
+| 8 | 2.01 | 2.12 | 0.96 | ~neutral | 2.2× slower |
+
+**3×3, stride 1, pad 1, 128→128, 28×28**
+
+| batch | master | **#697** | PyTorch | #697 vs master | #697 vs PyTorch |
+|------:|-------:|---------:|--------:|---------------:|----------------:|
+| 1 | 5.53 | **2.61** | 1.09 | **2.12× faster** | 2.4× slower |
+| 2 | 3.05 | **2.36** | 1.04 | 1.29× faster | 2.3× slower |
+| 4 | 1.70 | **1.64** | 0.98 | ~neutral | 1.7× slower |
+| 8 | 1.53 | 1.58 | 0.96 | ~neutral | 1.6× slower |
+
+**1×1, stride 1, pad 0, 256→256, 14×14**
+
+| batch | master | **#697** | PyTorch | #697 vs master | #697 vs PyTorch |
+|------:|-------:|---------:|--------:|---------------:|----------------:|
+| 1 | 0.49 | **0.33** | 0.28 | 1.48× faster | 1.2× slower |
+| 2 | 0.27 | 0.27 | 0.19 | ~neutral | 1.5× slower |
+| 4 | 0.20 | 0.20 | 0.14 | ~neutral | 1.4× slower |
+| 8 | 0.14 | 0.14 | 0.13 | ~neutral | 1.1× slower |
 
 ### Takeaways
 
-- The original issue's 7x7/stride-2 case reproduces: NNlib is **~2x slower**.
-- The gap is **larger (~3x) for 3x3 convs**, the most common conv shape.
-- The gap shrinks for 1x1 convs, which reduce to a single GEMM (BLAS-bound) —
-  consistent with the bottleneck being NNlib's im2col + scattered work around
-  the matmul rather than the matmul itself.
-- NNlib also allocates a lot (e.g. ~34 MiB for the 7x7 case) due to im2col
-  buffers, whereas PyTorch's CPU conv keeps overhead low.
+- **#697 gives a consistent ~2× speedup at batch=1** (and ~1.1–1.5× at batch=2)
+  across all shapes — exactly the small-batch regime of issue #234.
+- The gain tapers to **neutral by batch≥4–8**, where the unchanged batch-split
+  path already saturates the 4 threads. (A consistent ≤5% at batch=8 is within
+  measurement noise of the unchanged path.)
+- **PyTorch (oneDNN) is still faster everywhere** — ~1.5–3.4× — even after #697.
+  The gap is largest for 3×3 convs. So #697 closes the *threading* part of the
+  gap, not the *algorithmic* one (see below).
 
 Layout note: NNlib uses WHCN; PyTorch uses NCHW. The cases are defined with
 matching channel/spatial/batch sizes so the FLOP counts are identical.
 
 ## Why is NNlib slower?
 
-Mostly it's **threading granularity** (NNlib threads only over the batch) plus the
-optimized **oneDNN** backend PyTorch dispatches to. At full core utilization the
-im2col+GEMM math is competitive — NNlib even beats oneDNN on the 7x7 case — with a
-residual gap remaining only for small (3x3) kernels.
+Two separate factors: **threading** (now improved by #697) and the **backend**
+PyTorch dispatches to (oneDNN, an algorithmic advantage that remains).
 
-### Root cause: NNlib threads only over the batch dimension
+### Threading (the part #697 fixes)
 
-In [`src/impl/conv_im2col.jl`](../../src/impl/conv_im2col.jl) the work is split by
-partitioning the batch axis and spawning one task per batch chunk; each task runs a
-single-threaded `im2col!` + `gemm!`. When `batch < nthreads`, the extra threads sit
-idle. PyTorch parallelizes *inside* a single image, so it saturates all cores at any
-batch size. Per-image time (ms/img) for the 7x7 case makes this clear:
+The GEMM that dominates conv (~80% of per-image time) is *already* multithreaded
+by BLAS. The problems were:
 
-|                    | batch=1 | batch=2 | batch=4 | batch=8 |
-|--------------------|--------:|--------:|--------:|--------:|
-| NNlib, 4 threads   | 6.46    | 4.76    | 2.76    | **2.39**|
-| PyTorch, 4 threads | 2.58    | 2.46    | 2.51    | **2.41**|
+1. **im2col is serial** — the ~20% the GEMM threading can't touch.
+2. **`conv_im2col!` only parallelized over the batch axis** — with
+   `batch < nthreads` the surplus threads sat idle.
+3. **Oversubscription** — the old default (`julia × BLAS` threads) ran up to 16
+   threads, masking the problem on this 64-core box but hurting where cores ≈
+   threads.
 
-NNlib only improves as the batch grows; PyTorch is flat. **Once `batch ≥ nthreads`
-the two match exactly** (2.39 vs 2.41) — NNlib's throughput is fine when cores are
-saturated. The issue's 2x gap is because it uses batch=2 with ≥4 threads.
+[#697](https://github.com/FluxML/NNlib.jl/pull/697) addresses (1) and (2): when
+`batch < nthreads`, it splits each image's output-spatial dimension across tasks,
+so every task runs `im2col!` + GEMM on a contiguous slab of output rows —
+parallelizing both the copy and the matmul. BLAS is pinned to one thread inside
+that region to avoid (3). The batch=1 numbers above show the ~2× result.
 
-### What PyTorch dispatches to: oneDNN
+### Backend: PyTorch dispatches to oneDNN (the part that remains)
 
-PyTorch CPU conv ([`aten/.../Convolution.cpp`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Convolution.cpp),
-`select_conv_backend`) sends float32 contiguous convs (batch>1 or threads>1) to
-**oneDNN** (`aten::mkldnn_convolution`, confirmed via the profiler). The reference
-`Slow2d`/`thnn` kernel (im2col+GEMM, closest to NNlib) is only reached if oneDNN is
-disabled or the dtype/shape disqualifies it (e.g. f64, or bf16 without AVX512-BF16).
+PyTorch CPU conv ([`Convolution.cpp`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Convolution.cpp),
+`select_conv_backend`) sends float32 contiguous convs to **oneDNN**
+(`aten::mkldnn_convolution`, confirmed via the profiler). oneDNN uses a
+**JIT-generated direct convolution** — no full im2col buffer. Activations are
+reordered into a channel-blocked layout (`nChw8c` on this AVX2 box), and the
+inner loop keeps an output tile in vector registers, accumulating with
+broadcast+FMA. It parallelizes over batch × output-channel-blocks × spatial rows.
+On the 7×7 case it runs near the CPU's FLOP peak.
 
-### How oneDNN's direct conv works
+NNlib's im2col+GEMM can't match this for two reasons that threading can't fix:
 
-oneDNN uses a **JIT-generated direct convolution** (no full im2col buffer): activations
-are reordered into a channel-blocked layout (`nChw16c` on AVX512, **`nChw8c` on this
-AVX2 box**), weights into `OIhw8i8o`, and the inner loop keeps an output tile in vector
-registers, accumulating with broadcast+FMA. It parallelizes over
-batch × output-channel-blocks × spatial rows — hence full-core utilization on a single
-image. (Winograd is x86-unsupported in current oneDNN; an implicit-GEMM path is the
-fallback.)
+- **im2col's memory blow-up.** A 3×3 conv expands the input **9×** (`k²`) into the
+  col buffer; that materialization is pure memory traffic oneDNN never pays. This
+  is why the 3×3 gap (~2–3.4×) is larger than the 7×7 gap.
+- **GEMM efficiency.** The im2col GEMM is "skinny" (small N/K), so even
+  BLAS-threaded it doesn't reach oneDNN's near-peak direct kernel.
 
-### At saturation, the remaining gap is shape-dependent
+### Conclusion
 
-Comparing min per-image time at `batch=8` (all 4 cores busy) isolates the
-*algorithmic* gap from the threading one:
-
-| case (batch=8)   | NNlib (ms/img) | PyTorch/oneDNN (ms/img) | NNlib / PyTorch |
-|------------------|---------------:|------------------------:|----------------:|
-| 7x7 s2 (3→64)    | 1.85           | 2.30                    | **0.80x (NNlib faster)** |
-| 3x3 c64          | 2.30           | 1.45                    | 1.59x           |
-| 3x3 c128         | 1.87           | 1.14                    | 1.64x           |
-
-Two regimes:
-
-- **7x7 first-layer conv: NNlib is actually *faster* than oneDNN once saturated.**
-  With only 3 input channels the im2col buffer is small relative to a fat,
-  BLAS-friendly GEMM, and oneDNN's direct kernel isn't optimized for a 3-channel
-  input. So the issue's 2x is *entirely* a threading artifact here.
-- **3x3 convs keep a ~1.6x gap even fully saturated.** A 3x3 conv expands the input
-  **9x** (`k²`) into the col buffer; that materialization is pure memory traffic
-  oneDNN's direct conv never pays (it streams the blocked layout straight into FMA
-  accumulators). Threading can't remove those extra bytes — this part is algorithmic.
-
-### Conclusion: improve im2col, don't rewrite as direct conv
-
-- **The headline #234 gap is threading, fully fixable in the im2col path.** The
-  highest-ROI change is to parallelize *within* an image: partition the output
-  spatial dimension (the GEMM's `M`) across threads in
-  [`conv_im2col.jl`](../../src/impl/conv_im2col.jl), not just the batch axis. This
-  closes the small-batch / batch=1 inference gap and beats oneDNN on the 7x7 case.
-- **Tiling/fusing im2col+GEMM** (materialize only a per-thread tile of the col
-  buffer instead of one ~34 MiB allocation) cuts memory traffic and improves cache
-  reuse, *narrowing* the residual 3x3 gap.
-- **A from-scratch direct convolution** (blocked layout + SIMD/FMA/JIT kernels) is
-  the only thing that fully erases the 3x3 gap, but it means reimplementing a large
-  part of oneDNN in pure Julia — not worth it for a ~1.6x edge on one shape class
-  when the two changes above recover the dominant losses.
+- **#697 is the high-ROI fix** and is implemented: ~2× at small batch, by
+  parallelizing within an image instead of only over the batch.
+- **Closing the residual ~1.5–3× to oneDNN** would require attacking the
+  algorithm, not threading: tiling/fusing im2col+GEMM to cut the `k²` memory
+  traffic, or a from-scratch direct convolution (blocked layout + SIMD/JIT
+  kernels). The latter means reimplementing a large part of oneDNN in pure Julia
+  — likely not worth it for the remaining gap.

--- a/benchmark/conv_vs_pytorch/bench_nnlib.jl
+++ b/benchmark/conv_vs_pytorch/bench_nnlib.jl
@@ -11,7 +11,10 @@ using LinearAlgebra
 using Random
 
 Random.seed!(1234)
-BLAS.set_num_threads(4)
+# NNlib's conv parallelism is Julia-task based, so a fair "4 threads" run is
+# `julia --threads=4` with BLAS pinned to 1 (otherwise julia × BLAS threads
+# oversubscribe). This matches PyTorch's `torch.set_num_threads(4)`.
+BLAS.set_num_threads(1)
 
 # (name, in_ch, out_ch, kernel, stride, pad, H, W, batch)
 const CASES = [
@@ -24,16 +27,16 @@ const CASES = [
 function main()
     println("Julia threads: ", Threads.nthreads())
     println("BLAS threads:  ", BLAS.get_num_threads())
-    println(rpad("case", 22), lpad("fwd (ms)", 12), lpad("mem (MiB)", 12))
+    println(rpad("case", 22), lpad("min fwd (ms)", 14), lpad("mem (MiB)", 12))
     for (name, ci, co, k, s, p, H, W, b) in CASES
         # NNlib uses WHCN layout (vs PyTorch NCHW)
         x = randn(Float32, W, H, ci, b)
         w = randn(Float32, k, k, ci, co)
         cdims = DenseConvDims(x, w; stride=(s, s), padding=(p, p, p, p))
-        t = @benchmark conv($x, $w, $cdims) samples=50 evals=1
-        med_ms = median(t).time / 1e6
+        t = @benchmark conv($x, $w, $cdims) samples=80 evals=1
+        min_ms = minimum(t).time / 1e6   # min ≈ uncontended time on a shared box
         mem_mib = t.memory / 2^20
-        println(rpad(name, 22), lpad(round(med_ms; digits=4), 12),
+        println(rpad(name, 22), lpad(round(min_ms; digits=4), 14),
                 lpad(round(mem_mib; digits=3), 12))
     end
 end

--- a/benchmark/conv_vs_pytorch/bench_torch.py
+++ b/benchmark/conv_vs_pytorch/bench_torch.py
@@ -20,16 +20,15 @@ CASES = [
 ]
 
 
-def bench(fn, n=50, warmup=5):
+def bench(fn, n=80, warmup=10):
     for _ in range(warmup):
         fn()
-    ts = []
+    best = float("inf")
     for _ in range(n):
         t0 = time.perf_counter()
         fn()
-        ts.append(time.perf_counter() - t0)
-    ts.sort()
-    return ts[len(ts) // 2]  # median, in seconds
+        best = min(best, time.perf_counter() - t0)
+    return best  # min ≈ uncontended time on a shared box, in seconds
 
 
 def main():

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -62,6 +62,30 @@ for (gemm, elt) in gemm_datatype_mappings
     end
 end
 
+# Variant with explicit leading dimensions. This lets a caller multiply a
+# sub-block of `A`/`C` in place (e.g. a contiguous slice of the output spatial
+# dimension) without copying, by passing the full leading dimension while
+# giving a reduced row count `M` and pre-offset pointers.
+for (gemm, elt) in gemm_datatype_mappings
+    @eval begin
+        @inline function gemm!(transA::Val, transB::Val,
+                               M::Int, N::Int, K::Int,
+                               alpha::$(elt), A::Ptr{$elt}, lda::Int,
+                               B::Ptr{$elt}, ldb::Int,
+                               beta::$(elt), C::Ptr{$elt}, ldc::Int)
+            convtrans(V::Val{false}) = 'N'
+            convtrans(V::Val{true})  = 'C'
+            ccall((@blasfunc($(gemm)), libblas), Nothing,
+                  (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
+                   Ref{BlasInt}, Ref{$elt}, Ptr{$elt}, Ref{BlasInt},
+                   Ptr{$elt}, Ref{BlasInt}, Ref{$elt}, Ptr{$elt},
+                   Ref{BlasInt}),
+                  convtrans(transA), convtrans(transB), M, N, K,
+                  alpha, A, lda, B, ldb, beta, C, ldc)
+        end
+    end
+end
+
 for (gemm, elt) in gemm_datatype_mappings
     @eval begin
         @inline function batched_gemm!(transA::AbstractChar,

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -45,29 +45,95 @@ function conv_im2col!(
     N = channels_out(cdims)
     K = prod(kernel_size(cdims))*channels_in(cdims)
 
-    parts = Iterators.partition(axes(x, 5), ceil(Int, size(x, 5) / ntasks))
+    nbatch = size(x, 5)
+    ntasks = min(ntasks, size(col, 3))
 
-    function conv_part(task_n, part)
-        col_slice = col_slice = view(col, :, :, task_n) # col_slice is a task-local workspace
-        for batch_idx in part
-            im2col!(col_slice, view(x, :, :, :, :, batch_idx), cdims)
-            GC.@preserve col_slice w y begin
-                col_ptr = pointer(col_slice)
-                w_ptr = pointer(w)
-                y_ptr = pointer(y, (batch_idx - 1)*M*N + 1)
-                gemm!(Val(false), Val(false), M, N, K, alpha, col_ptr, w_ptr, beta, y_ptr)
-            end
+    # Multiply a contiguous block of `m_len` output-spatial rows, starting at
+    # 0-based row `m_off`, for image `n`, reading from workspace slice `cs`.
+    # `cs` is the full `(M, K)` workspace; only rows `m_off .+ (1:m_len)` are
+    # read, so several tasks can share `y`/`w` while writing disjoint rows.
+    function gemm_block!(cs, n, m_off, m_len)
+        GC.@preserve cs w y begin
+            col_ptr = pointer(cs, m_off + 1)
+            w_ptr   = pointer(w)
+            y_ptr   = pointer(y, (n - 1)*M*N + m_off + 1)
+            gemm!(Val(false), Val(false), m_len, N, K, alpha,
+                  col_ptr, M, w_ptr, K, beta, y_ptr, M)
         end
     end
 
-    if should_use_spawn() && length(parts) > 1
-        @sync for (task_n, part) in enumerate(parts)
-            Threads.@spawn conv_part(task_n, part)
+    # One task fully responsible for a chunk of whole images.
+    function batch_task(task_n, part)
+        cs = view(col, :, :, task_n)
+        for n in part
+            im2col!(cs, view(x, :, :, :, :, n), cdims)
+            gemm_block!(cs, n, 0, M)
         end
+    end
+
+    # Serial path (single thread or spawning disabled), or enough images to keep
+    # every task busy: process whole images, splitting the batch across tasks.
+    # This is the original behavior and leaves the per-image GEMM to BLAS.
+    if !should_use_spawn() || ntasks <= 1 || nbatch >= ntasks
+        parts = Iterators.partition(1:nbatch, cld(nbatch, max(ntasks, 1)))
+        if should_use_spawn() && ntasks > 1 && length(parts) > 1
+            @sync for (task_n, part) in enumerate(parts)
+                Threads.@spawn batch_task(task_n, part)
+            end
+        else
+            for (task_n, part) in enumerate(parts)
+                batch_task(task_n, part)
+            end
+        end
+        return y
+    end
+
+    # Fewer images than tasks: split each image's output-spatial dimension so no
+    # thread sits idle at small batch (issue #234). We drive this parallelism
+    # ourselves and partition the GEMM by output rows, so pin BLAS to a single
+    # thread to avoid oversubscription (as `batched_gemm!` does). We split the
+    # outermost spatial axis with extent > 1, which keeps each task's output
+    # rows contiguous in `y`.
+    out_w, out_h, out_d = output_size(cdims)
+    if out_d > 1
+        naxis, stride_ax, axis = out_d, out_w*out_h, :d
+    elseif out_h > 1
+        naxis, stride_ax, axis = out_h, out_w, :h
     else
-        for (task_n, part) in enumerate(parts)
-            conv_part(task_n, part)
+        naxis, stride_ax, axis = out_w, 1, :w
+    end
+
+    # Distribute ntasks spatial blocks across the nbatch images.
+    base, extra = divrem(ntasks, nbatch)
+    units = Tuple{Int,UnitRange{Int}}[]
+    for n in 1:nbatch
+        nblk = clamp(base + (n <= extra ? 1 : 0), 1, naxis)
+        for cr in Iterators.partition(1:naxis, cld(naxis, nblk))
+            push!(units, (n, cr))
         end
+    end
+
+    function tile_task(task_n, n, cr)
+        cs = view(col, :, :, task_n)
+        xn = view(x, :, :, :, :, n)
+        if axis === :d
+            im2col!(cs, xn, cdims; d_range=cr)
+        elseif axis === :h
+            im2col!(cs, xn, cdims; h_range=cr)
+        else
+            im2col!(cs, xn, cdims; w_range=cr)
+        end
+        gemm_block!(cs, n, (first(cr) - 1)*stride_ax, length(cr)*stride_ax)
+    end
+
+    old_blas = get_num_threads()
+    set_num_threads(1)
+    try
+        @sync for (task_n, (n, cr)) in enumerate(units)
+            Threads.@spawn tile_task(task_n, n, cr)
+        end
+    finally
+        set_num_threads(old_blas)
     end
     return y
 end
@@ -197,7 +263,8 @@ out along the rows of `col`, one for each output pixel.  This routine is used by
 im2col-based convolutions, just with extra singleton dimensions added in the case of `2d`
 or `1d` images.
 """
-function im2col!(col::AbstractArray{T,2}, x::AbstractArray{T,4}, cdims::ConvDims) where {T}
+function im2col!(col::AbstractArray{T,2}, x::AbstractArray{T,4}, cdims::ConvDims;
+                 w_range=nothing, h_range=nothing, d_range=nothing) where {T}
     if spatial_dims(cdims) != 3
         throw(DimensionMismatch("im2col!() only accepts 3d convoluitional inputs"))
     end
@@ -210,6 +277,15 @@ function im2col!(col::AbstractArray{T,2}, x::AbstractArray{T,4}, cdims::ConvDims
     dil_w, dil_h, dil_d = dilation(cdims)
     stride_w, stride_h, stride_d = stride(cdims)
     out_width, out_height, out_depth = output_size(cdims)
+
+    # Optionally restrict the work to a sub-range of output positions, so that
+    # several tasks can fill disjoint output-spatial slabs of `col` in parallel
+    # (used to thread a single image; see `conv_im2col!`). Defaults span the
+    # whole output, reproducing the unrestricted behavior.
+    w_range = w_range === nothing ? (1:out_width)  : w_range
+    h_range = h_range === nothing ? (1:out_height) : h_range
+    d_range = d_range === nothing ? (1:out_depth)  : d_range
+    @inline _isect(a, b) = max(first(a), first(b)):min(last(a), last(b))
 
     # Reshape col for easy access.
     col_reshaped = reshape(col, (
@@ -241,9 +317,9 @@ function im2col!(col::AbstractArray{T,2}, x::AbstractArray{T,4}, cdims::ConvDims
         for kd in 1:kernel_d,
             kh in 1:kernel_h,
             kw in 1:kernel_w,
-            d in d_region,
-            h in h_region,
-            w in w_region
+            d in _isect(d_region, d_range),
+            h in _isect(h_region, h_range),
+            w in _isect(w_region, w_range)
 
             input_kd = project(d, stride_d, pad_d_lo) + (kd - 1)*dil_d
             input_kh = project(h, stride_h, pad_h_lo) + (kh - 1)*dil_h
@@ -259,9 +335,9 @@ function im2col!(col::AbstractArray{T,2}, x::AbstractArray{T,4}, cdims::ConvDims
     # For each "padded region", we run the fully general version
     @inbounds for (w_region, h_region, d_region) in padded_regions
         for c in 1:C_in,
-            d in d_region,
-            h in h_region,
-            w in w_region,
+            d in _isect(d_region, d_range),
+            h in _isect(h_region, h_range),
+            w in _isect(w_region, w_range),
             kd in 1:kernel_d,
             kh in 1:kernel_h,
             kw in 1:kernel_w


### PR DESCRIPTION
## Summary

CPU `conv_im2col!` only parallelized over the **batch** dimension, so with `batch < nthreads` the surplus threads sat idle. This is the dominant reason NNlib's CPU conv trailed PyTorch at small batch in #234 — at a fixed thread budget the GEMM/im2col math is fine, but threads were left on the table.

This PR adds **within-image threading**: when there are fewer images than tasks, each image's output-spatial dimension is split across tasks, so every task runs `im2col!` + GEMM on a contiguous slab of output rows. Both the im2col copy and the matmul now parallelize. Since the GEMM is partitioned at the Julia-task level, BLAS is pinned to one thread inside the parallel region to avoid oversubscription (mirroring what `batched_gemm!` already does).

The `batch >= ntasks` and serial paths are **unchanged** (original behavior preserved), so high-batch performance is untouched.

## Changes

- `conv_im2col!`: new small-batch branch that splits the outermost output-spatial axis across tasks; BLAS pinned to 1 thread there.
- `im2col!`: optional `w_range`/`h_range`/`d_range` kwargs to fill only a sub-range of output positions (defaults reproduce existing behavior exactly).
- `gemm!`: a variant taking explicit leading dimensions, so an output-row sub-block can be multiplied in place without copying.

## Benchmarks

Per-image time (ms), **4 threads**, Float32, measured back-to-back under identical load (absolute values inflated by machine load; the *ratio* is what matters):

**7x7 s2 p3 (the #234 shape)**
| batch | master | this PR | speedup |
|------:|-------:|--------:|--------:|
| 1 | 8.29 | **3.85** | **2.15x** |
| 2 | 4.43 | **3.58** | 1.24x |
| 4 | 3.67 | **2.75** | 1.34x |
| 8 | 2.48 | 2.31 | 1.07x |

**3x3 c64**
| batch | master | this PR | speedup |
|------:|-------:|--------:|--------:|
| 1 | 8.89 | **3.91** | **2.27x** |
| 2 | 4.95 | **3.84** | 1.29x |
| 4 | 2.99 | 2.84 | 1.05x |
| 8 | 2.41 | 2.39 | 1.00x |

**3x3 c128**
| batch | master | this PR | speedup |
|------:|-------:|--------:|--------:|
| 1 | 6.74 | **3.46** | **1.95x** |
| 2 | 3.52 | **3.13** | 1.12x |
| 4 | 2.24 | **1.87** | 1.20x |
| 8 | 1.80 | 1.85 | 1.00x |

Consistent **~2x at batch=1**, tapering to neutral by batch=8 (where the unchanged batch-split path already saturates threads). This closes the small-batch portion of the gap to PyTorch; a residual gap remains for 3x3 vs oneDNN's direct conv (im2col's k² memory blow-up — algorithmic, out of scope here). See [benchmark/conv_vs_pytorch/](benchmark/conv_vs_pytorch) for the full analysis.

## Correctness

Full conv test suite passes (770 pass, 0 fail, 4 pre-existing broken), including AutoDiff gradient checks, grouped convs, and 1d/2d/3d. Additionally verified the threaded output matches both the serial path and the independent `direct` backend to ~1e-5 across shapes, padding, stride, dilation, flipkernel, groups, and batch sizes 1-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)