### PR TITLE
Add scaled_dot_product_attention with explicit head axis

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -39,8 +39,8 @@ trelu
 ## Attention 
 
 ```@docs
-dot_product_attention
-dot_product_attention_scores
+scaled_dot_product_attention
+scaled_dot_product_attention_scores
 make_causal_mask
 ```
 

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -44,7 +44,7 @@ end
 export sigmoid, hardsigmoid, logsigmoid, thresholdrelu, gelu # Aliases
 
 include("attention.jl")
-export dot_product_attention, dot_product_attention_scores, make_causal_mask
+export scaled_dot_product_attention, scaled_dot_product_attention_scores, make_causal_mask
 
 include("dropout.jl")
 export dropout, dropout!

--- a/src/attention.jl
+++ b/src/attention.jl
@@ -3,92 +3,133 @@ const AA4{T} = AbstractArray{T,4}
 const AA{N,T} = AbstractArray{T,N}
 
 """
-    dot_product_attention(query, key, value, [bias]; [fdrop, mask, nheads])
+    scaled_dot_product_attention(query, key, value, [bias]; [fdrop, mask, scale, is_causal])
 
-Multihead dot product attention used in transformer architectures.
+Multihead dot product attention used in transformer architectures, with an explicit
+head axis as in PyTorch.
 
-The input arrays must have the first two dimensions given by the number of features
-and the sequence length, then an arbitrary number of batch dimensions or none.
+The input arrays must have the shape `(head_dim, nheads, seq_len, batch_size...)`, that
+is a feature (head) dimension, a heads dimension, a sequence-length dimension, then an
+arbitrary number of batch dimensions or none. The number of heads is taken from the
+second dimension of each input, so no `nheads` keyword is needed.
 
+Grouped-query attention (GQA) is supported: if `key` and `value` have fewer heads than
+`query`, they are shared across query heads. The number of query heads must then be
+divisible by the number of key/value heads.
 
-Returns the attention output array of size `(v_dim, q_len, batch_size...)` and the attention scores
+Returns the attention output array of size `(v_head_dim, nheads, q_len, batch_size...)`.
+
+See also [`scaled_dot_product_attention_scores`](@ref) if you need the attention scores
 of size `(kv_len, q_len, nheads, batch_size...)`.
-
-See also [`dot_product_attention_scores`](@ref) if you only need the attention scores.
 
 # Arguments
 
-- `query`: Query array of size `(qk_dim, q_len, batch_size...)`.
-- `key`: Key array of size `(qk_dim, kv_len, batch_size...)`.
-- `value`: Value array of size `(v_dim, kv_len, batch_size...)`.
+- `query`: Query array of size `(qk_head_dim, nheads, q_len, batch_size...)`.
+- `key`: Key array of size `(qk_head_dim, nkvheads, kv_len, batch_size...)`.
+- `value`: Value array of size `(v_head_dim, nkvheads, kv_len, batch_size...)`.
 - `bias`: Either `nothing` or an array broadcastable to size `(kv_len, q_len, nheads, batch_size)`.
           It will be added to the attention scores before applying the softmax. Default `nothing`.
 - `fdrop`: A dropout function or layer to be applied on the attention scores right after the softmax.
            Default `identity` (no dropout).
 - `mask`: Either `nothing` or a boolean array broadcastable to size `(kv_len, q_len, nheads, batch_size)`.
           The mask is applied to the attention scores just before the softmax.
-          See [`make_causal_mask`](@ref) fore creating causal masks. Default `nothing`.
-- `nheads`: Number of heads to split the input arrays into. Default `1`.
+          See [`make_causal_mask`](@ref) for creating causal masks. Default `nothing`.
+          Cannot be used together with `is_causal=true`.
+- `scale`: The denominator used to scale the `queryᵀ * key` dot products before
+          the softmax. Default `nothing`, meaning `√(qk_head_dim)`.
+- `is_causal`: If `true`, a causal mask is applied so that each query position can
+          only attend to key positions up to and including its own. Convenience for
+          `mask = make_causal_mask(...)`; cannot be combined with `mask`. Default `false`.
 
 # Examples
 
 ```julia
-q, k, v = rand(10, 20, 2), rand(10, 30, 2), rand(20, 30, 2)
-y, α = dot_product_attention(q, k, v)
+# (head_dim, nheads, seq_len, batch)
+q = rand(Float32, 16, 8, 20, 4)
+k = v = rand(Float32, 16, 8, 30, 4)
+y = scaled_dot_product_attention(q, k, v)
+# size(y) == (16, 8, 20, 4)
+
+# grouped-query attention: 8 query heads sharing 2 key/value heads
+q = rand(Float32, 16, 8, 20, 4)
+k = v = rand(Float32, 16, 2, 30, 4)
+y = scaled_dot_product_attention(q, k, v)
 ```
 """
