### PR TITLE
Support complex inputs in meanpool across backends (fixes #610)

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -57,7 +57,7 @@ logsoftmax
 
 `Flux`'s `AdaptiveMaxPool`, `AdaptiveMeanPool`, `GlobalMaxPool`, `GlobalMeanPool`, `MaxPool`, `MeanPool` and `lpnormpool` use `NNlib.PoolDims`, `NNlib.maxpool`, `NNlib.meanpool` and `NNlib.lpnormpool` as their backend.
 
-`NNlib.meanpool` supports complex datatypes on CPU and CUDA devices (the real and imaginary parts are pooled independently). `maxpool` does not, since `max` is undefined for complex numbers.
+`NNlib.meanpool` supports complex inputs (the real and imaginary parts are pooled independently). This is handled in the generic code, so it works on every backend that pools real arrays — CPU, CUDA and AMDGPU. `maxpool` does not support complex inputs, since `max` is undefined for complex numbers.
 
 ```@docs
 PoolDims

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -57,6 +57,8 @@ logsoftmax
 
 `Flux`'s `AdaptiveMaxPool`, `AdaptiveMeanPool`, `GlobalMaxPool`, `GlobalMeanPool`, `MaxPool`, `MeanPool` and `lpnormpool` use `NNlib.PoolDims`, `NNlib.maxpool`, `NNlib.meanpool` and `NNlib.lpnormpool` as their backend.
 
+`NNlib.meanpool` supports complex datatypes on CPU and CUDA devices (the real and imaginary parts are pooled independently). `maxpool` does not, since `max` is undefined for complex numbers.
+
 ```@docs
 PoolDims
 maxpool

--- a/ext/NNlibCUDACUDNNExt/pooling.jl
+++ b/ext/NNlibCUDACUDNNExt/pooling.jl
@@ -44,6 +44,33 @@ function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{
     return dx
 end
 
+# Complex mean pooling (fixes https://github.com/FluxML/NNlib.jl/issues/610).
+# Mean pooling is linear, so we pool the real and imaginary parts independently
+# with cuDNN and recombine. This matches the CPU path, where complex `meanpool`
+# already works. These handle any spatial rank: the inner real `meanpool!`/
+# `∇meanpool!` calls dispatch to the 1D (rank-3) cuDNN methods below as needed.
+# (`maxpool` has no canonical complex extension — `max` is undefined for complex
+# numbers, and the CPU path errors too — so it is intentionally not supported.)
+function meanpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
+                   count_include_pad::Bool=true) where T<:CUDNNComplexFloat
+    xr, xi = reim(x)
+    yr = meanpool!(similar(y, real(T)), xr, pdims; count_include_pad)
+    yi = meanpool!(similar(y, real(T)), xi, pdims; count_include_pad)
+    @. y = complex(yr, yi)
+    return y
+end
+
+function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T},
+                    pdims::PoolDims; count_include_pad::Bool=true) where T<:CUDNNComplexFloat
+    dyr, dyi = reim(dy)
+    yr, yi = reim(y)
+    xr, xi = reim(x)
+    dxr = ∇meanpool!(similar(dx, real(T)), dyr, yr, xr, pdims; count_include_pad)
+    dxi = ∇meanpool!(similar(dx, real(T)), dyi, yi, xi, pdims; count_include_pad)
+    @. dx = complex(dxr, dxi)
+    return dx
+end
+
 ### Since CUDA.jl does not support 1D pooling, we have to convert to 2d
 
 add1d(x) = reshape(x, 1, size(x)...)

--- a/ext/NNlibCUDACUDNNExt/pooling.jl
+++ b/ext/NNlibCUDACUDNNExt/pooling.jl
@@ -44,33 +44,6 @@ function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{
     return dx
 end
 
-# Complex mean pooling (fixes https://github.com/FluxML/NNlib.jl/issues/610).
-# Mean pooling is linear, so we pool the real and imaginary parts independently
-# with cuDNN and recombine. This matches the CPU path, where complex `meanpool`
-# already works. These handle any spatial rank: the inner real `meanpool!`/
-# `∇meanpool!` calls dispatch to the 1D (rank-3) cuDNN methods below as needed.
-# (`maxpool` has no canonical complex extension — `max` is undefined for complex
-# numbers, and the CPU path errors too — so it is intentionally not supported.)
-function meanpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
-                   count_include_pad::Bool=true) where T<:CUDNNComplexFloat
-    xr, xi = reim(x)
-    yr = meanpool!(similar(y, real(T)), xr, pdims; count_include_pad)
-    yi = meanpool!(similar(y, real(T)), xi, pdims; count_include_pad)
-    @. y = complex(yr, yi)
-    return y
-end
-
-function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T},
-                    pdims::PoolDims; count_include_pad::Bool=true) where T<:CUDNNComplexFloat
-    dyr, dyi = reim(dy)
-    yr, yi = reim(y)
-    xr, xi = reim(x)
-    dxr = ∇meanpool!(similar(dx, real(T)), dyr, yr, xr, pdims; count_include_pad)
-    dxi = ∇meanpool!(similar(dx, real(T)), dyi, yi, xi, pdims; count_include_pad)
-    @. dx = complex(dxr, dxi)
-    return dx
-end
-
 ### Since CUDA.jl does not support 1D pooling, we have to convert to 2d
 
 add1d(x) = reshape(x, 1, size(x)...)

