### PR TITLE
Compare gradients against both Zygote and Enzyme in `test_gradients`

### DIFF
--- a/test/common_testsuite/fold.jl
+++ b/test/common_testsuite/fold.jl
@@ -40,11 +40,13 @@ function fold_testsuite(Backend)
         w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
         cdims = DenseConvDims(x, w)
 
-        @test test_gradients(x -> NNlib.unfold(x, cdims), x; test_gpu = Backend != CPU)
+        # Enzyme fails to compile the `unfold`/`fold` gradient (LLVM verifier crash),
+        # so compare against Zygote only for now.
+        @test test_gradients(x -> NNlib.unfold(x, cdims), x; test_gpu = Backend != CPU, compare = AutoZygote())
         Backend == CPU && ChainRulesTestUtils.test_rrule(NNlib.unfold, x, cdims)
 
         y = NNlib.unfold(x, cdims)
-        @test test_gradients(y -> NNlib.fold(y, size(x), cdims), y; test_gpu = Backend != CPU)
+        @test test_gradients(y -> NNlib.fold(y, size(x), cdims), y; test_gpu = Backend != CPU, compare = AutoZygote())
         Backend == CPU && ChainRulesTestUtils.test_rrule(NNlib.fold, y, size(x), cdims)
     end
 end

--- a/test/common_testsuite/gather.jl
+++ b/test/common_testsuite/gather.jl
@@ -157,9 +157,7 @@ function gather_testsuite(Backend)
             f_gpu = xs -> gather(xs, idx_d))
     end
 
