### PR TITLE
Make padding functions and stft type-stable (#702)

### DIFF
--- a/ext/NNlibFFTWExt/stft.jl
+++ b/ext/NNlibFFTWExt/stft.jl
@@ -34,15 +34,15 @@ function NNlib.stft(x;
     n_frames = 1 + (n - n_fft) ÷ hop_length
 
     # time2col.
-    # Reshape `x` to (n_fft, n_frames, B) if needed.
-    # Each row in `n_frames` is shifted by `hop_length`.
-    if n_frames > 1
-        # TODO can be more efficient if we support something like torch.as_strided
-        ids = [
-            row + hop_length * col
-            for row in 1:n_fft, col in 0:(n_frames - 1)]
-        x = @inbounds x[ids, ntuple(_ -> Colon(), ndims(x) - 1)...]
-    end
+    # Reshape `x` to (n_fft, n_frames, B). Each column in `n_frames` is
+    # shifted by `hop_length`. This is done unconditionally (even when
+    # `n_frames == 1`) so that the output rank does not depend on the runtime
+    # value of `n_frames`, keeping `stft` type-stable (see issue #702).
+    # TODO can be more efficient if we support something like torch.as_strided
+    ids = [
+        row + hop_length * col
+        for row in 1:n_fft, col in 0:(n_frames - 1)]
+    x = @inbounds x[ids, ntuple(_ -> Colon(), ndims(x) - 1)...]
 
     region = 1
     use_window && (x = x .* window;)

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -204,20 +204,27 @@ function pad_repeat(x::AbstractArray, pad::NTuple{M,Int};
   return x
 end
 
-function pad_repeat(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
+# `dims` is forwarded as a `Val` so that `selectdim` and `cat` have a
+# compile-time-constant dimension and the method stays type-stable (see #702).
+@inline function pad_repeat(x::AbstractArray{F,N}, pad::NTuple{2,Int};
                     dims::Int = 1) where {F,N}
+  return _pad_repeat(x, pad, Val(dims))
+end
+
+function _pad_repeat(x::AbstractArray{F,N}, pad::NTuple{2,Int},
+                     ::Val{dims}) where {F,N,dims}
   lpad, rpad = pad
 
   xlborder = selectdim(x, dims, 1:1)
-  nrepl = ntuple(i -> i == dims ? lpad : 1, N)
+  nrepl = ntuple(i -> i == dims ? lpad : 1, Val(N))
   xl = repeat(xlborder, outer = nrepl)
 
   n = size(x, dims)
   xrborder = selectdim(x, dims, n:n)
-  nrepr = ntuple(i -> i == dims ? rpad : 1, N)
+  nrepr = ntuple(i -> i == dims ? rpad : 1, Val(N))
   xr = repeat(xrborder, outer = nrepr)
 
-  return cat(xl, x, xr, dims = dims)
+  return cat(xl, x, xr; dims=Val(dims))
 end
 
 """
@@ -265,18 +272,29 @@ function pad_reflect(x::AbstractArray, pad::NTuple{M,Int};
   return x
 end
 
-function pad_reflect(
+# `dims` is forwarded as a `Val` so that `selectdim` and `cat` below have a
+# compile-time-constant dimension. Otherwise the return type of `cat(...; dims)`
+# widens to `Any` (a runtime `dims` is type-unstable), which propagates up
+# through `stft` (see https://github.com/FluxML/NNlib.jl/issues/702). The
+# `@inline` lets a literal `dims` keyword constant-propagate into `Val(dims)`.
+@inline function pad_reflect(
   x::AbstractArray{F,N}, pad::NTuple{2,Int}; dims::Int = 1,
 ) where {F,N}
+  return _pad_reflect(x, pad, Val(dims))
+end
+
+function _pad_reflect(
+  x::AbstractArray{F,N}, pad::NTuple{2,Int}, ::Val{dims},
+) where {F,N,dims}
   lpad, rpad = pad
   n = size(x, dims)
   xl = lpad == 0 ?
-    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), ndims(x))) :
+    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), Val(N))) :
     reverse(selectdim(x, dims, 2:lpad+1); dims)
   xr = rpad == 0 ?
-    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), ndims(x))) :
+    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), Val(N))) :
     reverse(selectdim(x, dims, n-rpad:n-1); dims)
-  return cat(xl, x, xr; dims)
+  return cat(xl, x, xr; dims=Val(dims))
 end
 
 """
@@ -324,19 +342,27 @@ function pad_symmetric(x::AbstractArray, pad::NTuple{M,Int};
   return x
 end
 
-function pad_symmetric(
+# `dims` is forwarded as a `Val` so that `selectdim` and `cat` have a
+# compile-time-constant dimension and the method stays type-stable (see #702).
+@inline function pad_symmetric(
   x::AbstractArray{F,N}, pad::NTuple{2,Int}; dims::Int = 1,
 ) where {F,N}
+  return _pad_symmetric(x, pad, Val(dims))
+end
+
+function _pad_symmetric(
+  x::AbstractArray{F,N}, pad::NTuple{2,Int}, ::Val{dims},
+) where {F,N,dims}
   lpad, rpad = pad
   n = size(x, dims)
 
   xl = lpad == 0 ?
-    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), ndims(x))) :
+    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), Val(N))) :
     reverse(selectdim(x, dims, 1:lpad); dims)
   xr = rpad == 0 ?