-function dot_product_attention(q::AA{N}, k::AA{N}, v::AA{N}, args...; kws...) where N
-    batch_size = size(q)[3:end]
-    batch_size == size(k)[3:end] == size(v)[3:end] || throw(ArgumentError("Batch dimensions have to be the same."))
-    q, k, v = map(x -> reshape(x, size(x, 1), size(x, 2), :), (q, k, v))
-
-    x, α = dot_product_attention(q, k, v, args...; kws...)
-
-    x = reshape(x, size(x, 1), size(x, 2), batch_size...)
-    α = reshape(α, size(α)[1:3]..., batch_size...)
-    return x, α
+function scaled_dot_product_attention(q::AA{N}, k::AA{N}, v::AA{N}, bias=nothing;
+            kws...) where N
+    x, _ = _scaled_dot_product_attention(q, k, v, bias; kws...)
+    return x
 end
 
-function dot_product_attention(q::AA3, k::AA3, v::AA3, bias=nothing;
-            fdrop=identity, mask=nothing, nheads=1)
+# Shared implementation returning both the attention output and the scores `α`,
+# so the (deprecated) `dot_product_attention` can return a consistent `(x, α)` pair
+# without applying a stochastic `fdrop` twice.
+function _scaled_dot_product_attention(q::AA{N}, k::AA{N}, v::AA{N}, bias=nothing;
+            fdrop=identity, mask=nothing, scale=nothing, is_causal::Bool=false) where N
 
