### PR TITLE
Enzyme rules for cuDNN pooling/softmax/activations + imrotate/upsample (#734)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ NNlibAMDGPUExt = "AMDGPU"
 NNlibCUDACUDNNExt = ["CUDA", "cuDNN"]
 NNlibCUDAExt = "CUDA"
 NNlibEnzymeCoreExt = "EnzymeCore"
+NNlibEnzymeCoreCUDNNExt = ["EnzymeCore", "CUDA", "cuDNN"]
 NNlibMooncakeCUDAExt = ["Mooncake", "CUDA"]
 NNlibFFTWExt = "FFTW"
 NNlibForwardDiffExt = "ForwardDiff"

--- a/ext/NNlibCUDACUDNNExt/pooling.jl
+++ b/ext/NNlibCUDACUDNNExt/pooling.jl
@@ -17,10 +17,11 @@ function maxpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where
     cudnnPoolingForward!(y, x, d)
 end
 
-function ∇maxpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims) where T<:CUDNNFloat
+function ∇maxpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
+                   alpha=1, beta=0, kwargs...) where T<:CUDNNFloat
     xDesc, yDesc = cudnnTensorDescriptor.((x, y))
     d = cudnnPoolingDescriptor(pdims, x, CUDNN_POOLING_MAX)
-    alpha, beta = scalingParameter(T,1), scalingParameter(T,0)
+    alpha, beta = scalingParameter(T,alpha), scalingParameter(T,beta)
     cudnnPoolingBackward(handle(), d, alpha, yDesc, y, yDesc, dy, xDesc, x, beta, xDesc, dx)
     return dx
 end
@@ -36,10 +37,10 @@ function meanpool!(y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
 end
 
 function ∇meanpool!(dx::DenseCuArray{T}, dy::DenseCuArray{T}, y::DenseCuArray{T}, x::DenseCuArray{T}, pdims::PoolDims;
-                    count_include_pad::Bool=true) where T<:CUDNNFloat
+                    count_include_pad::Bool=true, alpha=1, beta=0, kwargs...) where T<:CUDNNFloat
     xDesc, yDesc = cudnnTensorDescriptor.((x, y))
     d = cudnnPoolingDescriptor(pdims, x, meanpool_mode(count_include_pad))
-    alpha, beta = scalingParameter(T,1), scalingParameter(T,0)
+    alpha, beta = scalingParameter(T,alpha), scalingParameter(T,beta)
     cudnnPoolingBackward(handle(), d, alpha, yDesc, y, yDesc, dy, xDesc, x, beta, xDesc, dx)
     return dx
 end
@@ -68,14 +69,14 @@ function meanpool!(y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims;
     return y
 end
 
-function ∇maxpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims) where T<:CUDNNFloat
-    ∇maxpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims))
+function ∇maxpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims; kwargs...) where T<:CUDNNFloat
+    ∇maxpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims); kwargs...)
     return dx
 end
 
 function ∇meanpool!(dx::DenseCuArray{T,3}, dy::DenseCuArray{T,3}, y::DenseCuArray{T,3}, x::DenseCuArray{T,3}, pdims::PoolDims;
-                    count_include_pad::Bool=true) where T<:CUDNNFloat
-    ∇meanpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims); count_include_pad)
+                    count_include_pad::Bool=true, kwargs...) where T<:CUDNNFloat
+    ∇meanpool!(add1d(dx), add1d(dy), add1d(y), add1d(x), fix_pooldims_1d(pdims); count_include_pad, kwargs...)
     return dx
 end
 

