### PR TITLE
inline bias_act! fallback method

### DIFF
--- a/src/bias_act.jl
+++ b/src/bias_act.jl
@@ -42,7 +42,7 @@ function bias_act!(::typeof(identity), x::StridedArray{<:AbstractFloat}, b::Bool
     x  # pass-through
 end
 
-function bias_act!(σ::Function, x::AbstractArray, b)
+@inline function bias_act!(σ::Function, x::AbstractArray, b)
     b === true && error("bias=true is not accepted; layer constructors shoud guarantee this")
     fast_act(σ, x).(x .+ b)  # fallback
 end


### PR DESCRIPTION
This may be a bit niche, but I build very small allocation free models with Flux and StaticArrays. `bias_act!()` is called from various Flux layers and appears sensitive to inlining heuristics. Beyond some level of complexity (size of inputs and type of activation) it allocates.

Example:
```Julia
N = 32
X = rand(SVector{N, Float32})
b = rand(SVector{N, Float32})
@btime bias_act!(leakyrelu, $(Ref(X))[], $(Ref(b))[]);
```

Before:
```
 386.302 ns (5 allocations: 800 bytes)
```

After:
```
  2.988 ns (0 allocations: 0 bytes)
```