--- a/src/pooling.jl
+++ b/src/pooling.jl
@@ -132,6 +132,30 @@ for backend in (Symbol(), :_direct)
     end
 end
 
+# Complex mean pooling (https://github.com/FluxML/NNlib.jl/issues/610).
+#
+# Mean pooling is linear, so it extends to complex inputs by pooling the real and
+# imaginary parts independently and recombining. Doing this once here, in terms of
+# the real-valued `meanpool`/`∇meanpool`, gives complex support to every backend
+# that pools real arrays (CPU, cuDNN, MIOpen, ...) for free — no per-backend method.
+# Differentiation flows through the same split: the `meanpool` `rrule` below is
+# restricted to real `x`, so for complex `x` the AD engine differentiates the two
+# real `meanpool` calls (each picking up its backend's own rule) and the `complex.`
+# recombination.
+#
+# `maxpool`/`lpnormpool` are not extended: `max` and the p-norm are undefined for
+# complex numbers, so they keep erroring (as they already do on the CPU path).
+function meanpool(x::AbstractArray{<:Complex,N}, pdims::PoolDims; kwargs...) where {N}
+    return complex.(meanpool(real(x), pdims; kwargs...),
+                    meanpool(imag(x), pdims; kwargs...))
+end
+
+function ∇meanpool(dy::AbstractArray{<:Complex,N}, y::AbstractArray{<:Complex,N},
+                   x::AbstractArray{<:Complex,N}, pdims::PoolDims; kwargs...) where {N}
+    return complex.(∇meanpool(real(dy), real(y), real(x), pdims; kwargs...),
+                    ∇meanpool(imag(dy), imag(y), imag(x), pdims; kwargs...))
+end
+
 expand(N, i::Tuple) = i
 expand(N, i::Integer) = ntuple(_ -> i, N)
 
