### PR TITLE
Always use accurate cuDNN softmax algorithm (fixes #506)

### DIFF
--- a/ext/NNlibCUDACUDNNExt/softmax.jl
+++ b/ext/NNlibCUDACUDNNExt/softmax.jl
@@ -2,7 +2,7 @@ import NNlib: softmax, softmax!, ∇softmax, ∇softmax!,
               logsoftmax, logsoftmax!, ∇logsoftmax, ∇logsoftmax!
 
 using cuDNN: CUDNN_SOFTMAX_LOG, CUDNN_SOFTMAX_MODE_CHANNEL,
-             CUDNN_SOFTMAX_FAST, CUDNN_SOFTMAX_ACCURATE, cudnnSoftmaxForward!,
+             CUDNN_SOFTMAX_ACCURATE, cudnnSoftmaxForward!,
              cudnnSoftmaxBackward
 
 # Softmax
@@ -61,9 +61,12 @@ function softmaxdims(x, dims)
     return (1, stride, dimsize, batchsize)
 end
 
-# Determine softmax algo based on math_mode
+# Always use the accurate algorithm (subtracts the row max before exp). The fast
+# algorithm skips that and overflows to NaN on masked/large inputs, and is unsafe in
+# Float16. We deliberately do not honour CUDA.FAST_MATH here. See
+# https://github.com/FluxML/NNlib.jl/issues/506
 
-softmaxalgo() = (CUDA.math_mode()===CUDA.FAST_MATH ? CUDNN_SOFTMAX_FAST : CUDNN_SOFTMAX_ACCURATE)
+softmaxalgo() = CUDNN_SOFTMAX_ACCURATE
 
 # Main implementations:
 

--- a/test/ext_cuda/softmax.jl
+++ b/test/ext_cuda/softmax.jl
@@ -18,3 +18,49 @@
         # (Note that ∇softmax! does not depend on x, it's just there to disambiguate from an even older signature.)
     end
 end
+
+@testset "softmax with masked input (fixes #506)" begin
+    # The cuDNN FAST algorithm overflows to NaN on masked/large-magnitude inputs,
+    # so softmax must always use the ACCURATE algorithm regardless of CUDA.math_mode.
+    # This reproduces the attention-mask scenario from the issue (fill with -1000).
+    orig = CUDA.math_mode()
+    try
+        for mode in (CUDA.DEFAULT_MATH, CUDA.FAST_MATH)
+            CUDA.math_mode!(mode)
+
+            # (a) large finite negative mask, as in #506. Outputs stay finite, so we
+            #     can compare against the CPU reference directly.
+            x = randn(Float32, 128, 32)
+            x[1:64, :] .= -1f3        # masked entries
+            gx = cu(x)
+
+            gy = softmax(gx; dims=1)
+            @test all(isfinite, collect(gy))
+            @test collect(gy) ≈ softmax(x; dims=1) atol=1e-4
+
+            gly = logsoftmax(gx; dims=1)
+            @test all(isfinite, collect(gly))
+            @test collect(gly) ≈ logsoftmax(x; dims=1) atol=1e-4
+
+            # (b) hard -Inf mask. softmax must give exactly-0 (finite) at masked
+            #     positions; logsoftmax gives -Inf there (never NaN). Compare only
+            #     at the unmasked positions to avoid Inf-Inf=NaN inside `isapprox`.
+            xi = randn(Float32, 128, 32)
+            mask = falses(128, 32)
+            mask[1:64, :] .= true
+            xi[mask] .= -Inf32
+            gxi = cu(xi)
+
+            gyi = softmax(gxi; dims=1)
+            @test all(isfinite, collect(gyi))
+            @test all(collect(gyi)[mask] .== 0)
+            @test collect(gyi) ≈ softmax(xi; dims=1) atol=1e-4
+
+            glyi = collect(logsoftmax(gxi; dims=1))
+            @test !any(isnan, glyi)
+            @test glyi[.!mask] ≈ logsoftmax(xi; dims=1)[.!mask] atol=1e-4
+        end
+    finally
+        CUDA.math_mode!(orig)
+    end
+end


### PR DESCRIPTION
## Summary

The cuDNN softmax algorithm was selected from `CUDA.math_mode()`: under `CUDA.FAST_MATH` it used `CUDNN_SOFTMAX_FAST`, which skips the row-max subtraction and therefore overflows to `NaN` on masked or large-magnitude inputs (e.g. attention masks of `-1000` or `-Inf`), and is unsafe in `Float16`. This is the bug reported in #506.

This PR makes `softmaxalgo()` always return `CUDNN_SOFTMAX_ACCURATE`, regardless of the global fast-math setting. The accurate algorithm subtracts the row max before `exp`, which is exactly what's needed for masked inputs and low precision — and matches what PyTorch does (its native softmax kernels always do max-subtraction; PyTorch doesn't use cuDNN for softmax at all). `logsoftmax`/`∇logsoftmax` were already on `CUDNN_SOFTMAX_LOG`, which is likewise overflow-safe, so they were never affected.

## Changes

- `ext/NNlibCUDACUDNNExt/softmax.jl`: `softmaxalgo()` always returns `CUDNN_SOFTMAX_ACCURATE`; drop the now-unused `CUDNN_SOFTMAX_FAST` import.
- `test/ext_cuda/softmax.jl`: regression test running `softmax`/`logsoftmax` under both `DEFAULT_MATH` and `FAST_MATH` with large-negative (`-1000`) and hard `-Inf` attention masks, asserting finite outputs (no `NaN`), exactly-zero softmax at masked positions, and agreement with the CPU reference.

Fixes #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)