### PR TITLE
Fix Float16 GPU conv via PSEUDO_HALF_CONFIG (fixes #505, #515)

### DIFF
--- a/ext/NNlibCUDACUDNNExt/conv.jl
+++ b/ext/NNlibCUDACUDNNExt/conv.jl
@@ -45,13 +45,24 @@ function cudnnConvolutionDescriptorAndPaddedInput(cdims::DenseConvDims, x::Dense
     return cudnnConvolutionDescriptor(cdims, x_padded, pad_cudnn), x_padded, _x -> _x[xIs_pad]
 end
 
+# Compute (accumulation) type for the convolution descriptor. cuDNN's
+# TRUE_HALF_CONFIG (compute in Float16) is only supported for a narrow set of 2D
+# shapes; in particular it is unsupported for 3D convolutions and for many
+# backward-filter shapes, surfacing as CUDNN_STATUS_NOT_SUPPORTED/BAD_PARAM.
+# PSEUDO_HALF_CONFIG (Float16 data, Float32 compute) is broadly supported and is
+# the standard choice (matching e.g. PyTorch). So we always compute Float16
+# convolutions in Float32.
+# Fixes https://github.com/FluxML/NNlib.jl/issues/505 and #515.
+conv_compute_type(::Type{Float16}) = Float32
+conv_compute_type(::Type{T}) where T = T
+
 function cudnnConvolutionDescriptor(cdims::DenseConvDims, x::DenseCuArray{T}, pad = nnlibPadding(cdims)) where T
     mode=(NNlib.flipkernel(cdims) ? CUDNN_CROSS_CORRELATION : CUDNN_CONVOLUTION)
     cudnnConvolutionDescriptor(convdims(pad, size(x),0),
                                convdims(NNlib.stride(cdims),size(x),1),
                                convdims(NNlib.dilation(cdims),size(x),1),
                                mode,
-                               cudnnDataType(real(T)),
+                               cudnnDataType(conv_compute_type(real(T))),
                                math_mode(),
                                CUDNN_DEFAULT_REORDER,
                                Cint(NNlib.groupcount(cdims)))

--- a/test/ext_cuda/conv.jl
+++ b/test/ext_cuda/conv.jl
@@ -115,3 +115,43 @@ using NNlib: DenseConvDims
     end
 end
 end
+
+@testset "Float16" begin
+    # cuDNN's TRUE_HALF_CONFIG (compute in Float16) is unsupported for 3D convs and
+    # for many backward-filter shapes, so NNlib computes Float16 convolutions in
+    # Float32 (PSEUDO_HALF_CONFIG). A GPU Float16 result should therefore stay
+    # Float16 and match a Float32 CPU reference up to Float16 rounding.
+    # Regression tests for https://github.com/FluxML/NNlib.jl/issues/505 and #515.
+    function f16_matches_f32(f, xs...; rtol=1e-2, atol=1e-2)
+        ref = f(map(x -> Float32.(x), xs)...)
+        out = f(map(CuArray, xs)...)
+        @test eltype(out) == Float16
+        @test Float32.(collect(out)) ≈ Float32.(ref) rtol=rtol atol=atol
+    end
+
+    @testset "groups=$groups, num_spatial_dims=$num_spatial_dims" for groups in (1, 2), num_spatial_dims in (1, 2, 3)
+        C_in  = groups == 1 ? 3 : 4
+        C_out = 4
+        x = rand(Float16, fill(8, num_spatial_dims)..., C_in, 2)
+        w = rand(Float16, fill(2, num_spatial_dims)..., C_in ÷ groups, C_out)
+        cdims = DenseConvDims(x, w; groups)
+        dy = rand(Float16, size(NNlib.conv(x, w, cdims))...)
+
+        f16_matches_f32((x, w)  -> NNlib.conv(x, w, cdims), x, w)
+        f16_matches_f32((dy, w) -> NNlib.∇conv_data(dy, w, cdims), dy, w)
+        f16_matches_f32((x, dy) -> NNlib.∇conv_filter(x, dy, cdims), x, dy)
+    end
+
+    # Exact shapes from the issues, as explicit regression guards.
+    @testset "issue #505: 5D (3D conv) forward" begin
+        x, w = CUDA.rand(Float16, 8, 8, 8, 1, 1), CUDA.rand(Float16, 3, 3, 3, 1, 1)
+        @test size(NNlib.conv(x, w)) == (6, 6, 6, 1, 1)
+    end
+    @testset "issue #515: ∇conv_filter 3=>64, 1x1 output" begin
+        x, w = CUDA.rand(Float16, 3, 3, 3, 1), CUDA.rand(Float16, 3, 3, 3, 64)
+        cdims = DenseConvDims(x, w)
+        dy = CUDA.rand(Float16, size(NNlib.conv(x, w, cdims))...)
+        @test size(NNlib.∇conv_data(dy, w, cdims)) == size(x)
+        @test size(NNlib.∇conv_filter(x, dy, cdims)) == size(w)
+    end
+end


### PR DESCRIPTION
## Summary

Float16 convolutions on the GPU fail through cuDNN:
- **#505** — forward 3D conv (5D tensor) → `CUDNN_STATUS_NOT_SUPPORTED` (every shape)
- **#515** — `∇conv_filter` for Float16 → `CUDNN_STATUS_NOT_SUPPORTED` / `BAD_PARAM` for various shapes (e.g. the reported `3=>64` on a single 3×3 image)

Both are the same root cause: the convolution descriptor's compute type was set to the I/O eltype, so Float16 inputs requested cuDNN's `TRUE_HALF_CONFIG` (accumulate in Float16). cuDNN only supports that for a narrow set of 2D shapes — it is unsupported for 3D convs and for many backward-filter shapes.

## Fix

Set the descriptor's compute type to `Float32` for Float16 inputs (`PSEUDO_HALF_CONFIG`: Float16 data, Float32 accumulation). This is broadly supported and is the standard choice — PyTorch promotes the conv descriptor's math type `HALF -> FLOAT` for **all** conv dimensionalities (`ConvolutionDescriptor::set` in `aten/src/ATen/cudnn/Descriptors.h`), and on Tensor Cores there is no speed cost since they natively multiply in fp16 and accumulate in fp32.

Both forward and backward passes route through `cudnnConvolutionDescriptor`, so the one-line change covers `conv`, `∇conv_data`, and `∇conv_filter`.

## Tests

Adds a `Float16` GPU conv testset:
- `conv` / `∇conv_data` / `∇conv_filter` across 1D/2D/3D and grouped convs — output stays `Float16` and matches a Float32 CPU reference within Float16 rounding
- explicit regression guards for the exact #505 (5D forward) and #515 (`3=>64`, 1×1-output `∇conv_filter`) shapes

## Verification

Tested locally on an NVIDIA TITAN RTX (cuDNN 9.2, CUDA.jl 6.1, Julia 1.12). Before: both issues reproduce. After: both pass; the full `convolution` testset (3614/3614) and the new `Float16` testset (39/39) pass. GPU fp16 agreed with the fp32 reference to ≤ 4×10⁻⁴.

Fixes #505. Fixes #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)