@@ -204,10 +228,13 @@ function lpnormpool(x, p::Real, k::NTuple{N, Integer}; pad=0, stride=k) where {N
 end
 
 
+# Restricted to real `x`: complex `meanpool` has no direct rule and is instead
+# differentiated through its real/imaginary split (see the complex `meanpool`
+# above), while complex `maxpool`/`lpnormpool` are unsupported.
 for pool in [:maxpool, :meanpool, :lpnormpool]
     ∇pool = Symbol(:∇, pool)
     pullback = Symbol(pool, :_pullback)
-    @eval function rrule(::typeof($pool), x, pdims::PoolDims; kw...)
+    @eval function rrule(::typeof($pool), x::AbstractArray{<:Real}, pdims::PoolDims; kw...)
         Ω = $pool(x, pdims; kw...)
         $pullback(Δ) = (NoTangent(), $∇pool(unthunk(Δ), Ω, x, pdims; kw...), NoTangent())
         return Ω, $pullback

--- a/test/ext_amdgpu/pool.jl
+++ b/test/ext_amdgpu/pool.jl
@@ -9,3 +9,33 @@
         gputest(x -> NNlib.meanpool(x, pdims), x)
     end
 end
+
+@testset "complex meanpool (issue #610)" begin
+    # Complex `meanpool` is implemented once in core (NNlib pools the real and
+    # imaginary parts separately), so MIOpen needs no complex-specific method: the
+    # real parts dispatch to MIOpen's real `meanpool` and its rrule. Gradients flow
+    # through AD (there is no standalone `∇meanpool` for `ROCArray`); we use a
+    # real-valued loss since Zygote rejects gradients of complex outputs. `maxpool`
+    # is unsupported (`max` is undefined for complex).
+    channels, batch = 3, 2
+    for nd in (1, 2, 3)
+        x = rand(ComplexF32, fill(8, nd)..., channels, batch)
+        pdims = PoolDims(x, 2)
+
+        # forward: GPU matches CPU and stays a complex ROCArray
+        y_c = NNlib.meanpool(x, pdims)
+        y_g = NNlib.meanpool(ROCArray(x), pdims)
+        @test y_g isa ROCArray{ComplexF32}
+        @test collect(y_g) ≈ y_c
+
+        # gradient via AD: GPU matches CPU and stays complex
+        loss(z) = abs2(sum(NNlib.meanpool(z, pdims)))
+        g_c = gradient(loss, x)[1]
+        g_g = gradient(loss, ROCArray(x))[1]
+        @test g_g isa ROCArray{ComplexF32}
+        @test collect(g_g) ≈ g_c rtol=1f-3
+
+        # maxpool has no complex extension (max is undefined for complex)
+        @test_throws Exception NNlib.maxpool(ROCArray(x), pdims)
+    end
+end

--- a/test/ext_cuda/pooling.jl
+++ b/test/ext_cuda/pooling.jl
@@ -28,3 +28,39 @@
         end
     end
 end
+
+@testset "complex meanpool (issue #610)" begin
+
+    # Mean pooling is linear, so the cuDNN extension supports complex inputs by
+    # pooling the real and imaginary parts independently. We check it agrees with
+    # the (generic) CPU path. `maxpool` is intentionally NOT supported, since
+    # `max` is undefined for complex numbers; it errors on both CPU and GPU.
+    # `gputest`'s gradient check goes through `mean`, which Zygote rejects for
+    # complex outputs, so we use `checkgrad=false` and compare `∇meanpool` directly.
+    for num_spatial_dims in (1, 2, 3)
+        C_in = 3
+        batch_size = 2
+        x = rand(ComplexF64, fill(8, num_spatial_dims)..., C_in, batch_size)
+
+        # no padding
+        pdims = PoolDims(x, 2)
+        y = meanpool(x, pdims)
+        dy = rand(ComplexF64, size(y))
+        @test eltype(meanpool(CuArray(x), pdims)) == ComplexF64
+        gputest(x -> meanpool(x, pdims), x, checkgrad=false)
+        gputest((dy, y, x) -> ∇meanpool(dy, y, x, pdims), dy, y, x, checkgrad=false)
+
+        # with padding: count_include_pad changes the result (issue #218)
+        pdims_pad = PoolDims(x, 2; padding=1, stride=2)
+        for cip in (true, false)
+            ym = meanpool(x, pdims_pad; count_include_pad=cip)
+            dym = rand(ComplexF64, size(ym))
+            gputest(x -> meanpool(x, pdims_pad; count_include_pad=cip), x, checkgrad=false)
+            gputest((dy, y, x) -> ∇meanpool(dy, y, x, pdims_pad; count_include_pad=cip),
+                    dym, ym, x, checkgrad=false)
+        end
+
+        # maxpool has no complex extension (max is undefined for complex)
+        @test_throws Exception maxpool(CuArray(x), pdims)
+    end
+end

--- a/test/ext_cuda/pooling.jl
+++ b/test/ext_cuda/pooling.jl
@@ -31,36 +31,36 @@ end
 
 @testset "complex meanpool (issue #610)" begin
 
-    # Mean pooling is linear, so the cuDNN extension supports complex inputs by
-    # pooling the real and imaginary parts independently. We check it agrees with
-    # the (generic) CPU path. `maxpool` is intentionally NOT supported, since
-    # `max` is undefined for complex numbers; it errors on both CPU and GPU.
-    # `gputest`'s gradient check goes through `mean`, which Zygote rejects for
-    # complex outputs, so we use `checkgrad=false` and compare `∇meanpool` directly.
+    # Complex `meanpool` is implemented once in core (NNlib pools the real and
+    # imaginary parts separately), so cuDNN needs no complex-specific method; the
+    # real parts dispatch to the real cuDNN `meanpool`. We check the result and its
+    # gradient agree with the CPU path. The gradient goes through AD (the `meanpool`
+    # rrule is real-only, so AD differentiates the split); we use a real-valued loss
+    # since Zygote rejects gradients of complex outputs. `maxpool` is unsupported
+    # (`max` is undefined for complex) and errors on both CPU and GPU.
     for num_spatial_dims in (1, 2, 3)
         C_in = 3
         batch_size = 2
         x = rand(ComplexF64, fill(8, num_spatial_dims)..., C_in, batch_size)
 
-        # no padding
-        pdims = PoolDims(x, 2)
-        y = meanpool(x, pdims)
-        dy = rand(ComplexF64, size(y))
-        @test eltype(meanpool(CuArray(x), pdims)) == ComplexF64
-        gputest(x -> meanpool(x, pdims), x, checkgrad=false)
-        gputest((dy, y, x) -> ∇meanpool(dy, y, x, pdims), dy, y, x, checkgrad=false)
+        for pdims in (PoolDims(x, 2), PoolDims(x, 2; padding=1, stride=2))
+            for cip in (true, false)
+                # forward: GPU matches CPU and stays complex
+                y_c = meanpool(x, pdims; count_include_pad=cip)
+                y_g = meanpool(CuArray(x), pdims; count_include_pad=cip)
+                @test y_g isa CuArray{ComplexF64}
+                @test collect(y_g) ≈ y_c
 
-        # with padding: count_include_pad changes the result (issue #218)
-        pdims_pad = PoolDims(x, 2; padding=1, stride=2)
-        for cip in (true, false)
-            ym = meanpool(x, pdims_pad; count_include_pad=cip)
-            dym = rand(ComplexF64, size(ym))
-            gputest(x -> meanpool(x, pdims_pad; count_include_pad=cip), x, checkgrad=false)
-            gputest((dy, y, x) -> ∇meanpool(dy, y, x, pdims_pad; count_include_pad=cip),
-                    dym, ym, x, checkgrad=false)
+                # gradient via AD: GPU matches CPU and stays complex
+                loss(z) = abs2(sum(meanpool(z, pdims; count_include_pad=cip)))
+                g_c = gradient(loss, x)[1]
+                g_g = gradient(loss, CuArray(x))[1]
+                @test g_g isa CuArray{ComplexF64}
+                @test collect(g_g) ≈ g_c
+            end
         end
 
         # maxpool has no complex extension (max is undefined for complex)
-        @test_throws Exception maxpool(CuArray(x), pdims)
+        @test_throws Exception maxpool(CuArray(x), PoolDims(x, 2))
     end
 end

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -990,10 +990,10 @@ end
 end
 
 @testset "complex meanpool (issue #610)" begin
-    # Mean pooling is linear, so it extends to complex inputs by pooling the real
-    # and imaginary parts independently. This is the reference behaviour that the
-    # GPU/cuDNN extension mirrors. `maxpool` is not supported for complex inputs,
-    # since `max` is undefined for complex numbers.
+    # Mean pooling is linear, so complex support is implemented once in core by
+    # pooling the real and imaginary parts independently (and is shared by every
+    # backend). `maxpool` is not supported for complex inputs, since `max` is
+    # undefined for complex numbers.
     for nsd in (1, 2, 3)
         x = rand(ComplexF64, fill(7, nsd)..., 3, 2)
         for pdims in (PoolDims(x, 2), PoolDims(x, 2; padding=1, stride=2))
@@ -1004,12 +1004,23 @@ end
                 @test real(y) ≈ meanpool(real(x), pdims; count_include_pad=cip)
                 @test imag(y) ≈ meanpool(imag(x), pdims; count_include_pad=cip)
 
-                # backward also splits over real/imaginary parts
+                # `∇meanpool` also splits over real/imaginary parts
                 dy = rand(ComplexF64, size(y))
                 dx = ∇meanpool(dy, y, x, pdims; count_include_pad=cip)
                 @test eltype(dx) == ComplexF64
                 @test real(dx) ≈ ∇meanpool(real(dy), real(y), real(x), pdims; count_include_pad=cip)
                 @test imag(dx) ≈ ∇meanpool(imag(dy), imag(y), imag(x), pdims; count_include_pad=cip)
+
+                # AD goes through the same split (the `meanpool` rrule is real-only):
+                # check against a finite-difference-free reference built from the
+                # real-input rrule on each part.
+                g = gradient(z -> abs2(sum(meanpool(z, pdims; count_include_pad=cip))), x)[1]
+                gref = gradient(z -> abs2(sum(meanpool(z, pdims; count_include_pad=cip))),
+                                real(x))[1] .+
+                       im .* gradient(z -> abs2(sum(meanpool(z, pdims; count_include_pad=cip))),
+                                      imag(x))[1]
+                @test eltype(g) == ComplexF64
+                @test g ≈ gref
             end
         end
 

--- a/test/pooling.jl
+++ b/test/pooling.jl
@@ -989,6 +989,35 @@ end
     end
 end
 
+@testset "complex meanpool (issue #610)" begin
+    # Mean pooling is linear, so it extends to complex inputs by pooling the real
+    # and imaginary parts independently. This is the reference behaviour that the
+    # GPU/cuDNN extension mirrors. `maxpool` is not supported for complex inputs,
+    # since `max` is undefined for complex numbers.
+    for nsd in (1, 2, 3)
+        x = rand(ComplexF64, fill(7, nsd)..., 3, 2)
+        for pdims in (PoolDims(x, 2), PoolDims(x, 2; padding=1, stride=2))
+            for cip in (true, false)
+                y = meanpool(x, pdims; count_include_pad=cip)
+                @test eltype(y) == ComplexF64
+                # pooling commutes with taking real/imaginary parts
+                @test real(y) ≈ meanpool(real(x), pdims; count_include_pad=cip)
+                @test imag(y) ≈ meanpool(imag(x), pdims; count_include_pad=cip)
+
+                # backward also splits over real/imaginary parts
+                dy = rand(ComplexF64, size(y))
+                dx = ∇meanpool(dy, y, x, pdims; count_include_pad=cip)
+                @test eltype(dx) == ComplexF64
+                @test real(dx) ≈ ∇meanpool(real(dy), real(y), real(x), pdims; count_include_pad=cip)
+                @test imag(dx) ≈ ∇meanpool(imag(dy), imag(y), imag(x), pdims; count_include_pad=cip)
+            end
+        end
+
+        # maxpool has no complex extension (max is undefined for complex)
+        @test_throws Exception maxpool(x, PoolDims(x, 2))
+    end
+end
+
 @testset "AutoDiff: spatial_rank=$spatial_rank" for spatial_rank in (1, 2)
   # Use an input with distinct, well-separated values so that every pooling window has
   # a unique maximum. `maxpool` is non-differentiable at ties, where finite differences


### PR DESCRIPTION
Fixes #610.

## What

Adds complex-number support for `meanpool`. Mean pooling is linear, so complex inputs are handled by pooling the real and imaginary parts independently and recombining.

This is implemented **once, in the generic code** (`src/pooling.jl`):

```julia
meanpool(x::AbstractArray{<:Complex,N}, pdims; kwargs...) =
    complex.(meanpool(real(x), pdims; kwargs...), meanpool(imag(x), pdims; kwargs...))
```

so every backend that pools real arrays gets complex support for free — **no per-backend method**. The real sub-arrays dispatch to whatever real `meanpool` the backend provides (CPU, cuDNN, MIOpen).

```julia
meanpool(cu(rand(ComplexF64, 8,8,3,2)), PoolDims(x, 2))   # CUDA
meanpool(roc(rand(ComplexF32, 8,8,3,2)), PoolDims(x, 2))   # AMDGPU
```

## Gradients

The `maxpool`/`meanpool`/`lpnormpool` rrules are now restricted to real `x`. For complex `x` there is no rrule, so AD differentiates the real/imaginary split directly — each real `meanpool` call picks up **its own backend's rule**. This is what makes complex gradients work on **AMDGPU**, where the backward pass is only reachable through the rrule (there is no standalone `∇meanpool` for `ROCArray`). A complex `∇meanpool` is also provided for direct (non-AD) use on CPU/cuDNN.

## Scope

- **CPU, CUDA, AMDGPU**: complex `meanpool` supported.
- **Metal**: skipped — it has no pooling backend at all (not even real), so there is nothing to extend.
- **maxpool / lpnormpool**: intentionally unsupported for complex — `max` and the p-norm are undefined for complex numbers, so they error on every backend; the tests assert this.

## Tests

- **CPU** (`test/pooling.jl`): pooling commutes with `real`/`imag` (forward and `∇meanpool`); AD matches the real-rrule split.
- **CUDA** (`test/ext_cuda/pooling.jl`): forward and AD gradient agree with CPU across 1D/2D/3D, with/without padding, and both `count_include_pad` modes; output stays complex; `maxpool` throws.
- **AMDGPU** (`test/ext_amdgpu/pool.jl`): forward and AD gradient agree with CPU across 1D/2D/3D; `maxpool` throws.

Verified on an NVIDIA TITAN RTX: CPU and CUDA testsets pass, real-valued pooling is unaffected, no new method ambiguities, and the real `meanpool` gradient matches finite differences. The AMDGPU tests follow the same structure but require AMD hardware (run via `NNLIB_TEST_AMDGPU=true`), so they were not exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