-    # Skip on Metal: `EnzymeTestUtils.test_reverse` does scalar indexing (disallowed on
-    # Metal). (`MetalBackend` isn't loaded on other workers, so match by type name.)
-    if NNLIB_TEST_ENZYME && nameof(Backend) !== :MetalBackend
+    if NNLIB_TEST_ENZYME
         @testset "EnzymeRules: gather! gradient for scalar index" begin
             src = device(Float64[3, 4, 5, 6, 7])
             idx = device([

--- a/test/common_testsuite/gather.jl
+++ b/test/common_testsuite/gather.jl
@@ -147,8 +147,10 @@ function gather_testsuite(Backend)
             5 7 7 5]
         idx_d = device(idx_cpu)
         dst_d = device(dst_cpu)
+        # Enzyme errors on `gather!` here; Enzyme is covered by the dedicated
+        # `EnzymeRules` testset below.
         @test test_gradients(xs -> gather!(dst_cpu, xs, idx_cpu), src;
-            test_gpu = Backend != CPU,
+            test_gpu = Backend != CPU, compare = AutoZygote(),
             f_gpu = xs -> gather!(dst_d, xs, idx_d))
         @test test_gradients(xs -> gather(xs, idx_cpu), src;
             test_gpu = Backend != CPU,
@@ -183,11 +185,12 @@ function gather_testsuite(Backend)
         dst_cpu = Tgrad[3, 5, 7, 4, 6, 8]
         idx_d = device(idx_cpu)
         dst_d = device(dst_cpu)
+        # Enzyme errors on these tuple-index cases; covered by the `EnzymeRules` testset.
         @test test_gradients(xs -> gather!(dst_cpu, xs, idx_cpu), src;
-            test_gpu = Backend != CPU,
+            test_gpu = Backend != CPU, compare = AutoZygote(),
             f_gpu = xs -> gather!(dst_d, xs, idx_d))
         @test test_gradients(xs -> gather(xs, idx_cpu), src;
-            test_gpu = Backend != CPU,
+            test_gpu = Backend != CPU, compare = AutoZygote(),
             f_gpu = xs -> gather(xs, idx_d))
     end
 

--- a/test/common_testsuite/scatter.jl
+++ b/test/common_testsuite/scatter.jl
@@ -175,6 +175,9 @@ function scatter_testsuite(Backend)
                 src_d = device(src); idx_d = device(idx)
                 @test test_gradients(x -> scatter!(op, copy(x), src, idx), dst;
                     test_gpu = Backend != CPU, reference = get_reference_ad(op),
+                    # Enzyme's `scatter!` rule errors here; Enzyme is covered by the
+                    # dedicated `EnzymeRules` testset below.
+                    compare = AutoZygote(),
                     f_gpu = x -> scatter!(op, copy(x), src_d, idx_d))
             end
         end
@@ -186,6 +189,7 @@ function scatter_testsuite(Backend)
                 idx_d = device(idx)
                 @test test_gradients(xs -> scatter(op, xs, idx), src;
                     test_gpu = Backend != CPU, reference = get_reference_ad(op),
+                    compare = AutoZygote(),  # Enzyme `scatter!` rule errors; covered separately below
                     f_gpu = xs -> scatter(op, xs, idx_d))
             end
         end
@@ -198,6 +202,7 @@ function scatter_testsuite(Backend)
             idx_d = device(idx)
             @test test_gradients(xs -> scatter(op, xs, idx), src;
                 test_gpu = Backend != CPU, reference = get_reference_ad(op),
+                compare = AutoZygote(),  # Enzyme `scatter!` rule errors; covered separately below
                 f_gpu = xs -> scatter(op, xs, idx_d))
         end
 

--- a/test/common_testsuite/scatter.jl
+++ b/test/common_testsuite/scatter.jl
@@ -210,7 +210,7 @@ function scatter_testsuite(Backend)
         # Skip on Metal: `EnzymeTestUtils.test_reverse` does scalar indexing internally,
         # which is disallowed on Metal. (`MetalBackend` isn't loaded on other workers, so
         # match by type name rather than referencing the type.)
-        if NNLIB_TEST_ENZYME && nameof(Backend) !== :MetalBackend
+        if NNLIB_TEST_ENZYME
 
         @testset "EnzymeRules" begin
             idx = device(Int32[2, 2, 3, 4, 4])

--- a/test/cpu/activations.jl
+++ b/test/cpu/activations.jl
@@ -395,10 +395,13 @@ end
         @test gradient(xs -> sum(elu.(xs, 2)), [1_000, 10_000]) == ([1., 1.],)
         @test gradient(x -> elu(x, 2), 1_000) == (1.,)
         @test gradient(x -> elu(x, 2), -1) == (2*exp(-1),)
-        @test test_gradients(x-> selu.(x),[100., 1_000.])
-        @test test_gradients(x -> elu.(x, 3.5),[100., 1_000.])
-        @test test_gradients(x -> elu.(x, 3.5),[1_000., 10_000.])
-        @test test_gradients(x -> selu.(x), [1_000., 10_000.])
+        # Enzyme differentiates through the raw `exp` and overflows to NaN on these
+        # saturated inputs; the overflow-safe gradient is a Zygote/ChainRules property,
+        # so compare against Zygote only here.
+        @test test_gradients(x-> selu.(x),[100., 1_000.]; compare = AutoZygote())
+        @test test_gradients(x -> elu.(x, 3.5),[100., 1_000.]; compare = AutoZygote())
+        @test test_gradients(x -> elu.(x, 3.5),[1_000., 10_000.]; compare = AutoZygote())
+        @test test_gradients(x -> selu.(x), [1_000., 10_000.]; compare = AutoZygote())
         @test test_gradients(x -> selu.(x), randn(rng, 10))
     end
 

--- a/test/cpu/batchedmul.jl
+++ b/test/cpu/batchedmul.jl
@@ -275,13 +275,16 @@ FiniteDifferences.to_vec(x::NNlib.BatchedTranspose) = FiniteDifferences.to_vec(c
     @test test_gradients(batched_mul, randn(rng, M, P, B), batched_transpose(randn(rng, Q, P, B)))
 
     # One a matrix...
+    # `adjoint`/`transpose` (LinearAlgebra wrappers) inputs: Enzyme returns a
+    # structural `(parent = ...)` tangent that `check_equal` can't compare against
+    # the array-shaped reference, so compare against Zygote only here.
     @test test_gradients(batched_mul, randn(rng, M, P), randn(rng, P, Q, B))
-    @test test_gradients(batched_mul, adjoint(randn(rng, P, M)), randn(rng, P, Q, B))
+    @test test_gradients(batched_mul, adjoint(randn(rng, P, M)), randn(rng, P, Q, B); compare = AutoZygote())
     @test test_gradients(batched_mul, randn(rng, M, P), batched_adjoint(randn(rng, Q, P, B)))
 
     @test test_gradients(batched_mul, randn(rng, M, P, B), randn(rng, P, Q))
     @test test_gradients(batched_mul, batched_transpose(randn(rng, P, M, B)), randn(rng, P, Q))
-    @test test_gradients(batched_mul, randn(rng, M, P, B), transpose(randn(rng, Q, P)))
+    @test test_gradients(batched_mul, randn(rng, M, P, B), transpose(randn(rng, Q, P)); compare = AutoZygote())
 
     # ... or equivalent to a matrix
     @test test_gradients(batched_mul, randn(rng, M, P, 1), randn(rng, P, Q, B))
@@ -294,7 +297,7 @@ FiniteDifferences.to_vec(x::NNlib.BatchedTranspose) = FiniteDifferences.to_vec(c
 
     # batched_vec
     @test test_gradients(batched_vec, randn(rng, M, P, B), randn(rng, P, B))
-    @test test_gradients(batched_vec, randn(rng, M, P, B), transpose(randn(rng, B, P)))
+    @test test_gradients(batched_vec, randn(rng, M, P, B), transpose(randn(rng, B, P)); compare = AutoZygote())
 
     @test test_gradients(batched_vec, randn(rng, M, P, B), randn(rng, P))
 end

--- a/test/cpu/sampling.jl
+++ b/test/cpu/sampling.jl
@@ -36,7 +36,9 @@
     @test eltype(∇input) == Float64
     @test eltype(∇grid) == Float64
 
-    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid)
+    # Enzyme returns a (near-zero) wrong gradient for `grid_sample`, so compare
+    # against Zygote only for now.
+    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid; compare = AutoZygote())
 end
 
 @testset "Test out-of-bounds for different paddings" begin
@@ -119,7 +121,9 @@ end
     @test eltype(∇input) == Float64
     @test eltype(∇grid) == Float64
 
-    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid)
+    # Enzyme returns a (near-zero) wrong gradient for `grid_sample`, so compare
+    # against Zygote only for now.
+    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid; compare = AutoZygote())
 end
 
 @testset "Test out-of-bounds for different paddings 3D" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,12 +16,13 @@ const NNLIB_TEST_AMDGPU   = get(ENV, "NNLIB_TEST_AMDGPU",   "false") == "true"
 const NNLIB_TEST_METAL    = get(ENV, "NNLIB_TEST_METAL",    "false") == "true"
 const NNLIB_TEST_THREADED = get(ENV, "NNLIB_TEST_THREADED", "false") == "true"
 
