### PR TITLE
Fix BatchNorm crash under Mooncake in eval mode

### DIFF
--- a/ext/NNlibMooncakeCUDAExt.jl
+++ b/ext/NNlibMooncakeCUDAExt.jl
@@ -65,7 +65,10 @@ function rrule!!(
     prv = primal(running_var)
     pm = primal(momentum)
 
-    fwd_cache = _BNFwdCache()
+    # cudnnBNForward! only populates a passed-in cache when training=true; in eval mode
+    # it's left unset, and cudnnBNBackward! reads it anyway, crashing on the stale
+    # `nothing`. Only build a live cache when training is actually on.
+    fwd_cache = get(pkw, :training, true) ? _BNFwdCache() : nothing
     y = batchnorm(pg, pb, px, prm, prv, pm; pkw..., cache=fwd_cache)
     dy_out = zero(y)
     zero_kw = zero_rdata(pkw)

--- a/ext/NNlibMooncakeCUDAExt.jl
+++ b/ext/NNlibMooncakeCUDAExt.jl
@@ -67,8 +67,15 @@ function rrule!!(
 
     # cudnnBNForward! only populates a passed-in cache when training=true; in eval mode
     # it's left unset, and cudnnBNBackward! reads it anyway, crashing on the stale
-    # `nothing`. Only build a live cache when training is actually on.
-    fwd_cache = get(pkw, :training, true) ? _BNFwdCache() : nothing
+    # `nothing`. Only build a live cache when training is actually on, and respect a
+    # caller-supplied cache (e.g. via Flux.BatchNorm's own `cache` argument) instead of
+    # silently replacing it with our own.
+    fwd_cache = if get(pkw, :training, true)
+        caller_cache = get(pkw, :cache, nothing)
+        caller_cache === nothing ? _BNFwdCache() : caller_cache
+    else
+        nothing
+    end
     y = batchnorm(pg, pb, px, prm, prv, pm; pkw..., cache=fwd_cache)
     dy_out = zero(y)
     zero_kw = zero_rdata(pkw)


### PR DESCRIPTION
While running BatchNorm through Mooncake in eval mode, the backward pass crashes with:

```
MethodError: no method matching unsafe_convert(::Type{CuPtr{Nothing}}, ::Nothing)
```

The cause: `cudnnBNForward!` only fills in the cache's `mean`/`ivar` when `training=true` — in eval mode it just leaves them unset. But `cudnnBNBackward!` doesn't check for that; it assumes any non-`nothing` cache is already populated and hands whatever's in it straight to cuDNN.

The Mooncake rule for `batchnorm` always builds a live cache, whether it's training or not, so eval-mode calls hit this every time. This is easy to trigger via `Flux.BatchNorm`, since its training/eval auto-detection (`NNlib.within_gradient`) never returns `true` under Mooncake — that trick only works for Zygote.

This PR makes two small fixes:
- Only build the cache when training is actually happening (matches what the "no cache" path already does safely).
- If the caller passes their own cache object, use it instead of quietly replacing it with our own.

I tested this directly on GPU: reproduced the crash on the released NNlib, confirmed it's gone with the patch, checked the gradient still matches Zygote, and ran through all four combinations of `training`/`track_stats` to make sure nothing else was missed. 