--- a/ext/NNlibEnzymeCoreCUDNNExt.jl
+++ b/ext/NNlibEnzymeCoreCUDNNExt.jl
@@ -1,0 +1,65 @@
+module NNlibEnzymeCoreCUDNNExt
+
+# Enzyme reverse-mode rule for the cuDNN activation forward.
+#
+# On a `CuArray`, broadcasting `tanh`/`σ`/`elu`/`relu` is routed to cuDNN via
+# `Base.materialize` overrides in `NNlibCUDACUDNNExt` (see `ext/.../activations.jl`),
+# which call `cuDNN.cudnnActivationForward!(y, x; mode)`. Enzyme cannot differentiate
+# the cuDNN `ccall`s underneath (it aborts with `unsupported tag gc-transition`, both
+# on the activation forward and on the activation-descriptor creation). The rule below
+# intercepts the whole `cudnnActivationForward!` call so Enzyme never descends into
+# those `ccall`s, and hands the reverse pass to `cudnnActivationBackward` — rebuilding
+# the same activation descriptor from `mode`/`coef` — so the gradient is exact.
+
+import EnzymeCore
+using EnzymeCore.EnzymeRules
+using cuDNN: cuDNN, cudnnActivationForward!, cudnnActivationBackward,
+             cudnnActivationDescriptor, cudnnTensorDescriptor, scalingParameter, handle,
+             CUDNN_ACTIVATION_RELU, CUDNN_NOT_PROPAGATE_NAN
+
+function EnzymeRules.augmented_primal(config,
+        func::EnzymeCore.Const{typeof(cudnnActivationForward!)}, ::Type{RT},
+        y, x; mode=CUDNN_ACTIVATION_RELU, nanOpt=CUDNN_NOT_PROPAGATE_NAN, coef=1, kw...) where {RT}
+
+    yv = func.val(y.val, x.val; mode, nanOpt, coef, kw...)
+
+    # cuDNN's activation backward needs both the input `x` and output `y`, plus the
+    # activation descriptor (rebuilt from `mode`/`nanOpt`/`coef` in `reverse`).
+    cache = (!(x isa EnzymeCore.Const) && !(y isa EnzymeCore.Const)) ?
+            (copy(x.val), copy(y.val), mode, nanOpt, coef) : nothing
+
+    primal = EnzymeRules.needs_primal(config) ? yv : nothing
+    shadow = EnzymeRules.needs_shadow(config) ? y.dval : nothing   # return aliases `y`
+    return EnzymeRules.AugmentedReturn(primal, shadow, cache)
+end
+
+function EnzymeRules.reverse(config,
+        func::EnzymeCore.Const{typeof(cudnnActivationForward!)}, ::Type{RT}, cache,
+        y, x; kw...) where {RT}
+
+    if cache !== nothing
+        cache_x, cache_y, mode, nanOpt, coef = cache
+        T = eltype(cache_x)
+        d = cudnnActivationDescriptor(mode, nanOpt, Cdouble(coef))
+        xDesc, yDesc = cudnnTensorDescriptor(cache_x), cudnnTensorDescriptor(cache_y)
+        a = scalingParameter(T, 1)
+        b = scalingParameter(T, 1)   # beta != 0 => accumulate into the input shadow
+
+        dys = y.dval
+        dxs = x.dval
+        if EnzymeRules.width(config) == 1
+            dys = (dys,)
+            dxs = (dxs,)
+        end
+
+        for (dy, dx) in zip(dys, dxs)
+            cudnnActivationBackward(handle(), d, a, yDesc, cache_y, yDesc, dy,
+                                    xDesc, cache_x, b, xDesc, dx)
+            dy .= 0
+        end
+    end
+
+    return (nothing, nothing)
+end
+
+end # module

--- a/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
+++ b/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
@@ -315,6 +315,58 @@ end
 end
 end
 