-const NNLIB_TEST_ENZYME =   get(ENV, "NNLIB_TEST_ENZYME",   "true")  == "true" ||
-                            (
+const NNLIB_TEST_ENZYME =   if haskey(ENV, "NNLIB_TEST_ENZYME") 
+                                ENV["NNLIB_TEST_ENZYME"] == "true"
+                            else
                                 VERSION <= v"1.13-" && # fails on nightly
                                 !NNLIB_TEST_AMDGPU && !NNLIB_TEST_METAL && !NNLIB_TEST_CUDA && # TODO fails on GPU backends
                                 !Sys.iswindows() # TODO fails on Windows
-                            )
+                            end
 
 # Tests that exercise NNlib's multithreaded code paths (`@spawn` / `@threads`).
 # The dedicated `NNLIB_TEST_THREADED` job runs *only* these, on multithreaded

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,11 @@ const NNLIB_TEST_AMDGPU   = get(ENV, "NNLIB_TEST_AMDGPU",   "false") == "true"
 const NNLIB_TEST_METAL    = get(ENV, "NNLIB_TEST_METAL",    "false") == "true"
 const NNLIB_TEST_THREADED = get(ENV, "NNLIB_TEST_THREADED", "false") == "true"
 
-# some enzyme tests on AMDGPU are crashing julia
-const NNLIB_TEST_ENZYME = VERSION <= v"1.13-" && !NNLIB_TEST_AMDGPU
+# Enzyme is opt-out via `NNLIB_TEST_ENZYME`, and additionally disabled where it is
+# known to break: some enzyme tests on AMDGPU crash julia, and it is unsupported
+# on Julia nightly (> 1.13).
+const NNLIB_TEST_ENZYME = get(ENV, "NNLIB_TEST_ENZYME", "true") == "true" &&
+    VERSION <= v"1.13-" && !NNLIB_TEST_AMDGPU
 
 # Tests that exercise NNlib's multithreaded code paths (`@spawn` / `@threads`).
 # The dedicated `NNLIB_TEST_THREADED` job runs *only* these, on multithreaded

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,11 +16,10 @@ const NNLIB_TEST_AMDGPU   = get(ENV, "NNLIB_TEST_AMDGPU",   "false") == "true"
 const NNLIB_TEST_METAL    = get(ENV, "NNLIB_TEST_METAL",    "false") == "true"
 const NNLIB_TEST_THREADED = get(ENV, "NNLIB_TEST_THREADED", "false") == "true"
 
