### PR TITLE
Enable Enzyme tests on Julia 1.12

### DIFF
--- a/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
+++ b/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
@@ -383,4 +383,127 @@ function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib._dropou
 end
 
 
+# batched_mul
+#
+# Without a custom rule, Enzyme differentiates through NNlib's threaded
+# `batched_gemm!`, whose `Threads.@spawn`/`Threads.@sync` is not supported and
+# (on Julia 1.12) hits an internal `cmpxchg` error in `wait(::Task)`.
+# See https://github.com/FluxML/NNlib.jl/issues/707 and
+# https://github.com/EnzymeAD/Enzyme.jl/issues/3150.
+#
+# The derivatives mirror the ChainRules `rrule` in src/batched/batchedmul.jl:
+#   dA = Δ ⊠ Bᴴ   (summed over the batch dim if `size(A,3) == 1`)
+#   dB = Aᴴ ⊠ Δ   (summed over the batch dim if `size(B,3) == 1`)
+
+@inline _batched_mul_const(x) = x isa EnzymeCore.Const
+
+function EnzymeRules.forward(config::EnzymeRules.FwdConfig,
+        func::EnzymeCore.Const{typeof(NNlib.batched_mul)}, ::Type{RT},
+        A::EnzymeCore.Annotation{<:AbstractArray{<:Any,3}},
+        B::EnzymeCore.Annotation{<:AbstractArray{<:Any,3}}) where {RT}
+
+    bothconst = _batched_mul_const(A) && _batched_mul_const(B)
+
+    # The primal is needed if requested, or to size the zero tangent when both
+    # arguments are Const but a shadow is still required (e.g. runtime activity).
+    primal = (EnzymeRules.needs_primal(config) ||
+              (EnzymeRules.needs_shadow(config) && bothconst)) ?
+             func.val(A.val, B.val) : nothing
+
+    EnzymeRules.needs_shadow(config) || return primal
+
+    # dC = dA ⊠ B + A ⊠ dB (a missing term means that argument is Const)
+    dC(dA, dB) =
+        if bothconst
+            zero(primal)
+        elseif _batched_mul_const(A)
+            NNlib.batched_mul(A.val, dB)
+        elseif _batched_mul_const(B)
+            NNlib.batched_mul(dA, B.val)
+        else
+            NNlib.batched_mul(dA, B.val) .+ NNlib.batched_mul(A.val, dB)
+        end
+
+    shadow = if EnzymeRules.width(config) == 1
+        dC(_batched_mul_const(A) ? nothing : A.dval,
+           _batched_mul_const(B) ? nothing : B.dval)
+    else
+        ntuple(i -> dC(_batched_mul_const(A) ? nothing : A.dval[i],
+                       _batched_mul_const(B) ? nothing : B.dval[i]),
+               Val(EnzymeRules.width(config)))
+    end
+
+    EnzymeRules.needs_primal(config) || return shadow
+    return EnzymeRules.width(config) == 1 ?
+        EnzymeCore.Duplicated(primal, shadow) :
+        EnzymeCore.BatchDuplicated(primal, shadow)
+end
+
+function EnzymeRules.augmented_primal(config::EnzymeRules.RevConfig,
+        func::EnzymeCore.Const{typeof(NNlib.batched_mul)}, ::Type{RT},
+        A::EnzymeCore.Annotation{<:AbstractArray{<:Any,3}},
+        B::EnzymeCore.Annotation{<:AbstractArray{<:Any,3}}) where {RT}
+
+    C = func.val(A.val, B.val)
+
+    primal = EnzymeRules.needs_primal(config) ? C : nothing
+    shadow = if EnzymeRules.needs_shadow(config)
+        EnzymeRules.width(config) == 1 ? zero(C) :
+            ntuple(_ -> zero(C), Val(EnzymeRules.width(config)))
+    else
+        nothing
+    end
+
+    # Cache A if it's overwritten and needed for dB (i.e. B is active),
+    # cache B if it's overwritten and needed for dA (i.e. A is active).
+    cache_A = ( EnzymeRules.overwritten(config)[2]
+                && !_batched_mul_const(B) ) ? copy(A.val) : nothing
+    cache_B = ( EnzymeRules.overwritten(config)[3]
+                && !_batched_mul_const(A) ) ? copy(B.val) : nothing
+
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, cache_A, cache_B))
+end
+
+function EnzymeRules.reverse(config::EnzymeRules.RevConfig,
+        func::EnzymeCore.Const{typeof(NNlib.batched_mul)}, ::Type{RT}, tape,
+        A::EnzymeCore.Annotation{<:AbstractArray{<:Any,3}},
+        B::EnzymeCore.Annotation{<:AbstractArray{<:Any,3}}) where {RT}
+
+    dCs, cache_A, cache_B = tape
+
+    # Nothing to propagate if the return wasn't differentiated.
+    dCs === nothing && return (nothing, nothing)
+
+    # Recover values not cached because they were not overwritten.
+    if !_batched_mul_const(B) && cache_A === nothing
+        cache_A = A.val
+    end
+    if !_batched_mul_const(A) && cache_B === nothing
+        cache_B = B.val
+    end
+
+    dAs = _batched_mul_const(A) ? dCs : A.dval
+    dBs = _batched_mul_const(B) ? dCs : B.dval
+
+    if EnzymeRules.width(config) == 1
+        dCs = (dCs,)
+        dAs = (dAs,)
+        dBs = (dBs,)
+    end
+
+    for (dC, dA, dB) in zip(dCs, dAs, dBs)
+        if !_batched_mul_const(A)
+            tmp = NNlib.batched_mul(dC, NNlib.batched_adjoint(cache_B))
+            dA .+= size(A.val, 3) == 1 ? sum(tmp; dims=3) : tmp
+        end
+        if !_batched_mul_const(B)
+            tmp = NNlib.batched_mul(NNlib.batched_adjoint(cache_A), dC)
+            dB .+= size(B.val, 3) == 1 ? sum(tmp; dims=3) : tmp
+        end
+    end
+
+    return (nothing, nothing)
+end
+
+
 end