+# `softmax!`/`logsoftmax!` gradients depend only on the output `y` (= the written
+# destination) and the seed `dy`, via `∇softmax!(dx, dy, y; dims)`. Without a rule
+# Enzyme would try to differentiate the underlying implementation directly — on a
+# GPU that is a cuDNN `ccall` it cannot handle (Enzyme recurses/hangs), and even on
+# the CPU a hand-off to `∇softmax!` matches the ChainRules `rrule`. The rule caches
+# `y` in the augmented pass and accumulates `∇softmax!` into the input shadow on
+# reverse. These are first-order rules (they use the fast, non-`within_gradient`
+# `∇softmax!`), matching what `test_gradients` compares.
+for (fwd!, bwd!) in ((:(NNlib.softmax!),    :(NNlib.∇softmax!)),
+                     (:(NNlib.logsoftmax!), :(NNlib.∇logsoftmax!)))
+    @eval begin
+
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof($fwd!)}, ::Type{RT},
+                                      out::OutType, x; dims=1) where {OutType, RT}
+    if OutType <: EnzymeCore.Duplicated || OutType <: EnzymeCore.BatchDuplicated
+        func.val(out.val, x.val; dims)
+    end
+
+    primal = EnzymeRules.needs_primal(config) ? out.val : nothing
+    shadow = EnzymeRules.needs_shadow(config) ? out.dval : nothing
+
+    # Cache the output `y` (needed by `∇softmax!`); `out.val` may be overwritten
+    # downstream, so copy it unless neither input nor output is differentiated.
+    cache_y = ( !(typeof(x) <: EnzymeCore.Const) && !(typeof(out) <: EnzymeCore.Const)
+              ) ? copy(out.val) : nothing
+
+    return EnzymeRules.AugmentedReturn(primal, shadow, cache_y)
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof($fwd!)}, ::Type{RT}, cache_y,
+                             out::OutType, x; dims=1) where {OutType, RT}
+    if !(typeof(x) <: EnzymeCore.Const) && !(typeof(out) <: EnzymeCore.Const)
+        dys = out.dval
+        dxs = x.dval
+        if EnzymeRules.width(config) == 1
+            dys = (dys,)
+            dxs = (dxs,)
+        end
+
+        for (dy, dx) in zip(dys, dxs)
+            # `∇softmax!` overwrites its destination, so accumulate via a temporary.
+            dx .+= $bwd!(similar(dx), dy, cache_y; dims)
+            dy .= 0
+        end
+    end
+
+    return (nothing, nothing)
+end
+
+    end
+end
+
 function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib._dropout!)}, ::Type{RT}, rng, dst::OutType, src, p, dims) where {OutType, RT}
 
     T = float(real(eltype(dst.val)))

--- a/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
+++ b/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
@@ -367,6 +367,88 @@ end
     end
 end
 
+# ---------------------------------------------------------------------------
+# Allocating ops whose gradient has a dedicated `∇` kernel: `imrotate`,
+# `upsample_nearest`, `upsample_linear` (the latter also covers `upsample_bi/
+# trilinear`, which forward to it). Enzyme cannot differentiate these forward
+# kernels on the GPU ("Active kernel arguments not supported"), so we wrap them:
+# the augmented pass allocates the output shadow, and the reverse pass feeds it to
+# the `∇` kernel and accumulates into the input shadow. This mirrors each op's
+# ChainRules `rrule`. (Written explicitly rather than via `Enzyme.@import_rrule`,
+# per Enzyme maintainers' recommendation, and so the rules stay in the lighter
+# EnzymeCore extension.)
+
+# Allocate the return shadow (a zeroed copy of `y`), respecting the batch width.
+_enz_shadow(config, y) =
+    EnzymeRules.width(config) == 1 ? EnzymeCore.make_zero(y) :
+        ntuple(_ -> EnzymeCore.make_zero(y), EnzymeRules.width(config))
+
+# Pair each return-shadow (`dy`) with its input shadow (`dx`) across the width.
+_enz_pairs(config, dy, dx) =
+    EnzymeRules.width(config) == 1 ? ((dy, dx),) : zip(dy, dx)
+
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.imrotate)},
+        ::Type{RT}, arr, θ;
+        method=:bilinear, rotation_center=size(arr.val) .÷ 2 .+ 1) where {RT}
+    y = func.val(arr.val, θ.val; method, rotation_center)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    # `∇imrotate` reads only `arr`'s shape/backend (the op is linear in `arr`), so
+    # keeping `arr.val` — not a copy — is safe even if it is later overwritten.
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, arr.val, θ.val, method, rotation_center))
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.imrotate)},
+        ::Type{RT}, cache, arr, θ; kwargs...) where {RT}
+    shadow, arr_val, θ_val, method, rotation_center = cache
+    if !(arr isa EnzymeCore.Const)
+        for (dy, dx) in _enz_pairs(config, shadow, arr.dval)
+            dx .+= NNlib.∇imrotate(dy, arr_val, θ_val; method, rotation_center)
+        end
+    end
+    return (nothing, nothing)   # θ is `NoTangent` in the rrule
+end
+
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.upsample_nearest)},
+        ::Type{RT}, x, s) where {RT}
+    y = func.val(x.val, s.val)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, s.val))
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.upsample_nearest)},
+        ::Type{RT}, cache, x, s) where {RT}
+    shadow, scales = cache
+    if !(x isa EnzymeCore.Const)
+        for (dy, dx) in _enz_pairs(config, shadow, x.dval)
+            dx .+= NNlib.∇upsample_nearest(dy, scales)
+        end
+    end
+    return (nothing, nothing)
+end
+
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.upsample_linear)},
+        ::Type{RT}, x; size, align_corners::Bool=true) where {RT}
+    y = func.val(x.val; size, align_corners)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    # `∇upsample_linear` needs the original spatial size of `x` (see the rrule).
+    insize = Base.size(x.val)[1:ndims(x.val)-2]
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, insize, align_corners))
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.upsample_linear)},
+        ::Type{RT}, cache, x; kwargs...) where {RT}
+    shadow, insize, align_corners = cache
+    if !(x isa EnzymeCore.Const)
+        for (dy, dx) in _enz_pairs(config, shadow, x.dval)
+            dx .+= NNlib.∇upsample_linear(dy; size=insize, align_corners)
+        end
+    end
+    return (nothing,)
+end
+
 function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib._dropout!)}, ::Type{RT}, rng, dst::OutType, src, p, dims) where {OutType, RT}
 
     T = float(real(eltype(dst.val)))