-    (all(size.((q, k, v), 1) .% nheads .== 0)) || throw(ArgumentError("""
-    First dimension in query, key and value must be divisible by `nheads`.
-    Instead:
+    N >= 3 || throw(ArgumentError(
+        "Inputs must have at least 3 dimensions (head_dim, nheads, seq_len). Got $(N)."))
+
+    size(q, 1) == size(k, 1) || throw(ArgumentError("""
+    Head dimension (first dimension) of query and key has to be the same. Instead:
     - size(q): $(size(q))
     - size(k): $(size(k))
-    - size(v): $(size(v))
-    - nheads: $nheads
     """))
-    (size(q, 3) == size(k, 3) == size(v, 3)) || throw(ArgumentError("""
+    size(k, 2) == size(v, 2) || throw(ArgumentError("""
+    Number of heads (second dimension) of key and value has to be the same. Instead:
+    - size(k): $(size(k))
+    - size(v): $(size(v))
+    """))
+    size(k, 3) == size(v, 3) || throw(ArgumentError("""
+    Sequence length (third dimension) of key and value has to be the same. Instead:
+    - size(k): $(size(k))
+    - size(v): $(size(v))
+    """))
+    size(q)[4:end] == size(k)[4:end] == size(v)[4:end] || throw(ArgumentError("""
     Batch dimensions have to be the same. Instead:
     - size(q): $(size(q))
     - size(k): $(size(k))
     - size(v): $(size(v))
     """))
-    size(q, 1) == size(k, 1) || throw(ArgumentError("""
-    First dimension in query and key has to be the same. Instead:
-    - size(q): $(size(q))
-    - size(k): $(size(k))
+    nheads, nkvheads = size(q, 2), size(k, 2)
+    (nheads % nkvheads == 0) || throw(ArgumentError("""
+    Number of query heads must be divisible by the number of key/value heads
+    (grouped-query attention). Instead:
+    - nheads (size(q, 2)): $nheads
+    - nkvheads (size(k, 2)): $nkvheads
     """))
-    size(k, 2) == size(v, 2) || throw(ArgumentError("""
-    Second dimension in key and value has to be the same. Instead:
-    - size(k): $(size(k))
-    - size(v): $(size(v))
-    """))
+    (is_causal && mask !== nothing) && throw(ArgumentError(
+        "`mask` and `is_causal=true` cannot be specified at the same time."))
 
-    # Multihead attention. TODO create fastpath for singlehead attention.
-    q, k, v = split_heads.((q, k, v), nheads)
-    x, α = _dot_product_attention(q, k, v, bias, fdrop, mask)
-    return join_heads(x), α
+    if is_causal
+        mask = make_causal_mask(q, size(k, 3), size(q, 3))
+    end
+
+    batch_size = size(q)[4:end]
+    # collapse the batch dimensions into a single one
+    q, k, v = map(x -> reshape(x, size(x, 1), size(x, 2), size(x, 3), :), (q, k, v))
+    if nkvheads != nheads
+        # Grouped-query attention: expand the kv heads so each group of
+        # `nheads ÷ nkvheads` query heads shares one key/value head.
+        r = nheads ÷ nkvheads
+        k = repeat_kv_heads(k, r)
+        v = repeat_kv_heads(v, r)
+    end
+
+    x, α = _attention(q, k, v, bias, fdrop, mask, scale)
+
+    x = reshape(x, size(x, 1), size(x, 2), size(x, 3), batch_size...)
+    α = reshape(α, size(α)[1:3]..., batch_size...)
+    return x, α
 end
 
-function _dot_product_attention(q::AA4, k::AA4, v::AA4, bias, fdrop, mask)
-    # [q] = [qk_dim ÷ nheads, nheads, q_len, batch_size]
-    # [k] = [qk_dim ÷ nheads, nheads, kv_len, batch_size]
-    # [v] = [v_dim ÷ nheads, nheads, kv_len, batch_size]
+function _attention(q::AA4, k::AA4, v::AA4, bias, fdrop, mask, scale)
+    # [q] = [qk_head_dim, nheads, q_len, batch_size]
+    # [k] = [qk_head_dim, nheads, kv_len, batch_size]
+    # [v] = [v_head_dim,  nheads, kv_len, batch_size]
 
-    α = dot_product_attention_scores(q, k, bias; fdrop, mask)
+    α = _attention_scores(q, k, bias, fdrop, mask, scale)
     # [α] = [kv_len, q_len, nheads, batch_size]
 
     # The following permutedims and batched_mul are equivalent to
@@ -96,26 +137,58 @@ function _dot_product_attention(q::AA4, k::AA4, v::AA4, bias, fdrop, mask)
     vt = permutedims(v, (1, 3, 2, 4))
     x = batched_mul(vt, α)
     x = permutedims(x, (1, 3, 2, 4))
-    # [x] = [kv_dim ÷ nheads, nheads, q_len, batch_size]
+    # [x] = [v_head_dim, nheads, q_len, batch_size]
     return x, α
 end
 
 """
-    dot_product_attention_scores(query, key, [bias]; [fdrop, mask])
+    scaled_dot_product_attention_scores(query, key, [bias]; [fdrop, mask, scale, is_causal])
 
-Return the attention scores for the [`dot_product_attention`](@ref).
-Input arrays must have dimensions
-`(num_features ÷ nheads, nheads, sequence_length, batch_size)`.
+Return the attention scores for [`scaled_dot_product_attention`](@ref).
+Input arrays must have dimensions `(head_dim, nheads, seq_len, batch_size...)`.
 
-See [`dot_product_attention`](@ref) for more details.
+The `scale` keyword sets the denominator scaling the `queryᵀ * key` dot products;
+it defaults to `√(head_dim)`.
+
+See [`scaled_dot_product_attention`](@ref) for more details.
 """
-function dot_product_attention_scores(q::AA4{T}, k::AA4{T}, bias=nothing;
-            fdrop=identity, mask=nothing) where T
+function scaled_dot_product_attention_scores(q::AA{N}, k::AA{N}, bias=nothing;
+            fdrop=identity, mask=nothing, scale=nothing, is_causal::Bool=false) where N
 
+    N >= 3 || throw(ArgumentError(
+        "Inputs must have at least 3 dimensions (head_dim, nheads, seq_len). Got $(N)."))
+    size(q, 1) == size(k, 1) || throw(ArgumentError("""
+    Head dimension (first dimension) of query and key has to be the same. Instead:
+    - size(q): $(size(q))
+    - size(k): $(size(k))
+    """))
+    nheads, nkvheads = size(q, 2), size(k, 2)
+    (nheads % nkvheads == 0) || throw(ArgumentError(
+        "Number of query heads ($nheads) must be divisible by the number of \
+         key/value heads ($nkvheads)."))
+    (is_causal && mask !== nothing) && throw(ArgumentError(
+        "`mask` and `is_causal=true` cannot be specified at the same time."))
+
+    if is_causal
+        mask = make_causal_mask(q, size(k, 3), size(q, 3))
+    end
+
+    batch_size = size(q)[4:end]
+    q, k = map(x -> reshape(x, size(x, 1), size(x, 2), size(x, 3), :), (q, k))
+    if nkvheads != nheads
+        k = repeat_kv_heads(k, nheads ÷ nkvheads)
+    end
+
+    α = _attention_scores(q, k, bias, fdrop, mask, scale)
+    return reshape(α, size(α)[1:3]..., batch_size...)
+end
+
+function _attention_scores(q::AA4{T}, k::AA4, bias, fdrop, mask, scale) where T
+    s = scale === nothing ? √T(size(q, 1)) : T(scale)
     # The following permutedims and batched_mul are equivalent to
-    # @tullio logits[j, i, h, b] := q[d, h, i, b] * k[d, h, j, b] / √T(qk_dim)
+    # @tullio logits[j, i, h, b] := q[d, h, i, b] * k[d, h, j, b] / s
     kt = permutedims(k, (3, 1, 2, 4))
-    qt = permutedims(q, (1, 3, 2, 4)) ./ √T(size(q, 1))
+    qt = permutedims(q, (1, 3, 2, 4)) ./ s
     logits = batched_mul(kt, qt)
     # [logits] = [kv_len, q_len, nheads, batch_size]
 
@@ -139,24 +212,34 @@ end
 
 
 """
-    make_causal_mask(x, dims=2)
+    make_causal_mask(x, dims=3)
 
 Return a boolean square matrix `m` of the same type as `x` and of side `size(x, dims)`.
 Its elements are set such that `m[i, j] == i ≤ j`.
 
-Can be used to mask the attention scores in [`dot_product_attention`](@ref).
+Can be used to mask the attention scores in [`scaled_dot_product_attention`](@ref),
+whose inputs have the sequence-length along `dims=3`.
 """
-function make_causal_mask(x::AbstractArray; dims::Int=2)
+function make_causal_mask(x::AbstractArray; dims::Int=3)
   len = size(x, dims)
   mask = triu(trues_like(x, (len, len)))
   return mask
 end
+
+# Rectangular causal mask of size `(kvlen, qlen)` with `m[j, i] == j ≤ i`,
+# used internally by `scaled_dot_product_attention(...; is_causal=true)`.
+make_causal_mask(x::AbstractArray, kvlen::Int, qlen::Int) = triu(trues_like(x, (kvlen, qlen)))
 
 trues_like(x::AbstractArray, sz=size(x)) = fill!(similar(x, Bool, sz), true)
 falses_like(x::AbstractArray, sz=size(x)) = fill!(similar(x, Bool, sz), false)
 
 split_heads(x, nheads) = reshape(x, size(x, 1) ÷ nheads, nheads, size(x)[2:end]...)
 join_heads(x) = reshape(x, :, size(x)[3:end]...)
+
+# Grouped-query attention: repeat each kv head `r` times contiguously along the
+# heads dimension, so it lines up with the query heads.
+# [x] = [head_dim, nkvheads, len, batch] -> [head_dim, nkvheads * r, len, batch]
+repeat_kv_heads(x::AA4, r::Int) = repeat(x; inner=(1, r, 1, 1))
 
 @non_differentiable make_causal_mask(::Any...)
 @non_differentiable trues_like(::Any...)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -11,3 +11,26 @@ function ∇logsoftmax_data(dy::AbstractArray, y::AbstractArray; dims = 1)
     Base.depwarn("`∇logsoftmax_data(dy, y)` is deprecated, use `∇logsoftmax(dy, y)` instead.", :∇logsoftmax_data)
     return ∇logsoftmax(dy, y; dims)
 end
+
+
+# Old interface: heads are packed into the feature dimension and split via `nheads`,
+# inputs are `(features, seq_len, batch...)`, and the output heads are joined back.
+# The new `scaled_dot_product_attention` takes an explicit head axis instead.
+function dot_product_attention(q, k, v, bias=nothing;
+            nheads=1, nkvheads=nheads, kws...)
+    Base.depwarn("`dot_product_attention(q, k, v; nheads)` is deprecated, use \
+        `scaled_dot_product_attention(q, k, v)` with an explicit head axis \
+        `(head_dim, nheads, seq_len, batch...)` instead.", :dot_product_attention)
+    qh = split_heads(q, nheads)
+    kh = split_heads(k, nkvheads)
+    vh = split_heads(v, nkvheads)
+    x, α = _scaled_dot_product_attention(qh, kh, vh, bias; kws...)
+    return join_heads(x), α
+end
+
+# Old `dot_product_attention_scores` already used the explicit-head 4D convention.
+function dot_product_attention_scores(q, k, bias=nothing; kws...)
+    Base.depwarn("`dot_product_attention_scores` is deprecated, use \
+        `scaled_dot_product_attention_scores` instead.", :dot_product_attention_scores)
+    scaled_dot_product_attention_scores(q, k, bias; kws...)
+end

--- a/test/attention.jl
+++ b/test/attention.jl
@@ -1,35 +1,43 @@
 @testset "different batchsizes" begin
-    n = 15
+    head_dim = 5
     lenq = 3
     lenkv = 4
     for batch_size in [(), 1, 2, (2,1,3)], nheads in [1, 3, 5]
-        q = rand(Float32, n, lenq, batch_size...)
-        k = rand(Float32, n, lenkv, batch_size...)
-        v = rand(Float32, n, lenkv, batch_size...)
-        y, α = dot_product_attention(q, k, v; nheads)
+        q = rand(Float32, head_dim, nheads, lenq, batch_size...)
+        k = rand(Float32, head_dim, nheads, lenkv, batch_size...)
+        v = rand(Float32, head_dim, nheads, lenkv, batch_size...)
+        y = scaled_dot_product_attention(q, k, v)
+        α = scaled_dot_product_attention_scores(q, k)
         @test y isa Array{Float32}
-        @test size(y) == (n, lenq, batch_size...)
+        @test size(y) == (head_dim, nheads, lenq, batch_size...)
         @test size(α) == (lenkv, lenq, nheads, batch_size...)
         @test sum(α, dims=1) ≈ ones(1, lenq, nheads, batch_size...)
     end
 end
 
-@testset "dot_product_attention_scores" begin
-    q = k = reshape([1:24;], 4, 2, 3, 1) ./ 24
-    α = dot_product_attention_scores(q, k)
-    q2, k2 = reshape.((q, k), 8, 3, 1)
-    y, α2 = dot_product_attention(q2, k2, k2; nheads=2)
-    @test α ≈ α2
+@testset "scores ↔ output consistency" begin
+    q = rand(Float32, 4, 2, 3, 1)
+    k = v = rand(Float32, 4, 2, 5, 1)
+    α = scaled_dot_product_attention_scores(q, k)
+    y = scaled_dot_product_attention(q, k, v)
+    # y[:, h, i, b] = Σ_j α[j, i, h, b] * v[:, h, j, b]
+    yref = similar(y)
+    for b in 1:1, h in 1:2, i in 1:3
+        yref[:, h, i, b] = sum(α[j, i, h, b] .* v[:, h, j, b] for j in 1:5)
+    end
+    @test y ≈ yref
 end
 
 @testset "specific results" begin
-    q = k = v = reshape([1:12;], 4, 3, 1) ./ 12
-    y, α = dot_product_attention(q, k, v; nheads=2)
+    # (head_dim, nheads, seq_len, batch) = (2, 2, 3, 1)
+    q = k = v = reshape([1:12;] ./ 12, 2, 2, 3, 1)
+    y = scaled_dot_product_attention(q, k, v)
+    α = scaled_dot_product_attention_scores(q, k)
     ytrue = [0.429754, 0.513087, 0.613791, 0.697125, 0.46431, 0.547644, 0.647876, 0.73121, 0.49773, 0.581064, 0.680455, 0.763788]
     ytrue = reshape(ytrue, 4, 3, 1)
     αtrue = [0.313896, 0.332948, 0.353157, 0.264431, 0.328206, 0.407362, 0.219215, 0.31838, 0.462405, 0.288691, 0.331243, 0.380066, 0.241239, 0.323893, 0.434868, 0.198438, 0.311761, 0.489801]
     αtrue = reshape(αtrue, 3, 3, 2, 1)
-    @test y ≈ ytrue atol=1e-5
+    @test reshape(y, 4, 3, 1) ≈ ytrue atol=1e-5   # heads joined back for comparison
     @test α ≈ αtrue atol=1e-5
 end
 
@@ -38,39 +46,99 @@ end
     k = rand(4, 2, 5, 1)
 
     mask = rand(Bool, (5, 3))
-    α = dot_product_attention_scores(q, k; mask)
+    α = scaled_dot_product_attention_scores(q, k; mask)
     @test all((α[:,:,1,1].> 0) .== mask)
     @test all((α[:,:,2,1].> 0) .== mask)
 
     @testset "causal" begin
         x = rand(4, 2, 3, 1)
         mask = make_causal_mask(x, dims=3)
-        α = dot_product_attention_scores(x, x; mask)
+        α = scaled_dot_product_attention_scores(x, x; mask)
         @test all((α[:,:,1,1].> 0) .== mask)
         @test all((α[:,:,2,1].> 0) .== mask)
     end
 end
 
 @testset "dropout" begin
-    q = k = v = rand(10, 10, 10)
+    q = k = rand(5, 2, 10)
     fdrop(x, p) = (rand!(similar(x)) .> p) .* x ./ (1-p)
-    y, α = dot_product_attention(q, k, v; nheads=2, fdrop = x -> fdrop(x, 0.5))
+    α = scaled_dot_product_attention_scores(q, k; fdrop = x -> fdrop(x, 0.5))
     @test 0.6 > mean(>(0), α) > 0.4
 end
 
 @testset "bias" begin
-    q = rand(4, 5, 1)
-    k = v = rand(4, 3, 1)
+    q = rand(2, 2, 5, 1)
+    k = v = rand(2, 2, 3, 1)
     bias = randn(3, 5)
-    y, α = dot_product_attention(q, k, v, bias; nheads=2)
+    y = scaled_dot_product_attention(q, k, v, bias)
+    α = scaled_dot_product_attention_scores(q, k, bias)
     @test size(α) == (3, 5, 2, 1)
-    @test size(y) == (4, 5, 1)
+    @test size(y) == (2, 2, 5, 1)
 end
 
 @testset "gradient" begin
-    q = rand(4, 5, 1)
-    k = v = rand(4, 3, 1)
+    q = rand(2, 2, 5, 1)
+    k = v = rand(2, 2, 3, 1)
     bias = randn(3, 5)
-    y, α = dot_product_attention(q, k, v, bias; nheads=2)
-    gradtest((x...) -> dot_product_attention(x...; nheads=2)[1], q, k, v, bias)
+    gradtest((x...) -> scaled_dot_product_attention(x...), q, k, v, bias)
+end
+
+@testset "scale" begin
+    head_dim, nheads = 4, 2
+    q = rand(Float32, head_dim, nheads, 5, 1)
+    k = v = rand(Float32, head_dim, nheads, 3, 1)
+    # passing the default scale explicitly reproduces the default
+    α0 = scaled_dot_product_attention_scores(q, k)
+    α1 = scaled_dot_product_attention_scores(q, k; scale=sqrt(Float32(head_dim)))
+    @test α1 ≈ α0
+    # a different scale changes the result
+    α2 = scaled_dot_product_attention_scores(q, k; scale=1f0)
+    @test !(α2 ≈ α0)
+    # the output path accepts `scale` too
+    @test size(scaled_dot_product_attention(q, k, v; scale=2f0)) == (head_dim, nheads, 5, 1)
+end
+
+@testset "is_causal" begin
+    head_dim, nheads = 4, 2
+    x = rand(Float32, head_dim, nheads, 4, 1)
+    αcausal = scaled_dot_product_attention_scores(x, x; is_causal=true)
+    mask = make_causal_mask(x, dims=3)
+    αmask = scaled_dot_product_attention_scores(x, x; mask)
+    @test αcausal ≈ αmask
+    # lower triangle (key index > query index) must be masked out
+    @test all(all(αcausal[j, i, :, 1] .== 0) for j in 1:4, i in 1:4 if j > i)
+    # output path agrees
+    @test scaled_dot_product_attention(x, x, x; is_causal=true) ≈
+          scaled_dot_product_attention(x, x, x; mask)
+    # `mask` and `is_causal` are mutually exclusive
+    @test_throws ArgumentError scaled_dot_product_attention(x, x, x; mask, is_causal=true)
+end
+
+@testset "grouped-query attention" begin
+    head_dim, nheads, nkvheads = 4, 6, 2
+    q = rand(Float32, head_dim, nheads, 5, 2)
+    k = rand(Float32, head_dim, nkvheads, 3, 2)
+    v = rand(Float32, head_dim, nkvheads, 3, 2)
+
+    y = scaled_dot_product_attention(q, k, v)
+    α = scaled_dot_product_attention_scores(q, k)
+    @test size(y) == (head_dim, nheads, 5, 2)
+    @test size(α) == (3, 5, nheads, 2)
+    @test sum(α, dims=1) ≈ ones(Float32, 1, 5, nheads, 2)
+
+    # GQA must match standard MHA with the kv heads expanded along the heads axis
+    r = nheads ÷ nkvheads
+    kf = repeat(k; inner=(1, r, 1, 1))
+    vf = repeat(v; inner=(1, r, 1, 1))
+    @test y ≈ scaled_dot_product_attention(q, kf, vf)
+    @test α ≈ scaled_dot_product_attention_scores(q, kf)
+
+    # number of query heads must be divisible by the number of kv heads
+    badk = rand(Float32, head_dim, 4, 3, 2)   # 6 % 4 != 0
+    @test_throws ArgumentError scaled_dot_product_attention(q, badk, badk)
+
+    qd = rand(head_dim, nheads, 5, 2)
+    kd = rand(head_dim, nkvheads, 3, 2)
+    vd = rand(head_dim, nkvheads, 3, 2)
+    gradtest((qq, kk, vv) -> scaled_dot_product_attention(qq, kk, vv), qd, kd, vd)
 end

--- a/test/ext_amdgpu/attention.jl
+++ b/test/ext_amdgpu/attention.jl
@@ -1,23 +1,24 @@
 @testset "Compare CPU & GPU" begin
-    n = 15
+    head_dim = 5
     lenq = 3
     lenkv = 4
     for batch_size in [(), 1, 2, (2, 1, 3)], nheads in [1, 3, 5]
-        q = AMDGPU.rand(Float32, n, lenq, batch_size...)
-        k = AMDGPU.rand(Float32, n, lenkv, batch_size...)
-        v = AMDGPU.rand(Float32, n, lenkv, batch_size...)
-        y, α = @inferred dot_product_attention(q, k, v; nheads)
+        q = AMDGPU.rand(Float32, head_dim, nheads, lenq, batch_size...)
+        k = AMDGPU.rand(Float32, head_dim, nheads, lenkv, batch_size...)
+        v = AMDGPU.rand(Float32, head_dim, nheads, lenkv, batch_size...)
+        y = @inferred scaled_dot_product_attention(q, k, v)
+        α = scaled_dot_product_attention_scores(q, k)
 
         @test y isa ROCArray{Float32}
-        @test size(y) == (n, lenq, batch_size...)
+        @test size(y) == (head_dim, nheads, lenq, batch_size...)
         @test size(α) == (lenkv, lenq, nheads, batch_size...)
         @test sum(Array(α), dims=1) ≈ ones(1, lenq, nheads, batch_size...)
 
-        qh = rand(Float32, n, lenq, batch_size...)
-        kh = rand(Float32, n, lenkv, batch_size...)
-        vh = rand(Float32, n, lenkv, batch_size...)
+        qh = rand(Float32, head_dim, nheads, lenq, batch_size...)
+        kh = rand(Float32, head_dim, nheads, lenkv, batch_size...)
+        vh = rand(Float32, head_dim, nheads, lenkv, batch_size...)
         gputest(
-            (x...) -> dot_product_attention(x...; nheads)[1], qh, kh, vh;
+            (x...) -> scaled_dot_product_attention(x...), qh, kh, vh;
             atol=1f-5)
     end
 end
@@ -26,7 +27,7 @@ end
     x = AMDGPU.rand(Float32, 4, 2, 3, 1)
     mask = make_causal_mask(x, dims=3)
     @test mask isa ROCArray{Bool}
-    α = dot_product_attention_scores(x, x; mask)
+    α = scaled_dot_product_attention_scores(x, x; mask)
 
     α_host, mask_host = Array.((α, mask))
     @test all((α_host[:, :, 1, 1] .> 0) .== mask_host)
@@ -34,9 +35,9 @@ end
 end
 
 @testset "Dropout" begin
-    q = k = v = AMDGPU.rand(Float32, 10, 10, 10)
+    q = k = AMDGPU.rand(Float32, 5, 2, 10)
     fdrop(x, p) = (rand!(similar(x)) .> p) .* x ./ (1-p)
-    y, α = dot_product_attention(
-        q, k, v; nheads=2, fdrop=x -> dropout(x, 0.5))
+    α = scaled_dot_product_attention_scores(
+        q, k; fdrop=x -> dropout(x, 0.5))
     @test 0.6 > mean(>(0), α) > 0.4
 end


### PR DESCRIPTION
## Summary

Introduces a new attention interface, `scaled_dot_product_attention`, taking inputs with an **explicit head axis** `(head_dim, nheads, seq_len, batch...)` as in PyTorch, and deprecates the old packed-head `dot_product_attention`.

The number of heads is inferred from the tensor shape (`size(q, 2)`), so there is no `nheads` keyword anymore.

## What's new

- **`scaled_dot_product_attention(q, k, v, [bias]; fdrop, mask, scale, is_causal)`** — returns *only* the attention output `(v_head_dim, nheads, q_len, batch...)`.
- **`scaled_dot_product_attention_scores(q, k, [bias]; ...)`** — returns the attention weights `(kv_len, q_len, nheads, batch...)`.
- **Grouped-query attention (GQA)**: key/value may have fewer heads than the query (number of query heads must be divisible by the number of kv heads).
- New **`scale`** (denominator, default `√head_dim`) and **`is_causal`** keywords.
- **`make_causal_mask` default changed to `dims=3`** to match the new layout's sequence axis.

## Deprecation

The old `dot_product_attention` / `dot_product_attention_scores` keep working with a `depwarn`, forwarding through the new implementation (heads split out of the feature dim, then joined back on output). Output and scores come from a single pass, so a stochastic `fdrop` is not applied twice.

## Notes / open questions

- This is a **API change with deprecations** (new exported names, old ones deprecated).
- The kernel is unchanged (`batched_mul` + `softmax` + `batched_mul`) — this PR is about the interface, not a fused/flash kernel. It sets up the `nheads`/`is_causal` surface a future NNkernels/cuDNN backend could dispatch on.
- `scale` is kept as the *denominator* (matching the previous behavior) rather than PyTorch's multiplier convention — open to changing if preferred.

## Tests

- [test/attention.jl](test/attention.jl) rewritten for the new API (80 tests pass): batch shapes, GQA, `is_causal`, `scale`, scores↔output consistency, gradients through the GQA path.
- [test/ext_amdgpu/attention.jl](test/ext_amdgpu/attention.jl) updated to the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)