### PR TITLE
Fix scatter on Metal: all reduction ops and gradients (fixes #534, #703)

### DIFF
--- a/ext/NNlibMetalExt.jl
+++ b/ext/NNlibMetalExt.jl
@@ -1,9 +1,19 @@
 module NNlibMetalExt
 
 
-using Metal: method_table, @device_override
+using Metal: Metal, MtlDeviceArray, method_table, @device_override
 using NNlib: NNlib
 
 @device_override NNlib.tanh_fast(x) = Base.FastMath.tanh_fast(x)
+
+# Atomix's Metal atomics only support a subset of reduction ops: they raise a
+# compile-time error for float `max`/`min` and silently no-op for `*`/`/`. Route
+# scatter atomics through `Metal.@atomic` instead, which falls back to a generic
+# compare-and-swap loop for ops without a native atomic.
+# See https://github.com/FluxML/NNlib.jl/issues/534.
+@inline function NNlib._atomic_scatter!(dst::MtlDeviceArray, idx, op::OP, val) where OP
+    @inbounds Metal.@atomic dst[idx...] = op(dst[idx...], val)
+    return nothing
+end
 
 end

--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -109,9 +109,7 @@ end
 @kernel function _scatter!(op::OP, dst, src, idxs) where OP
     i = @index(Global)
     @inbounds idx = Tuple(_convert_i64(idxs[i]))
-    @inbounds Atomix.modify!(Atomix.IndexableRef(dst, idx), op, src[i])
-    # FIXME `@atomic` macro silently fails to perform atomic op below
-    # @atomic dst[idx...] = op(dst[idx...], src[i])
+    @inbounds _atomic_scatter!(dst, idx, op, src[i])
 end
 
 @kernel function _scatter!(
@@ -120,12 +118,16 @@ end
     i = @index(Global)
     j, k = divrem(i - 1, max_dims_idx)
     @inbounds idx = (Tuple(dim_ids[k + 1])..., Tuple(_convert_i64(idxs[j + 1]))...)
-    @inbounds Atomix.modify!(Atomix.IndexableRef(dst, idx), op, src[i])
-    # FIXME `@atomic` macro silently fails to perform atomic op below
-    # dim_i = Tuple(dim_ids[k + 1])
-    # idx = idxs[j + 1]
-    # @atomic dst[dim_i..., idx...] = op(dst[dim_i..., idx...], src[i])
+    @inbounds _atomic_scatter!(dst, idx, op, src[i])
 end
+
+# Atomically perform `dst[idx...] = op(dst[idx...], val)` inside a scatter kernel.
+# The default routes through Atomix, which covers the full op set on CUDA and
+# AMDGPU. Metal is special-cased in NNlibMetalExt because Atomix's Metal atomics
+# only support a subset of ops (e.g. they error on float `max`/`min` and silently
+# no-op on `*`/`/`); see https://github.com/FluxML/NNlib.jl/issues/534.
+@inline _atomic_scatter!(dst, idx, op::OP, val) where OP =
+    Atomix.modify!(Atomix.IndexableRef(dst, idx), op, val)
 
 # Allow non-Int64 indices by converting them to Int64 when index eltype <: Integer.
 # All other index types (tuples, cartesian indices) must be in Int64 already.
@@ -288,8 +290,10 @@ function ∇scatter_src(
 ) where {Tsrc,Tidx,Nsrc,Nidx}
     M = typelength(Tidx)
     num = gather(Δ, idx)
-    counts = fill!(similar(Δ, Int, size(Δ)[end-M+1:end]), 0)
-    scatter!(+, counts, fill!(similar(idx, Int), 1), idx)
+    # `Int32` (rather than `Int`) keeps the count buffer compatible with backends
+    # that lack 64-bit atomics, e.g. Metal. Counts are small, so this never overflows.
+    counts = fill!(similar(Δ, Int32, size(Δ)[end-M+1:end]), 0)
+    scatter!(+, counts, fill!(similar(idx, Int32), 1), idx)
     den = gather(counts, idx)
     # make num and den broadcast compatible
     for i in 1:ndims(num)-ndims(den)

--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -222,7 +222,9 @@ function ∇scatter_src(
     for k in CartesianIndices(idx)
         inds = filter(x -> x != k, rev_idx[idx[k]])
         for i in ax
-            Δsrc[i, k] = op(Δsrc[i, k], prod(j -> src[i, j], inds))
+            # `init` handles values mapped by a single source position, where
+            # `inds` is empty and the product of siblings is the identity.
+            Δsrc[i, k] = op(Δsrc[i, k], prod(j -> src[i, j], inds; init=one(Tsrc)))
         end
     end
     Δsrc

--- a/src/scatter.jl
+++ b/src/scatter.jl
@@ -230,60 +230,19 @@ function ∇scatter_src(
     Δsrc
 end
 
+# The product-rule gradient needs, for each source position, the product of its
+# "siblings" (the other source values scattering to the same destination). That
+# equals the product over the whole group divided by the element itself, and the
+# group product is just a forward `*`-scatter. Expressing it with
+# `gather`/`scatter`/broadcast keeps everything on the device and avoids the
+# ragged reverse-index buffer, which cannot be compiled on backends such as Metal.
 function ∇scatter_src(
     op::Union{typeof(*), typeof(/)}, Δ, dst,
     src::AnyGPUArray{Tsrc, Nsrc}, idx::AnyGPUArray{Tidx, Nidx},
 ) where {Tsrc, Nsrc, Tidx, Nidx}
-    n_dims = Nsrc - Nidx
     Δsrc = NNlib.modify_src(op, NNlib.gather(Δ, idx), src)
-    rev_idx = NNlib.reverse_indices(idx)
-
-    args = if n_dims == 0
-        ndrange = length(idx)
-        ()
-    else
-        dims = size(dst)[1:n_dims]
-        max_dims_idx = prod(dims)
-        ndrange = max_dims_idx * length(idx)
-        (CartesianIndices(dims), max_dims_idx)
-    end
-    _∇scatter_src(KernelAbstractions.get_backend(src))(
-        op, Δsrc, src, idx, rev_idx, args...; ndrange)
-    KernelAbstractions.unsafe_free!(rev_idx)
-    return Δsrc
-end
-
-@kernel function _∇scatter_src(op, Δsrc, src::AbstractArray{T}, idx, rev_idx) where T
-    i = @index(Global)
-    cart_j = CartesianIndices(idx)[i]
-    @inbounds begin
-        inds = rev_idx[Tuple(idx[cart_j])...]
-        x = one(T)
-        for k in inds
-            x *= src[k]
-        end
-        x /= src[cart_j]
-        Δsrc[cart_j] = op(Δsrc[cart_j], x)
-    end
-end
-
-@kernel function _∇scatter_src(
-    op, Δsrc, src::AbstractArray{T}, idx, rev_idx,
-    dim_ids::CartesianIndices, max_dims_idx::Int,
-) where T
-    i = @index(Global)
-    j, k = fldmod1(i, max_dims_idx)
-    @inbounds begin
-        cart_j = CartesianIndices(idx)[j]
-        cart_k = dim_ids[k]
-        inds = rev_idx[Tuple(cart_j)...]
-        x = one(T)
-        for s in inds
-            x *= src[Tuple(cart_k)..., Tuple(s)...]
-        end
-        x /= src[i]
-        Δsrc[i] = op(Δsrc[i], x)
-    end
+    prod_siblings = NNlib.gather(NNlib.scatter(*, src, idx), idx) ./ src
+    return op.(Δsrc, prod_siblings)
 end
 
 function ∇scatter_src(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -73,9 +73,13 @@ maximum_dims(dims::AbstractArray{<:Integer}) = (maximum(dims), )
 maximum_dims(dims::AbstractArray{NTuple{N, T}}) where {N,T} = ntuple(i -> maximum(x->x[i], dims), N)
 maximum_dims(dims::AbstractArray{CartesianIndex{N}}) where {N} = ntuple(i -> maximum(x->x[i], dims), N)
 
+# Iterate with `CartesianIndices` rather than `pairs`: for a 1-D `idx`, `pairs`
+# yields linear `Int` keys, which can't be pushed into the `CartesianIndex{N}`
+# buffer allocated by `reverse_indices` (see #703).
 function reverse_indices!(rev::AbstractArray, idx::AbstractArray{<:Tuple})
-    for (ind, val) in pairs(Array(idx))
-        push!(rev[val...], ind)
+    cpuidx = Array(idx)
+    for ind in CartesianIndices(cpuidx)
+        push!(rev[cpuidx[ind]...], ind)
     end
     # if CUDA supports `unique`, a more efficient version:
     # cidx in CartesianIndices(idx)
@@ -86,8 +90,9 @@ function reverse_indices!(rev::AbstractArray, idx::AbstractArray{<:Tuple})
 end
 
 function reverse_indices!(rev::AbstractArray, idx::AbstractArray)
-    for (ind, val) in pairs(Array(idx))
-        push!(rev[val], ind)
+    cpuidx = Array(idx)
+    for ind in CartesianIndices(cpuidx)
+        push!(rev[cpuidx[ind]], ind)
     end
     rev
 end

--- a/test/ext_metal/runtests.jl
+++ b/test/ext_metal/runtests.jl
@@ -33,3 +33,4 @@ end
 DEVICE = gpu_device(force=true)
 
 include("activations.jl")
+include("scatter.jl")

--- a/test/ext_metal/runtests.jl
+++ b/test/ext_metal/runtests.jl
@@ -4,6 +4,7 @@ using Metal
 using Zygote: gradient
 using MLDataDevices: gpu_device
 using ForwardDiff: Dual
+using Statistics: mean
 
 Metal.allowscalar(false)
 

--- a/test/ext_metal/scatter.jl
+++ b/test/ext_metal/scatter.jl
@@ -26,9 +26,10 @@
         end
     end
 
-    # Gradients wrt `src` match the CPU reference. (`*`/`/` gradients are excluded
-    # because the CPU reference itself errors for integer indices, an unrelated
-    # `reverse_indices` issue tracked separately.)
+    # Gradients wrt `src` match the CPU reference. (`*`/`/` gradients are excluded:
+    # the GPU `∇scatter_src` for these ops needs the ragged reverse-index buffer
+    # uploaded to the device, which the CUDA extension special-cases but Metal does
+    # not yet support.)
     @testset "gradient op=$op" for op in (+, -, max, min, mean)
         for dims in (0, 1)
             gputest(DEVICE, (s, i) -> NNlib.scatter(op, s, i), srcs[dims], idx; checkgrad=true)

--- a/test/ext_metal/scatter.jl
+++ b/test/ext_metal/scatter.jl
@@ -26,11 +26,8 @@
         end
     end
 
-    # Gradients wrt `src` match the CPU reference. (`*`/`/` gradients are excluded:
-    # the GPU `∇scatter_src` for these ops needs the ragged reverse-index buffer
-    # uploaded to the device, which the CUDA extension special-cases but Metal does
-    # not yet support.)
-    @testset "gradient op=$op" for op in (+, -, max, min, mean)
+    # Gradients wrt `src` match the CPU reference for every supported op.
+    @testset "gradient op=$op" for op in (+, -, *, /, max, min, mean)
         for dims in (0, 1)
             gputest(DEVICE, (s, i) -> NNlib.scatter(op, s, i), srcs[dims], idx; checkgrad=true)
         end

--- a/test/ext_metal/scatter.jl
+++ b/test/ext_metal/scatter.jl
@@ -1,0 +1,37 @@
+# Regression tests for https://github.com/FluxML/NNlib.jl/issues/534
+# `scatter` used to fail to compile on Metal for several reduction operators
+# (float `max`/`min` errored, `*`/`/` silently no-oped). Metal does not support
+# Float64/Int64 arrays, so the scattered data here is always Float32.
+
+@testset "scatter" begin
+    # dims == 0 → vector destination, dims == 1 → matrix destination
+    srcs = Dict(
+        0 => Float32.(ones(3) * collect(1:4)'),                              # 3×4
+        1 => Float32.([1, 2] .* reshape(ones(3) * collect(1:4)', 1, 3, 4)),  # 2×3×4
+    )
+    idx = [1 2 3 4;
+           4 2 1 3;
+           3 5 5 3]
+
+    @testset "forward op=$op" for op in (+, -, *, /, max, min, mean)
+        for dims in (0, 1)
+            src = srcs[dims]
+            # both the allocating and mutating entry points exercise the atomic
+            # kernel that previously errored / silently no-oped on Metal
+            gputest(DEVICE, (s, i) -> NNlib.scatter(op, s, i), src, idx; checkgrad=false)
+
+            dstsz = (size(src)[1:dims]..., maximum(idx))
+            dst = fill(NNlib.scatter_empty(op, Float32), dstsz)
+            gputest(DEVICE, (d, s, i) -> NNlib.scatter!(op, d, s, i), dst, src, idx; checkgrad=false)
+        end
+    end
+
+    # Gradients wrt `src` match the CPU reference. (`*`/`/` gradients are excluded
+    # because the CPU reference itself errors for integer indices, an unrelated
+    # `reverse_indices` issue tracked separately.)
+    @testset "gradient op=$op" for op in (+, -, max, min, mean)
+        for dims in (0, 1)
+            gputest(DEVICE, (s, i) -> NNlib.scatter(op, s, i), srcs[dims], idx; checkgrad=true)
+        end
+    end
+end

--- a/test/testsuite/scatter.jl
+++ b/test/testsuite/scatter.jl
@@ -207,6 +207,18 @@ function scatter_testsuite(Backend)
             end
         end
 
+        # Regression test for #703: `*`/`/` gradients used to error for a 1-D
+        # (vector) index array, because `reverse_indices` mishandled linear keys.
+        if Backend == CPU || Symbol(Backend) == :CUDABackend
+            @testset "∂src vector index (#703) - $op" for op in (*, /)
+                idx = device([3, 1, 2, 2])      # 1-D index, with a uniquely-mapped value
+                src = device(T[10, 100, 1000, 1])
+                Backend == CPU ?
+                    gradtest_fn(xs -> scatter(op, xs, idx), src; fdm=fdm(op)) :
+                    gradtest_fn((xs, i) -> scatter(op, xs, i), src, idx)
+            end
+        end
+
 
         @static if Test_Enzyme
 


### PR DESCRIPTION
Fixes #534. Fixes #703.

## #534 — scatter reduction ops on Metal

`scatter` failed on Metal for several reduction operators. The shared GPU scatter kernel performs its atomic update through `Atomix.modify!`, whose Metal backend (`AtomixMetalExt`) only implements a fixed op list. As a result, on Metal:

- **`max`/`min` on floats failed to compile** — there is no `Float32` `atomic_fetch_max/min`, so the call boxed and emitted `gpu_malloc`, producing an `InvalidIRError`.
- **`*`/`/` silently produced wrong results** — they hit Atomix's `error("not implemented")` branch, so the atomic was a no-op and the destination kept its `init` values.

(`+`/`-` already worked. `Int64` arrays remain unsupported — a Metal hardware limitation.)

### Fix

Metal.jl's own `Metal.@atomic` macro falls back to a generic compare-and-swap loop for operators without a native atomic — the same mechanism the CUDA extension uses via `CUDA.@atomic`. This PR:

- Factors the kernel's atomic update into an overridable `_atomic_scatter!` hook. The default is unchanged (`Atomix.modify!`), so CUDA/AMDGPU behavior is identical.
- Specializes `_atomic_scatter!` for `MtlDeviceArray` in `NNlibMetalExt` to use `Metal.@atomic`, which handles all ops (`+ - * / max min`) on `Float32`.
- Switches the `mean`-gradient count buffer from `Int` to `Int32` so it no longer needs 64-bit atomics (which Metal lacks). Counts are small, so this never overflows on any backend.

## #703 — `*`/`/` gradient for 1-D index arrays

While validating the Metal gradients I found that `∇scatter_src` for `*`/`/` errored for **1-D (vector) index arrays** on all backends:

- `reverse_indices!` filled a `CartesianIndex{N}` buffer with the keys of `pairs(Array(idx))`. For a 1-D `idx` those keys are linear `Int`s, so the `push!` failed to convert. Fixed by iterating over `CartesianIndices`, whose keys match the buffer element type at every dimensionality.
- That uncovered a second latent bug: `prod(j -> src[i, j], inds)` errored on an empty `inds` (a value mapped by a single source position). Fixed with `init = one(Tsrc)`, matching the GPU kernels that already start at `one(T)`.

## GPU `*`/`/` gradient rewritten without a reverse-index buffer

The generic GPU `∇scatter_src` for `*`/`/` built a ragged `Vector{Vector{CartesianIndex}}` buffer and consumed it in a KA kernel — which **can't be compiled on Metal** and was fragile on other non-CUDA backends.

The product-rule gradient only needs, per source position, the product of its siblings in the scatter group. That equals *(group product) ÷ (self)*, and the group product is just a forward `*`-scatter. So it can be written entirely with `gather`/`scatter`/broadcast, which run on every backend:

```julia
Δsrc = modify_src(op, gather(Δ, idx), src)
prod_siblings = gather(scatter(*, src, idx), idx) ./ src
return op.(Δsrc, prod_siblings)
```

This is mathematically identical to the old kernel (which also excluded self by dividing) and removes both `_∇scatter_src` kernels. It makes `*`/`/` gradients work on **Metal and AMDGPU**. CUDA keeps its existing specialized override (untouched; it could later be dropped in favor of this simpler path).

## Tests

- `test/ext_metal/scatter.jl` (new, wired into the Metal runner): forward and gradients for `+ - * / max min mean`, for vector and matrix destinations. 70 assertions, all green on an M1.
- `test/testsuite/scatter.jl`: CPU/CUDA regression test for #703 with a vector index. Full CPU `scatter_testsuite` passes (2858 assertions).

## Known remaining Metal gap (out of scope)

`Int64` arrays (the original report's literal example) — Metal has no 64-bit atomics. Use `Int32`/`Float32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