--- a/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
+++ b/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
@@ -387,6 +387,13 @@ _enz_shadow(config, y) =
 _enz_pairs(config, dy, dx) =
     EnzymeRules.width(config) == 1 ? ((dy, dx),) : zip(dy, dx)
 
+# The i-th slice of a return-shadow / input-shadow across the batch width.
+# `Val`-dispatched so the width-1 method never contains an array `getindex`:
+# on a width-1 `Duplicated`, `.dval` is the array itself (not a tuple of arrays),
+# and indexing it would scalar-index the GPU array (and poison broadcast typing).
+_enz_slice(::Val{1}, s, i) = s
+_enz_slice(::Val{W}, s, i) where {W} = s[i]
+
 function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.imrotate)},
         ::Type{RT}, arr, θ;
         method=:bilinear, rotation_center=size(arr.val) .÷ 2 .+ 1) where {RT}
@@ -447,6 +454,82 @@ function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.upsampl
         end
     end
     return (nothing,)
+end
+
+# `grid_sample(x, grid)` — allocating, differentiable in both `x` and `grid`;
+# `∇grid_sample(dy, x, grid)` returns `(∇x, ∇grid)` and reads the input & grid
+# values, so both are cached.
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.grid_sample)},
+        ::Type{RT}, x, grid; padding_mode=:zeros) where {RT}
+    y = func.val(x.val, grid.val; padding_mode)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, copy(x.val), copy(grid.val), padding_mode))
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.grid_sample)},
+        ::Type{RT}, cache, x, grid; kwargs...) where {RT}
+    shadow, xval, gridval, padding_mode = cache
+    if !(x isa EnzymeCore.Const) || !(grid isa EnzymeCore.Const)
+        wv = Val(EnzymeRules.width(config))
+        for i in 1:EnzymeRules.width(config)
+            dy = _enz_slice(wv, shadow, i)
+            ∇x, ∇grid = NNlib.∇grid_sample(dy, xval, gridval; padding_mode)
+            x    isa EnzymeCore.Const || (_enz_slice(wv, x.dval, i)    .+= ∇x)
+            grid isa EnzymeCore.Const || (_enz_slice(wv, grid.dval, i) .+= ∇grid)
+        end
+    end
+    return (nothing, nothing)
+end
+
+# `ctc_loss(ŷ, y)` returns a scalar (Active return), differentiable in `ŷ` only
+# (`y` is the target). We reuse `ctc_alpha` from the augmented pass and feed it to
+# `∇ctc_loss` on reverse, scaled by the incoming cotangent `dval.val`.
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.ctc_loss)},
+        ::Type{RT}, ŷ, y) where {RT}
+    tmp = NNlib.ctc_alpha(ŷ.val, y.val)
+    primal = EnzymeRules.needs_primal(config) ? tmp.loss : nothing
+    return EnzymeRules.AugmentedReturn(primal, nothing, tmp)
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.ctc_loss)},
+        dval::EnzymeCore.Active, tmp, ŷ, y) where {}
+    if !(ŷ isa EnzymeCore.Const)
+        grad = NNlib.∇ctc_loss(ŷ.val, y.val, tmp)
+        wv = Val(EnzymeRules.width(config))
+        for i in 1:EnzymeRules.width(config)
+            Δ = _enz_slice(wv, dval.val, i)
+            _enz_slice(wv, ŷ.dval, i) .+= Δ .* grad
+        end
+    end
+    return (nothing, nothing)
+end
+
+# `batchnorm(g, b, x, running_mean, running_var, momentum)` — allocating, GPU-only
+# (cuDNN); differentiable in `g`, `b`, `x`. `∇batchnorm` returns `(dg, db, dx)`
+# (with `dg`/`db` possibly `nothing` when non-affine).
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.batchnorm)},
+        ::Type{RT}, g, b, x, running_mean, running_var, momentum; kwargs...) where {RT}
+    y = func.val(g.val, b.val, x.val, running_mean.val, running_var.val, momentum.val; kwargs...)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    cache = (shadow, copy(g.val), copy(b.val), copy(x.val),
+             running_mean.val, running_var.val, momentum.val)
+    return EnzymeRules.AugmentedReturn(primal, shadow, cache)
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.batchnorm)},
+        ::Type{RT}, cache, g, b, x, running_mean, running_var, momentum; kwargs...) where {RT}
+    shadow, gval, bval, xval, rm, rv, mom = cache
+    wv = Val(EnzymeRules.width(config))
+    for i in 1:EnzymeRules.width(config)
+        dy = _enz_slice(wv, shadow, i)
+        dg, db, dx = NNlib.∇batchnorm(gval, bval, xval, dy, rm, rv, mom; kwargs...)
+        (g isa EnzymeCore.Const || dg === nothing) || (_enz_slice(wv, g.dval, i) .+= dg)
+        (b isa EnzymeCore.Const || db === nothing) || (_enz_slice(wv, b.dval, i) .+= db)
+        x isa EnzymeCore.Const || (_enz_slice(wv, x.dval, i) .+= dx)
+    end
+    return (nothing, nothing, nothing, nothing, nothing, nothing)
 end
 
 function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib._dropout!)}, ::Type{RT}, rng, dst::OutType, src, p, dims) where {OutType, RT}

