### PR TITLE
Clamp the exp argument in elu/selu/celu so primal-AD gradients stay finite for x > log(floatmax(T))

### DIFF
--- a/src/activations.jl
+++ b/src/activations.jl
@@ -304,7 +304,10 @@ julia> elu(-10f0, 2)
 -1.9999092f0
 ```
 """
-elu(x, α=1) = ifelse(x ≥ 0, float(x), @fastmath oftf(x, α) * (exp(x) - 1))
+# `Base.min` escapes `@fastmath` (`min_fast` would drop NaN propagation). Clamping the
+# `exp` argument keeps reverse-mode AD of the primal finite for x > log(floatmax(T)):
+# the not-taken branch otherwise contributes `0 * exp(x) = 0 * Inf = NaN` to the adjoint.
+elu(x, α=1) = ifelse(x ≥ 0, float(x), @fastmath oftf(x, α) * (exp(Base.min(x, zero(x))) - 1))
 
 deriv_elu(Ω, α=1) = ifelse(Ω ≥ 0, one(Ω), Ω + oftype(Ω, α))
 
@@ -550,7 +553,7 @@ julia> selu(-10f0)
 function selu(x)
     λ = oftf(x, selu_λ)
     α = oftf(x, selu_α)
-    λ * ifelse(x > 0, x, @fastmath α * (exp(x) - 1))
+    λ * ifelse(x > 0, x, @fastmath α * (exp(Base.min(x, zero(x))) - 1))
 end
 
 const selu_λ = 1.0507009873554804934193349852946
@@ -585,7 +588,7 @@ julia> celu(-10f0)
 -0.9999546f0
 ```
 """
-celu(x, α=1) = ifelse(x ≥ 0, float(x), oftf(x,α) * (exp(x/oftf(x,α)) - 1))
+celu(x, α=1) = ifelse(x ≥ 0, float(x), oftf(x,α) * (exp(min(x, zero(x))/oftf(x,α)) - 1))
 
 deriv_celu(Ω, α=1) = ifelse(Ω > 0, oftf(Ω, 1), Ω / oftf(Ω, α) + 1)
 

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -276,6 +276,9 @@ function rrelu(x::T, l=oftf(x,1/8), u=oftf(x,1/3)) where T<:Number
     return leakyrelu(x, a)
 end
 
+# `Base.min` escapes `@fastmath` (`min_fast` would drop NaN propagation). Clamping the
+# `exp` argument keeps reverse-mode AD of the primal finite for x > log(floatmax(T)):
+# the not-taken branch otherwise contributes `0 * exp(x) = 0 * Inf = NaN` to the adjoint.
 """
     elu(x, α=1) = x > 0 ? x : α * (exp(x) - 1)
 
@@ -304,9 +307,6 @@ julia> elu(-10f0, 2)
 -1.9999092f0
 ```
 """
-# `Base.min` escapes `@fastmath` (`min_fast` would drop NaN propagation). Clamping the
-# `exp` argument keeps reverse-mode AD of the primal finite for x > log(floatmax(T)):
-# the not-taken branch otherwise contributes `0 * exp(x) = 0 * Inf = NaN` to the adjoint.
 elu(x, α=1) = ifelse(x ≥ 0, float(x), @fastmath oftf(x, α) * (exp(Base.min(x, zero(x))) - 1))
 
 deriv_elu(Ω, α=1) = ifelse(Ω ≥ 0, one(Ω), Ω + oftype(Ω, α))


### PR DESCRIPTION

### Problem

`elu`, `selu`, and `celu` compute their negative branch eagerly inside `ifelse`:

```julia
elu(x, α=1) = ifelse(x ≥ 0, float(x), @fastmath oftf(x, α) * (exp(x) - 1))
```

The forward value is correct for all `x` (the select discards the overflowed
arm). But ADs that differentiate the **primal** (Enzyme; Reactant/EnzymeMLIR —
as opposed to ADs that use the `deriv_elu` rrule, which is expressed through
the bounded output) multiply the not-taken branch's derivative by a zero
cotangent. For `x > log(floatmax(Float32)) ≈ 88.72` that is
`0 * exp(x) = 0 * Inf = NaN`:

```julia
using NNlib, Enzyme
f(z) = sum(elu.(z))
Enzyme.gradient(Enzyme.Reverse, f, Float32[88.0])[1]  # [1.0]
Enzyme.gradient(Enzyme.Reverse, f, Float32[89.0])[1]  # [NaN]   (expected 1.0)
```

The same reproduces under Reactant (`@jit Enzyme.gradient(...)`, CPU and CUDA
clients, Reactant 0.2.264/0.2.265), and for `selu` and `celu`.

This is nasty in practice: in a deep net without normalization layers, hidden
pre-activations can drift past 88.72 during training, at which point the
backward of one conv silently emits NaN and poisons every parameter upstream
of it while the loss stays finite. We chased exactly this for weeks in a
Lux + Reactant U-Net training pipeline before reducing it to the one-liner
above (full story + training-scale reproducer: EnzymeAD/Reactant.jl#2973).

### Fix

Clamp the `exp` argument to `≤ 0` in the eager arm — bitwise-identical forward
values (the arm is selected only for `x < 0`, where `min(x, 0) == x`), and the
arm's derivative `exp(min(x, 0)) ≤ 1` can no longer overflow:

```julia
elu(x, α=1) = ifelse(x ≥ 0, float(x), @fastmath oftf(x, α) * (exp(Base.min(x, zero(x))) - 1))
```

Notes:

- `Base.min` (qualified) escapes the `@fastmath` rewrite — `min_fast` would
  break NaN propagation (`@fastmath min(NaN32, 0f0) == 0.0f0`). Verified:
  `elu(NaN32)` still returns `NaN` after this change, matching current
  behavior and the "still preserves NaN" convention used elsewhere in this
  file.
- `celu` carries no `@fastmath`, so plain `min` is used there; the clamp is
  applied before the division by `α`.
- Value identity spot-checked over `±1f4 … ±1f-4`, `0`, and `NaN`; Enzyme
  gradient at `x = 100` goes from `NaN` to `1.0`.
- One extra `min` per call on the negative-branch computation; `min` is a
  single SIMD instruction, so the change should be performance-neutral. Happy
  to add benchmarks if desired.

### Out of scope (but observed)

A sweep of all `NNlib.ACTIVATIONS` under plain Enzyme and Reactant at extreme
inputs found one more non-finite gradient: `gelu_tanh` returns NaN under plain
Enzyme (not under Reactant) for `|x| ≳ 88`. Its mechanism differs (no eager
`exp` arm) and is not addressed here. All other activations (including
`sigmoid`, which already uses the stable `exp(-abs(x))` form, `tanh`,
`softplus`, `swish`, `mish`, …) are clean on both backends.

Related: EnzymeAD/Enzyme.jl#2285 (the general "not-taken branch with Inf
shadow" class; `Enzyme.set_strong_zero` is the mode-level workaround),
EnzymeAD/Reactant.jl#2637 (the analogous `softplus` overflow, fixed via a
Reactant-side override).

---

*Attribution: the root-cause investigation, the fix, and this write-up were done by Claude (Anthropic Fable 5) running in Claude Code; I reviewed and am submitting on its behalf from my account.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