--- a/test/batchedmul.jl
+++ b/test/batchedmul.jl
@@ -304,6 +304,36 @@ FiniteDifferences.to_vec(x::BatchedTranspose) = FiniteDifferences.to_vec(collect
     gradtest(batched_vec, randn(rng, M, P, B), randn(rng, P))
 end
 
+@static if Test_Enzyme
+
+# Regression test for https://github.com/FluxML/NNlib.jl/issues/707:
+# the custom EnzymeRules avoid differentiating through the threaded `batched_gemm!`.
+@testset "EnzymeRules: batched_mul" begin
+    A = randn(rng, Float32, 4, 5, 3)
+    B = randn(rng, Float32, 5, 6, 3)
+    # broadcasting over the batch dimension (size(·,3) == 1)
+    A1 = randn(rng, Float32, 4, 5, 1)
+    B1 = randn(rng, Float32, 5, 6, 1)
+
+    for Tret in (EnzymeCore.Const, EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated),
+        TA in (EnzymeCore.Const, EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated),
+        TB in (EnzymeCore.Const, EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated)
+
+        EnzymeTestUtils.are_activities_compatible(Tret, TA, TB) || continue
+
+        EnzymeTestUtils.test_forward(batched_mul, Tret, (A, TA), (B, TB); atol=1e-4, rtol=1e-4)
+        EnzymeTestUtils.test_reverse(batched_mul, Tret, (A, TA), (B, TB); atol=1e-4, rtol=1e-4)
+
+        # broadcasting batch dim of A, then of B
+        EnzymeTestUtils.test_forward(batched_mul, Tret, (A1, TA), (B, TB); atol=1e-4, rtol=1e-4)
+        EnzymeTestUtils.test_reverse(batched_mul, Tret, (A1, TA), (B, TB); atol=1e-4, rtol=1e-4)
+        EnzymeTestUtils.test_forward(batched_mul, Tret, (A, TA), (B1, TB); atol=1e-4, rtol=1e-4)
+        EnzymeTestUtils.test_reverse(batched_mul, Tret, (A, TA), (B1, TB); atol=1e-4, rtol=1e-4)
+    end
+end
+
+end # Test_Enzyme
+
 @testset "batched_vec: N-D batches" begin
     # Test 4D case: A is 4D, B is 3D
     A4d = randn(4, 5, 3, 2)  # (matrix_rows, matrix_cols, batch_dim1, batch_dim2)

--- a/test/dropout.jl
+++ b/test/dropout.jl
@@ -94,11 +94,15 @@ end
 
     reverse(Const(dropout), Const(rng), Duplicated(x1, dx1), Const(p), tape)
 
-    @test dx1[.!tape[1]] ≈ zero(x1)[.!tape[1]]
+    # The dropout mask isn't exposed through Enzyme's (internal) tape layout, but the
+    # dropped entries are exactly the zeros of the primal output (`x1` has no zeros).
+    kept = primal .!= 0
+
+    @test dx1[.!kept] ≈ zero(x1)[.!kept]
 
     val = convert(Float32, 1/(1-p))
 
-    @test dx1[tape[1]] ≈ (val * dout)[tape[1]]
+    @test dx1[kept] ≈ (val * dout)[kept]
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ import ReverseDiff as RD        # used in `pooling.jl`
 import Pkg
 using SpecialFunctions
 
-const Test_Enzyme = VERSION <= v"1.12-"
+const Test_Enzyme = VERSION <= v"1.13-"
 
 DocMeta.setdocmeta!(NNlib, :DocTestSetup, :(using NNlib, UnicodePlots); recursive=true)
 


### PR DESCRIPTION
Closes #693.
Closes #707.

Enzyme is functional on Julia 1.12 (tested against Enzyme 0.13.154). I ran every Enzyme test block against 1.12.5 — all pass except the dropout test, which broke only because it depended on Enzyme's internal tape layout.

This PR enables the Enzyme tests on 1.12 and adds the one missing rule that 1.12 exposed: a custom `EnzymeRules` set for `batched_mul`.

## Changes

- **`ext/NNlibEnzymeCoreExt`**: add `forward`, `augmented_primal` and `reverse` rules for `batched_mul`. Without them, Enzyme differentiates through NNlib's threaded `batched_gemm!`, whose `Threads.@spawn`/`Threads.@sync` it cannot handle: on Julia 1.12 `wait(::Task)` performs an atomic `cmpxchg` that triggers an internal Enzyme error (`Illegal replace ficticious phi ... cmpxchg`), and on earlier versions it emits `active variables passed by value to jl_new_task` warnings. This blocked Enzyme gradients for Flux layers funnelling through `batched_mul` (`MultiHeadAttention`, `Bilinear`). The derivatives mirror the existing ChainRules `rrule` (`dA = Δ ⊠ Bᴴ`, `dB = Aᴴ ⊠ Δ`, summed over the batch dim when an input is broadcast), so Enzyme never enters the threaded GEMM. See also https://github.com/EnzymeAD/Enzyme.jl/issues/3150.

- **`test/batchedmul.jl`**: regression test for the rule above, exercising all `Const`/`Duplicated`/`BatchDuplicated` activity combinations (forward and reverse) plus batch-dim broadcasting.

- **`test/runtests.jl`**: extend the `Test_Enzyme` guard from `v"1.12-"` to `v"1.13-"`, enabling the Enzyme tests on 1.10/1.11/1.12 while still skipping the CI `nightly` job (1.13.0-DEV), where Enzyme typically lags behind Julia.

- **`test/dropout.jl`**: the dropout `EnzymeRules` test indexed into `tape[1]` expecting the dropout keep-mask. In current Enzyme, `tape` is a `NamedTuple` (the full closure capture), so `tape[1]` is raw `Memory{Float32}` and `.!tape[1]` throws. Derive the mask from the primal output instead: `dropout`'s output is `keep .* val .* x1` and `randn` produces no exact zeros, so the dropped entries are exactly the zeros of the primal. This verifies the same gradient property without relying on Enzyme internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)