--- a/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
+++ b/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
@@ -532,6 +532,54 @@ function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.batchno
     return (nothing, nothing, nothing, nothing, nothing, nothing)
 end
 
+# `unfold(x, cdims)` / `fold(y, output_size, cdims)` are adjoints of each other
+# (the `unfold` pullback is `fold` and vice versa — see their rrules). Enzyme can't
+# differentiate the underlying `unfold!`/`fold!` KA kernels (LLVM verifier crash /
+# ReadOnlyMemoryError), so route the reverse pass through the sibling operator. The
+# rules target the `DenseConvDims` methods; the `kernel_size` convenience methods
+# forward to these, so Enzyme reaches the rule through them too.
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.unfold)},
+        ::Type{RT}, x, cdims::EnzymeCore.Const{<:NNlib.DenseConvDims}) where {RT}
+    y = func.val(x.val, cdims.val)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, Base.size(x.val), cdims.val))
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.unfold)},
+        ::Type{RT}, cache, x, cdims::EnzymeCore.Const{<:NNlib.DenseConvDims}) where {RT}
+    shadow, xsize, cd = cache
+    if !(x isa EnzymeCore.Const)
+        wv = Val(EnzymeRules.width(config))
+        for i in 1:EnzymeRules.width(config)
+            dy = _enz_slice(wv, shadow, i)
+            _enz_slice(wv, x.dval, i) .+= NNlib.fold(dy, xsize, cd)
+        end
+    end
+    return (nothing, nothing)
+end
+
+function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.fold)},
+        ::Type{RT}, x, output_size, cdims::EnzymeCore.Const{<:NNlib.DenseConvDims}) where {RT}
+    y = func.val(x.val, output_size.val, cdims.val)
+    shadow = EnzymeRules.needs_shadow(config) ? _enz_shadow(config, y) : nothing
+    primal = EnzymeRules.needs_primal(config) ? y : nothing
+    return EnzymeRules.AugmentedReturn(primal, shadow, (shadow, cdims.val))
+end
+
+function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.fold)},
+        ::Type{RT}, cache, x, output_size, cdims::EnzymeCore.Const{<:NNlib.DenseConvDims}) where {RT}
+    shadow, cd = cache
+    if !(x isa EnzymeCore.Const)
+        wv = Val(EnzymeRules.width(config))
+        for i in 1:EnzymeRules.width(config)
+            dy = _enz_slice(wv, shadow, i)
+            _enz_slice(wv, x.dval, i) .+= NNlib.unfold(dy, cd)
+        end
+    end
+    return (nothing, nothing, nothing)
+end
+
 function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib._dropout!)}, ::Type{RT}, rng, dst::OutType, src, p, dims) where {OutType, RT}
 
     T = float(real(eltype(dst.val)))