-# Enzyme is opt-out via `NNLIB_TEST_ENZYME`, and additionally disabled where it is
-# known to break: some enzyme tests on AMDGPU crash julia, and it is unsupported
-# on Julia nightly (> 1.13).
-const NNLIB_TEST_ENZYME = get(ENV, "NNLIB_TEST_ENZYME", "true") == "true" &&
-    VERSION <= v"1.13-" && !NNLIB_TEST_AMDGPU
+const NNLIB_TEST_ENZYME =   get(ENV, "NNLIB_TEST_ENZYME",   "true")  == "true" &&
+                            VERSION <= v"1.13-" && # fails on nighlt
+                            !NNLIB_TEST_AMDGPU && !NNLIB_TEST_METAL && !NNLIB_TEST_CUDA && # TODO fails on GPU backends
+                            !Sys.iswindows() # TODO fails on Windows
 
 # Tests that exercise NNlib's multithreaded code paths (`@spawn` / `@threads`).
 # The dedicated `NNLIB_TEST_THREADED` job runs *only* these, on multithreaded

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,10 +16,12 @@ const NNLIB_TEST_AMDGPU   = get(ENV, "NNLIB_TEST_AMDGPU",   "false") == "true"
 const NNLIB_TEST_METAL    = get(ENV, "NNLIB_TEST_METAL",    "false") == "true"
 const NNLIB_TEST_THREADED = get(ENV, "NNLIB_TEST_THREADED", "false") == "true"
 
-const NNLIB_TEST_ENZYME =   get(ENV, "NNLIB_TEST_ENZYME",   "true")  == "true" &&
-                            VERSION <= v"1.13-" && # fails on nighlt
-                            !NNLIB_TEST_AMDGPU && !NNLIB_TEST_METAL && !NNLIB_TEST_CUDA && # TODO fails on GPU backends
-                            !Sys.iswindows() # TODO fails on Windows
+const NNLIB_TEST_ENZYME =   get(ENV, "NNLIB_TEST_ENZYME",   "true")  == "true" ||
+                            (
+                                VERSION <= v"1.13-" && # fails on nightly
+                                !NNLIB_TEST_AMDGPU && !NNLIB_TEST_METAL && !NNLIB_TEST_CUDA && # TODO fails on GPU backends
+                                !Sys.iswindows() # TODO fails on Windows
+                            )
 
 # Tests that exercise NNlib's multithreaded code paths (`@spawn` / `@threads`).
 # The dedicated `NNLIB_TEST_THREADED` job runs *only* these, on multithreaded

--- a/test/test_module.jl
+++ b/test/test_module.jl
@@ -126,11 +126,16 @@ function test_gradients(
             # GPU, since it captures only non-array config like `DenseConvDims`/kwargs).
             f_gpu = nothing,
             reference::AbstractADType = test_cpu ? AutoFiniteDifferences(;fdm=_default_fdm()) : AutoZygote(),
-            compare::AbstractADType = AutoZygote(),
+            compare::Union{AbstractADType, Vector{<:AbstractADType}} = [AutoZygote(), AutoEnzyme()],
             loss = (f, xs...) -> mean(f(xs...)),
             )
 
     @assert test_cpu || test_gpu "at least one of `test_cpu` or `test_gpu` must be true"
+
+    compares = compare isa AbstractADType ? [compare,] : compare
+    if !NNLIB_TEST_ENZYME
+        compares = filter(adtype -> !(adtype isa AutoEnzyme), compares)
+    end
 
     cpu_dev = cpu_device()
 
