### PR TITLE
skip enzyme tests on amdgpu

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,14 +18,15 @@ import ReverseDiff as RD        # used in `pooling.jl`
 import Pkg
 using SpecialFunctions
 
-const Test_Enzyme = VERSION <= v"1.13-"
-
 DocMeta.setdocmeta!(NNlib, :DocTestSetup, :(using NNlib, UnicodePlots); recursive=true)
 
 # ENV["NNLIB_TEST_CUDA"] = "true" # uncomment to run CUDA tests
 # ENV["NNLIB_TEST_AMDGPU"] = "true" # uncomment to run AMDGPU tests
 # ENV["NNLIB_TEST_METAL"] = "true" # uncomment to run Metal tests
 # ENV["NNLIB_TEST_CPU"] = "false" # uncomment to skip CPU tests
+
+# some enzyme tests on AMDGPU are crashing julia
+const Test_Enzyme = VERSION <= v"1.13-" && (get(ENV, "NNLIB_TEST_AMDGPU", "false") != "true")
 
 const rng = StableRNG(123)
 include("test_utils.jl")

--- a/test/testsuite/gather.jl
+++ b/test/testsuite/gather.jl
@@ -154,7 +154,7 @@ function gather_testsuite(Backend)
             gradtest_fn((s, i) -> gather(s, i), src, idx)
     end
 
-    if Test_Enzyme && (Symbol(Backend) != :ROCBackend)
+    if Test_Enzyme
         @testset "EnzymeRules: gather! gradient for scalar index" begin
             src = device(Float64[3, 4, 5, 6, 7])
             idx = device([

--- a/test/testsuite/gather.jl
+++ b/test/testsuite/gather.jl
@@ -154,26 +154,22 @@ function gather_testsuite(Backend)
             gradtest_fn((s, i) -> gather(s, i), src, idx)
     end
 
-    @static if Test_Enzyme
+    if Test_Enzyme && (Symbol(Backend) != :ROCBackend)
+        @testset "EnzymeRules: gather! gradient for scalar index" begin
+            src = device(Float64[3, 4, 5, 6, 7])
+            idx = device([
+                1 2 3 4;
+                4 2 1 3;
+                3 5 5 3])
+            dst = gather(src, idx)
+            for Tret in (EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated),
+                Tdst in (EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated),
+                Tsrc in (EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated)
 
-    @testset "EnzymeRules: gather! gradient for scalar index" begin
-        src = device(Float64[3, 4, 5, 6, 7])
-        idx = device([
-            1 2 3 4;
-            4 2 1 3;
-            3 5 5 3])
-        dst = gather(src, idx)
-        for Tret in (EnzymeCore.Const, EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated),
-            Tdst in (EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated),
-            Tsrc in (EnzymeCore.Duplicated, EnzymeCore.BatchDuplicated)
-
-            Tret == EnzymeCore.Const && continue # ERROR
-            EnzymeTestUtils.are_activities_compatible(Tret, Tdst, Tsrc) || continue
-
-            EnzymeTestUtils.test_reverse(gather!, Tret, (dst, Tdst), (src, Tsrc), (idx, EnzymeCore.Const))
+                EnzymeTestUtils.are_activities_compatible(Tret, Tdst, Tsrc) || continue
+                EnzymeTestUtils.test_reverse(gather!, Tret, (dst, Tdst), (src, Tsrc), (idx, EnzymeCore.Const))
+            end
         end
-    end
-
     end
 
     @testset "gather gradient for tuple index" begin


### PR DESCRIPTION
follow up to #708,  skipping enzyme tests on AMDGPU since they fail (the `gather` testset) or crash julia entirely (unknown tests)