--- a/test/common_testsuite/fold.jl
+++ b/test/common_testsuite/fold.jl
@@ -40,13 +40,11 @@ function fold_testsuite(Backend)
         w = rand(rng, repeat([3], spatial_rank)..., 3, 3)
         cdims = DenseConvDims(x, w)
 
-        # Enzyme fails to compile the `unfold`/`fold` gradient (LLVM verifier crash),
-        # so compare against Zygote only for now.
-        @test test_gradients(x -> NNlib.unfold(x, cdims), x; test_gpu = Backend != CPU, compare = AutoZygote())
+        @test test_gradients(x -> NNlib.unfold(x, cdims), x; test_gpu = Backend != CPU)
         Backend == CPU && ChainRulesTestUtils.test_rrule(NNlib.unfold, x, cdims)
 
         y = NNlib.unfold(x, cdims)
-        @test test_gradients(y -> NNlib.fold(y, size(x), cdims), y; test_gpu = Backend != CPU, compare = AutoZygote())
+        @test test_gradients(y -> NNlib.fold(y, size(x), cdims), y; test_gpu = Backend != CPU)
         Backend == CPU && ChainRulesTestUtils.test_rrule(NNlib.fold, y, size(x), cdims)
     end
 end

--- a/test/cpu/sampling.jl
+++ b/test/cpu/sampling.jl
@@ -36,9 +36,7 @@
     @test eltype(∇input) == Float64
     @test eltype(∇grid) == Float64
 
-    # Enzyme returns a (near-zero) wrong gradient for `grid_sample`, so compare
-    # against Zygote only for now.
-    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid; compare = AutoZygote())
+    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid)
 end
 
 @testset "Test out-of-bounds for different paddings" begin
@@ -121,9 +119,7 @@ end
     @test eltype(∇input) == Float64
     @test eltype(∇grid) == Float64
 
-    # Enzyme returns a (near-zero) wrong gradient for `grid_sample`, so compare
-    # against Zygote only for now.
-    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid; compare = AutoZygote())
+    @test test_gradients((x, grid) -> grid_sample(x, grid; padding_mode), x, grid)
 end
 
 @testset "Test out-of-bounds for different paddings 3D" begin