@@ -145,22 +150,31 @@ function test_gradients(
     l = loss(f, xs...)
     @assert l isa Number "loss should return a number, got $(typeof(l))"
 
+    # Compute reference gradients with inputs promoted to f64 precision.
     y, gs = withgradient((xs...) -> loss(f, xs...), reference, f64(xs)...)
     @assert isapprox(l, y; rtol, atol) "forward pass mismatch: $l ≉ $y (reference)"
 
     if test_cpu
-        y2, gs2 = withgradient((xs...) -> loss(f, xs...), compare, xs...)
-        @assert isapprox(l, y2; rtol, atol) "forward pass mismatch: $l ≉ $y2 (compare)"
-        check_equal(gs, gs2; rtol, atol)
+        for adtype in compares
+            y2, gs2 = withgradient((xs...) -> loss(f, xs...), adtype, xs...)
+            @assert isapprox(l, y2; rtol, atol) "forward pass mismatch: $l ≉ $y2 (compare $adtype)"
+            check_equal(gs, gs2; rtol, atol)
+        end
     end
 
     if test_gpu
         l_gpu = loss(_f_gpu, xs_gpu...)
         @assert l_gpu isa Number "gpu loss should return a number, got $(typeof(l_gpu))"
 
-        y_gpu, gs_gpu = withgradient((xs...) -> loss(_f_gpu, xs...), compare, xs_gpu...)
-        @assert isapprox(l_gpu, y_gpu; rtol, atol) "gpu forward pass mismatch: $l_gpu ≉ $y_gpu"
-        check_equal(gs, gs_gpu |> cpu_dev; rtol, atol)
+        # TODO fix Enzyme errors on Metal
+        gpu_compares = nameof(typeof(gpu_dev)) === :MetalDevice ?
+            filter(adtype -> !(adtype isa AutoEnzyme), compares) : compares
+
+        for adtype in gpu_compares
+            y_gpu, gs_gpu = withgradient((xs...) -> loss(_f_gpu, xs...), adtype, xs_gpu...)
+            @assert isapprox(l_gpu, y_gpu; rtol, atol) "gpu forward pass mismatch: $l_gpu ≉ $y_gpu (compare $adtype)"
+            check_equal(gs, gs_gpu |> cpu_dev; rtol, atol)
+        end
     end
 
     return true


### PR DESCRIPTION
@wsmoses on windows we have several crashes.

Add the moment this excludes Enzyme testing on windows and on gpu. 

----
## Summary

Extends `test_gradients` (in `test/test_module.jl`) to check gradients against **multiple AD backends**, and flips the default to compare against both **Zygote and Enzyme** (previously Zygote only).

- `compare` now accepts either a single `AbstractADType` or a `Vector` of them; default is `[AutoZygote(), AutoEnzyme()]`. Each backend is checked against the reference, and mismatch messages name the offending backend.
- Enzyme respects the existing `NNLIB_TEST_ENZYME` flag: when disabled (env opt-out, Julia > 1.13, or AMDGPU), `AutoEnzyme` entries are dropped from `compare`.
- On **Metal**, Enzyme is dropped from the *GPU* comparison — Enzyme reverse mode is broadly non-functional there (matching the existing `Backend !== :MetalBackend` gates), and it otherwise caused ~10 min hangs before erroring.

## Enzyme-specific restrictions

Enabling Enzyme by default surfaced several ops where Enzyme currently fails; these specific calls are pinned to `compare = AutoZygote()` with explanatory comments, while the rest of each suite still exercises Enzyme:

| Op | Issue |
|---|---|
| saturated `selu`/`elu` (activations, issue #758) | Enzyme differentiates raw `exp` → overflow `NaN` |
| `Adjoint`/`Transpose` inputs (batchedmul) | Enzyme returns a structural `(parent=…)` tangent `check_equal` can't compare |
| `grid_sample` (sampling) | Enzyme returns a wrong (near-zero) gradient |
| `scatter!`/`gather!` | Enzyme rule errors (already covered by dedicated `EnzymeRules` testsets) |
| `unfold`/`fold` | Enzyme LLVM verifier crash that kills the worker |

## Testing

Locally (Julia 1.12, macOS arm64) all CPU test files pass, and the Metal suites (`gpu/metal/{activations,batched_mul,dropout}` + `common_testsuite/{gather,scatter,fold,upsample}` on Metal) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)