### PR TITLE
Fix clamping-activation gradients (hardσ correctness bug) and unbreak tests

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -941,11 +941,11 @@ UNARY_ACTS = [ # f, dfdx
     ## `conj`, and the scalar `@scalar_rule` conjugates internally, so both paths yield the
     ## ChainRules-convention `conj(f')` needed for correct complex (holomorphic) gradients.
     (:σ,            :(Ω * (1 - Ω))),
-    (:hardσ,        :(ifelse((Ω>0)&(Ω<1), oftf(Ω, 1/6), oftf(Ω, 1)))),
+    (:hardσ,        :(ifelse((Ω>0)&(Ω<1), oftf(Ω, 1)/oftf(Ω, 6), oftf(Ω, 0)))),
     (:logσ,         :(sigmoid_fast(-x))),
     (:hardtanh,     :((Ω>-1) & (Ω<1))),
     (:relu,         :(Ω > 0)),
-    (:leakyrelu,    :(ifelse(Ω > 0, oftf(Ω, 1), oftf(Ω, leakyrelu_a)))),
+    (:leakyrelu,    :(ifelse(Ω > 0, oftf(Ω, 1), oftf(Ω, 1)/oftf(Ω, 100)))),  # 1/100 == leakyrelu_a; built from Ints to stay Float64-free for GPU (Metal) kernels
     (:relu6,        :((Ω>0) & (Ω<6))),
     # rrelu is random, can't write a rule.
     (:elu,          :(deriv_elu(Ω))),

--- a/test/activations.jl
+++ b/test/activations.jl
@@ -406,6 +406,17 @@ end
         gradtest(x -> selu.(x), 10, atol=1e-4)
     end
 
+    @testset "saturated gradients: $f" for f in (hardσ, hardtanh, relu6, hardswish)
+        # The `gradtest`s above only probe near the origin (±2±rand), which sits inside
+        # the linear region of the clamping activations and never exercises the saturated
+        # branch of their derivative. Check that branch directly against ForwardDiff.
+        for x in (-50.0, 50.0, -7.0, 7.0)
+            ad = Zygote.gradient(z -> sum(f.(z)), [x])[1][1]
+            fd = ForwardDiff.derivative(f, x)
+            @test ad ≈ fd  atol=1e-6
+        end
+    end
+
 end
 
 @testset "Second derivatives" begin

--- a/test/conv.jl
+++ b/test/conv.jl
@@ -786,8 +786,13 @@ end
       @test gs_w_reg ≈ gs_w[:,:,:,o]
    end
 
-   # Currently hangs due to a FiniteDifferences issue
-   @test_skip gradtest((x, w) -> sum(conv(x, w, cdims)), x′, w′)
+   # Finite-differencing the gradient of the full-size `x′`/`w′` above is intractable
+   # (it perturbs every one of the ~157k input elements), so check the grouped-conv
+   # gradient against finite differences on a small input instead.
+   xs = rand(rng, Float64, 6, 6, 4, 2)
+   ws = rand(rng, Float64, 3, 3, 2, 4)
+   csdims = DenseConvDims(xs, ws; groups=2)
+   gradtest((x, w) -> sum(conv(x, w, csdims)), xs, ws)
 end
 
 @testset "conv_wrapper" begin
@@ -891,7 +896,6 @@ end
   dcdims = DepthwiseConvDims(x, w)
   gradtest((x, w) -> depthwiseconv(x, w, dcdims), x, w)
 
-  # FIXME fails
   y = depthwiseconv(x, w, dcdims)
   gradtest((y, w) -> ∇depthwiseconv_data(y, w, dcdims), y, w)
   gradtest((y, w) -> sum(∇depthwiseconv_data(y, w, dcdims)), y, w)

--- a/test/ext_metal/activations.jl
+++ b/test/ext_metal/activations.jl
@@ -1,17 +1,15 @@
 @testset "activation broadcast" begin
-    broken_f = (:hardσ, :leakyrelu) 
     for name in NNlib.ACTIVATIONS
         # println("Testing forward diff for activation: ", name)
         f = @eval $name
-        @test gputest(DEVICE, x -> f.(x), rand(5)) broken=name ∈ broken_f
+        @test gputest(DEVICE, x -> f.(x), rand(5))
     end
 end
 
 @testset "forward diff" begin
-    broken_f = (:hardσ, :leakyrelu) 
     for name in NNlib.ACTIVATIONS
         # println("Testing forward diff for activation: ", name)
         f = @eval $name
-        @test gputest(DEVICE, x -> f.(x), Dual.(rand(Float32, 5), 1)) broken=name ∈ broken_f
+        @test gputest(DEVICE, x -> f.(x), Dual.(rand(Float32, 5), 1))
     end
 end

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -990,18 +990,22 @@ end
 end
 
 @testset "AutoDiff: spatial_rank=$spatial_rank" for spatial_rank in (1, 2)
-  x = rand(rng, repeat([10], spatial_rank)..., 3, 2)
+  # Use an input with distinct, well-separated values so that every pooling window has
+  # a unique maximum. `maxpool` is non-differentiable at ties, where finite differences
+  # and AD disagree; with random input this makes the `maxpool` gradtests flaky (this is
+  # what the now-closed #188 was about). Distinct integers (gaps >= 1 >> the FD step)
+  # keep the argmax stable, so the comparison is well-posed for all spatial ranks.
+  x = Float64.(reshape(randperm(rng, 10^spatial_rank * 3 * 2), repeat([10], spatial_rank)..., 3, 2))
   pdims = PoolDims(x, 2)
-  gradtest(x -> maxpool(x, pdims), x; skip = spatial_rank==2)
+  gradtest(x -> maxpool(x, pdims), x)
   gradtest(x -> meanpool(x, pdims), x)
-  gradtest(x -> sum(maxpool(x, pdims)), x, skip = spatial_rank==2)
+  gradtest(x -> sum(maxpool(x, pdims)), x)
   gradtest(x -> sum(meanpool(x, pdims)), x)
 
-  #https://github.com/FluxML/NNlib.jl/issues/188
   k = ntuple(_ -> 2, spatial_rank)  # Kernel size of pool in ntuple format
-  gradtest(x -> maxpool(x, k), x; skip = spatial_rank==2)
+  gradtest(x -> maxpool(x, k), x)
   gradtest(x -> meanpool(x, k), x)
-  gradtest(x -> sum(maxpool(x, k)), x, skip = spatial_rank==2)
+  gradtest(x -> sum(maxpool(x, k)), x)
   gradtest(x -> sum(meanpool(x, k)), x)
 
   # count_include_pad=false (issue #218), with padding so the modes differ


### PR DESCRIPTION
Follow-up to the test audit in #702. While checking which broken/skipped tests on the Metal/M1 backend could be un-broken, the disabled Metal `hardσ` activation test turned out to be sitting on top of a **real, backend-independent correctness bug**.

## The bug

The `hardσ` gradient rule returned `1` in its *saturated* branch instead of `0`:

```julia
# before
(:hardσ, :(ifelse((Ω>0)&(Ω<1), oftf(Ω, 1/6), oftf(Ω, 1)))),
# after
(:hardσ, :(ifelse((Ω>0)&(Ω<1), oftf(Ω, 1)/oftf(Ω, 6), oftf(Ω, 0)))),
```

`hardσ(x) = clamp((x+3)/6, 0, 1)`, so its derivative is `1/6` on `-3 < x < 3` and **`0`** outside. The rule gave `1.0` for `|x| > 3`, on every backend (CPU included). It went unnoticed for years because the activation gradtests only probe `±2±rand`, which always lands inside hardσ's linear region and never exercises the saturated branch. Verified against ForwardDiff:

| x | ForwardDiff | rrule (before) | rrule (after) |
|---|---|---|---|
| -5 | 0.0 | **1.0** | 0.0 |
| -1 | 0.16667 | 0.16667 | 0.16667 |
|  5 | 0.0 | **1.0** | 0.0 |

## Metal GPU compatibility

The in-region slopes used Float64 literals (`1/6`, and leakyrelu's `0.01`). Inside a fused `@.` gradient broadcast these reach the Metal kernel as `double` values and fail to compile (`InvalidIRError: unsupported use of double value`). Building the constants from Ints (`oftf(Ω,1)/oftf(Ω,6)`, `oftf(Ω,1)/oftf(Ω,100)`) is value-identical in both Float32 and Float64 but keeps the kernel Float64-free. Type stability (`@inferred`, Float16/32/64) is preserved.

With this, **all 156 Metal activation tests pass** (broadcast + forward-diff) on an M1.

## Tests unbroken / unskipped (all verified passing locally, Metal included)

- **`test/ext_metal/activations.jl`** — drop `broken=` for `hardσ`/`leakyrelu`.
- **`test/pooling.jl`** — unskip the `maxpool` gradtests for `spatial_rank==2`. These were flaky because `maxpool` is non-differentiable at ties, where finite differences and AD disagree (the now-closed #188). Using input with distinct, well-separated values keeps the argmax unambiguous; 256/256 pass across 8 seeds. The stale #188 comment is updated.
- **`test/conv.jl`** — replace the skipped grouped-conv gradtest (it didn't hang due to a FiniteDifferences bug; finite-differencing ~157k inputs is just intractable) with a tractable small-input gradtest. Also drop the stale `# FIXME fails` above the `∇depthwiseconv_data` gradtests — they pass since depthwiseconv was routed through grouped conv (#698).
- **`test/activations.jl`** — add a regression test checking saturated-region gradients of `hardσ`/`hardtanh`/`relu6`/`hardswish` against ForwardDiff, so the masked branch is covered going forward.

## Still genuinely broken (left marked, out of scope here)

From the same audit, these remain correctly marked and are *not* touched:
- dropout forward-over-reverse Hessian (`@test_broken`) — AD limitation.
- `bias_act!` 2nd-order with a captured global (`@test_skip`) — Zygote `accum_global` limitation.
- `∇conv_filter_direct!`/`∇conv_data_direct!` with `alpha`/`beta` + stride/dilation (`broken=`) — a genuine `conv_direct!` accumulation bug (the `beta=0` path overwrites correctly; the `beta≠0` path mis-accumulates). Worth its own issue/fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)