### PR DESCRIPTION
Enzyme-on-GPU fixes toward enabling Enzyme gradient tests on CUDA (part of #734). Each removes an NNlib-side failure where Enzyme reached a cuDNN `ccall`, a scalar-indexing fallthrough, or an un-differentiable KA kernel; the reverse pass is routed to the op's existing `∇` kernel instead.

## 1. cuDNN pooling backward: accept `alpha`/`beta` (`ext/NNlibCUDACUDNNExt/pooling.jl`)

The `EnzymeRules.reverse` rule for `maxpool!`/`meanpool!` calls `∇maxpool!(...; alpha=1, beta=1)` to accumulate into the input shadow. The cuDNN methods accepted no `alpha`/`beta`, so dispatch on a `CuArray` fell through to the generic CPU kernel → scalar-indexes the GPU array. Now accepted (matching the cuDNN conv backward); `beta != 0` accumulates, default `beta=0` preserves the overwrite path. `test/gpu/cuda/pooling.jl` (Zygote) passes 75/75.

## 2. Enzyme rules for `softmax!`/`logsoftmax!` (`ext/NNlibEnzymeCoreExt`)

Without a rule Enzyme differentiates softmax directly; on GPU it reaches a cuDNN `ccall` and recurses/hangs (>500s). The rule caches `y` and hands off to `∇softmax!`. CPU `test/cpu/softmax.jl` (Zygote+Enzyme) 71/71; GPU cuDNN-routed dims now <2s and match Zygote.

## 3. Enzyme rule for cuDNN activations — new `NNlibEnzymeCoreCUDNNExt`

`tanh`/`σ`/`elu`/`relu` broadcasts on `CuArray`s route to `cudnnActivationForward!`, which Enzyme can't differentiate. A new weak extension (EnzymeCore+CUDA+cuDNN) adds a rule on `cudnnActivationForward!`; the reverse rebuilds the activation descriptor and calls `cudnnActivationBackward`. Verified GPU tanh/σ/relu/elu (1-D+2-D) vs Zygote. The other ~26 pure-broadcast activations already differentiate natively.

## 4. Enzyme rules for `imrotate`/`upsample_nearest`/`upsample_linear` (`ext/NNlibEnzymeCoreExt`)

Enzyme can't differentiate these allocating KA-kernel ops on GPU ("Active kernel arguments not supported"). Explicit rules allocate the output shadow and feed it to the op's `∇` kernel. `upsample_linear` also covers `upsample_bilinear`/`upsample_trilinear`. Verified CPU+GPU vs Zygote; CPU `rotation`+`upsample` testsuites (Zygote+Enzyme) 421/421.

(Written as explicit rules rather than `Enzyme.@import_rrule`, per Enzyme maintainers' recommendation.)

## 5. Enzyme rules for `grid_sample`/`ctc_loss`/`batchnorm` (`ext/NNlibEnzymeCoreExt`)

The remaining three `∇` gradient functions, wrapped so every `∇*` routine is now reachable from Enzyme:

- **`grid_sample`** — allocating, differentiable in both `x` and `grid` (`∇grid_sample` returns `(∇x, ∇grid)`). Newly enables Enzyme on CPU (was previously excluded there) and works on GPU. Verified vs Zygote on both.
- **`ctc_loss`** — scalar `Active` return, differentiable in `ŷ`; reuses `ctc_alpha` from the augmented pass and scales `∇ctc_loss` by the incoming cotangent. CPU-only; matches Zygote.
- **`batchnorm`** — allocating, GPU-only (cuDNN), differentiable in `g`, `b`, `x` (`∇batchnorm` returns `(dg, db, dx)`). All three gradients match Zygote on GPU.

Adds a `Val`-dispatched `_enz_slice` batch-width slice helper. This fixes a subtle bug in the manual `w == 1 ? arg.dval : arg.dval[i]` ternary: for a width-1 `Duplicated`, `arg.dval[i]` scalar-indexes the array (a `Float32` element), so the ternary type-joins to `Any` and poisons the `.+=` broadcast into the generic scalar-indexing fallback — which errors on GPU arrays. `Val`-dispatch keeps the width-1 method free of any array `getindex`.

## 6. Enzyme rules for `unfold`/`fold` + newly-enabled Enzyme test comparisons (`ext/NNlibEnzymeCoreExt`)

`unfold` and `fold` are adjoints of each other (the `unfold` pullback is `fold` and vice versa). Enzyme can't differentiate the underlying `unfold!`/`fold!` KA kernels (LLVM verifier crash / `ReadOnlyMemoryError`); explicit rules route the reverse pass through the sibling operator. Rules target the `DenseConvDims` methods (the `kernel_size` convenience methods forward to these).

With the new rules correct/compilable under Enzyme, three test sites that previously pinned `compare = AutoZygote()` now run the default Zygote **+** Enzyme comparison on CPU:
- `test/cpu/sampling.jl` — `grid_sample` (fixed by the §5 rule). 30/30.
- `test/common_testsuite/fold.jl` — `unfold`/`fold`. 67/67 on CPU.

(GPU backends keep Enzyme gated off via `NNLIB_TEST_ENZYME`, so these only exercise Enzyme on CPU.)

## Scope / context

All are prerequisite correctness fixes. Fully enabling Enzyme comparisons on CUDA is still blocked by a separate, upstream Enzyme+CUDA issue — reverse-mode through a GPU reduction (`mean`/`sum`/`mapreducedim!`, used by the `test_gradients` loss, by softmax's forward on non-leading `dims`, and by `∇upsample_nearest`) segfaults. `NNLIB_TEST_ENZYME` therefore stays gated off on GPU, so this PR changes no test wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