-    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), ndims(x))) :
+    similar(x, ntuple(i -> i == dims ? 0 : size(x, i), Val(N))) :
     reverse(selectdim(x, dims, n-rpad+1:n); dims)
-  return cat(xl, x, xr; dims)
+  return cat(xl, x, xr; dims=Val(dims))
 end
 
 """
@@ -388,23 +414,32 @@ function pad_circular(x::AbstractArray, pad::NTuple{M,Int};
   return x
 end
 
-function pad_circular(x::AbstractArray{F,N}, pad::NTuple{2,Int}; 
+# `dims` is forwarded as a `Val` so that `selectdim` and `cat` have a
+# compile-time-constant dimension and the method stays type-stable (see #702).
+@inline function pad_circular(x::AbstractArray{F,N}, pad::NTuple{2,Int};
                      dims::Int = 1) where {F,N}
+  return _pad_circular(x, pad, Val(dims))
+end
+
+function _pad_circular(x::AbstractArray{F,N}, pad::NTuple{2,Int},
+                       ::Val{dims}) where {F,N,dims}
   lpad, rpad = pad
   n = size(x, dims)
 
   xl = selectdim(x, dims, n-lpad+1:n)
   xr = selectdim(x, dims, 1:rpad)
-  return cat(xl, x, xr, dims = dims)
+  return cat(xl, x, xr; dims=Val(dims))
 end
 
-# convenience methods for symmetric and homogeneous padding
-pad_repeat(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
+# Convenience methods for symmetric and homogeneous padding.
+# `@inline` so a literal scalar `dims` (e.g. `pad_reflect(x, n; dims=1)` from
+# `stft`) constant-propagates into the type-stable `Val`-based kernels above.
+@inline pad_repeat(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
   pad_repeat(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
-pad_reflect(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
+@inline pad_reflect(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
   pad_reflect(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
-pad_symmetric(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
+@inline pad_symmetric(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
   pad_symmetric(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
-pad_circular(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
+@inline pad_circular(x::AbstractArray{F,N}, pad::Int; dims=1:N-2) where {F,N} =
   pad_circular(x, ntuple(_ -> pad, 2length(dims)); dims = dims)
 

--- a/test/testsuite/spectral.jl
+++ b/test/testsuite/spectral.jl
@@ -39,10 +39,10 @@ function spectral_testsuite(Backend)
 
         @testset "Batch $batch" begin
             x = device(ones(Float32, 16, batch...))
-            # TODO fix type stability for pad_reflect
-            # @inferred stft(x; n_fft=16)
 
             bd = ntuple(_ -> Colon(), length(batch))
+
+            @inferred stft(x; n_fft=16)
 
             y = stft(x; n_fft=16)
             @test size(y) == (9, 5, batch...)


### PR DESCRIPTION
## Summary

Addresses the `test/testsuite/spectral.jl` item in #702: the `@inferred stft(x; n_fft=16)` test was disabled with a *"TODO fix type stability for `pad_reflect`"* comment. There were **two** distinct sources of instability:

1. **Padding kernels.** The single-dimension kernels (`pad_reflect`, `pad_symmetric`, `pad_circular`, `pad_repeat`) forward a runtime `dims::Int` into `cat(...; dims)`, whose return type widens to `Any` unless `dims` is a compile-time constant. That `Any` propagated up through `stft`.
2. **`stft` itself.** It gathered `x` only inside `if n_frames > 1`, changing the array rank on a runtime-dependent branch, so inference unioned the two possible shapes.

## Changes

- **`src/padding.jl`** — split each kernel into an `@inline` boundary that forwards `Val(dims)` to a type-stable worker using `cat(...; dims=Val(dims))` and `ntuple(..., Val(N))`. The `pad_*(x, pad::Int; dims)` convenience methods are marked `@inline` so a literal scalar `dims` (as `stft` passes) constant-propagates into the `Val`. **All four pad methods are now type-stable.**
- **`ext/NNlibFFTWExt/stft.jl`** — perform the time2col gather unconditionally, so the output rank no longer depends on the runtime `n_frames`. This also makes the output match the documented `(n_fft, n_frames, B)` shape; the old `n_frames == 1` path silently dropped the frames axis (a latent bug for batched single-frame inputs).
- **`test/testsuite/spectral.jl`** — re-enable the `@inferred stft` test.

## Verification

- `stft` now infers concretely: `Matrix{ComplexF32}` (1D) and `Array{ComplexF32, 3}` (batched).
- All four pad methods are type-stable for `dims=1`/`dims=2`, `Int`- and tuple-pad, on 1D/2D/3D arrays.
- Outputs match the docstring examples exactly; Zygote gradients agree with finite differences to ~1e-13; the CPU spectrogram-gradient NaN test still passes.
- `test/padding.jl` (52/52) and the spectral CPU testsuite (60/60) pass.

GPU gradient paths (`Backend != CPU`) were not run locally, but the operations (`cat`, `selectdim`, `repeat`, gather) are behaviorally unchanged — only the dimension is now passed as a compile-time constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)