### PR TITLE
Functional normalization operators (batchnorm CPU impl, instance/group/layer norm)

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -161,6 +161,20 @@ grid_sample
 ∇grid_sample
 ```
 
+## Normalization
+
+`Flux`'s `BatchNorm`, `InstanceNorm`, `GroupNorm` and `LayerNorm` layers can use
+`NNlib.batchnorm`, `NNlib.instancenorm`, `NNlib.groupnorm` and `NNlib.layernorm`
+as their functional backend.
+
+```@docs
+NNlib.normalise
+NNlib.batchnorm
+NNlib.instancenorm
+NNlib.groupnorm
+NNlib.layernorm
+```
+
 ## Losses
 
 ```@docs

--- a/ext/NNlibCUDACUDNNExt/batchnorm.jl
+++ b/ext/NNlibCUDACUDNNExt/batchnorm.jl
@@ -1,6 +1,7 @@
 using cuDNN: CUDNN_BN_MIN_EPSILON, cudnnBatchNormalizationBackward,
              cudnnBatchNormalizationForwardInference, CUDNN_BATCHNORM_SPATIAL,
              cudnnBatchNormalizationForwardTraining
+using ChainRulesCore: ChainRulesCore, NoTangent, unthunk
 import NNlib: batchnorm, ∇batchnorm
 
 # TODO: replace with new cudnn normalization interface
@@ -188,4 +189,17 @@ function cudnnBNBackward!(dg::DenseCuArray{P}, g::DenseCuArray{P}, db::DenseCuAr
   cudnnBatchNormalizationBackward(handle(), CUDNN_BATCHNORM_SPATIAL,
         scalingParameter(T, alpha), scalingParameter(T, beta), scalingParameter(T, dalpha), scalingParameter(T, dbeta),
         xd, x, dyd, dy, dxd, dx, gd, g, dg, db, eps, mean, ivar)
+end
+
+# GPU differentiation of the cuDNN fast path. The generic `batchnorm` in NNlib core
+# has no `rrule`, so on the CPU (and other array types) it is differentiated through
+# the standard AD path instead.
+function ChainRulesCore.rrule(::typeof(batchnorm), g, b, x::DenseCuArray,
+                              running_mean, running_var, momentum; kw...)
+  y = batchnorm(g, b, x, running_mean, running_var, momentum; kw...)
+  function batchnorm_pullback(Δ)
+    grad = ∇batchnorm(g, b, x, unthunk(Δ), running_mean, running_var, momentum; kw...)
+    (NoTangent(), grad..., NoTangent(), NoTangent(), NoTangent())
+  end
+  y, batchnorm_pullback
 end

--- a/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
+++ b/ext/NNlibEnzymeCoreExt/NNlibEnzymeCoreExt.jl
@@ -3,6 +3,7 @@ module NNlibEnzymeCoreExt
 using NNlib
 import EnzymeCore
 using Random
+using GPUArraysCore: AbstractGPUArray
 
 using EnzymeCore.EnzymeRules
 
@@ -521,18 +522,22 @@ function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.ctc_los
     return (nothing, nothing)
 end
 
-# `batchnorm(g, b, x, running_mean, running_var, momentum)` — allocating, GPU-only
-# (cuDNN); differentiable in `g`, `b`, `x`. `∇batchnorm` returns `(dg, db, dx)`
-# (with `dg`/`db` possibly `nothing` when non-affine).
+# `batchnorm(g, b, x, running_mean, running_var, momentum)` — the allocating cuDNN
+# fast path routed through `∇batchnorm`, which only exists for GPU arrays. The rule
+# is therefore restricted to GPU `x`; on the CPU the generic `batchnorm` is
+# differentiated through Enzyme directly. Differentiable in `g`, `b`, `x`;
+# `∇batchnorm` returns `(dg, db, dx)` (with `dg`/`db` possibly `nothing` when non-affine).
 function EnzymeRules.augmented_primal(config, func::EnzymeCore.Const{typeof(NNlib.batchnorm)},
-        ::Type{RT}, g, b, x, running_mean, running_var, momentum; kwargs...) where {RT}
+        ::Type{RT}, g, b, x::EnzymeCore.Annotation{<:AbstractGPUArray},
+        running_mean, running_var, momentum; kwargs...) where {RT}
     y = func.val(g.val, b.val, x.val, running_mean.val, running_var.val, momentum.val; kwargs...)
     return _enz_alloc_augmented(config, y, (copy(g.val), copy(b.val), copy(x.val),
                                             running_mean.val, running_var.val, momentum.val))
 end
 
 function EnzymeRules.reverse(config, func::EnzymeCore.Const{typeof(NNlib.batchnorm)},
-        ::Type{RT}, cache, g, b, x, running_mean, running_var, momentum; kwargs...) where {RT}
+        ::Type{RT}, cache, g, b, x::EnzymeCore.Annotation{<:AbstractGPUArray},
+        running_mean, running_var, momentum; kwargs...) where {RT}
     shadow, gval, bval, xval, rm, rv, mom = cache
     # `∇batchnorm` returns `(dg, db, dx)` aligned with `(g, b, x)`; `dg`/`db` may be
     # `nothing` (non-affine), which `_enz_accum!` skips.

--- a/ext/NNlibForwardDiffExt.jl
+++ b/ext/NNlibForwardDiffExt.jl
@@ -6,4 +6,8 @@ using NNlib: NNlib
 NNlib.within_gradient(x::ForwardDiff.Dual) = true
 NNlib.within_gradient(x::AbstractArray{<:ForwardDiff.Dual}) = true
 
+# Strip the dual part before writing batch statistics back into (plain-typed)
+# running-mean/var buffers (see NNlib's `_update_running_stats!`).
+NNlib._value(x::ForwardDiff.Dual) = ForwardDiff.value(x)
+
 end

--- a/src/NNlib.jl
+++ b/src/NNlib.jl
@@ -5,6 +5,7 @@ import ChainRulesCore: rrule
 
 using Base.Broadcast: broadcasted
 using Base.Threads
+using BFloat16s: BFloat16
 using ChainRulesCore
 using GPUArraysCore
 using KernelAbstractions
@@ -101,7 +102,6 @@ include("sampling.jl")
 include("functions.jl")
 
 include("normalization.jl")
-# export batchnorm, ∇batchnorm
 
 ## Include implementations
 include("impl/padding_edges.jl")
@@ -126,7 +126,8 @@ export stft, istft, hann_window, hamming_window, spectrogram, melscale_filterban
 # Mark the documented but non-exported API with the `public` keyword.
 # `public` is only valid syntax on Julia 1.11+, so parse it lazily.
 @static if VERSION >= v"1.11.0-DEV.469"
-    eval(Meta.parse("public gather, gather!, scatter, scatter!, fold, unfold, glu, within_gradient"))
+    eval(Meta.parse("public gather, gather!, scatter, scatter!, fold, unfold, glu, within_gradient, " *
+                    "normalise, batchnorm, instancenorm, groupnorm, layernorm"))
 end
 
 end # module NNlib

--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -1,14 +1,249 @@
-# TODO: add CPU implementation
-function batchnorm end
+# Functional normalization operators.
+#
+# These are device-agnostic, differentiable (through the generic AD path — no
+# custom rrules are needed since they are built from `mean`/`var`/broadcast) and
+# mirror the maths of the corresponding Flux layers. Statistics-tracking layers
+# (`Flux.BatchNorm`, `Flux.InstanceNorm`, ...) can delegate their forward pass to
+# `batchnorm`/`instancenorm`/`groupnorm`/`layernorm` here.
+#
+# All four share the same argument layout as the cuDNN `batchnorm` fast path: the
+# scale `g` and bias `b` (either may be `nothing` for no affine transform) come
+# first, then the feature maps `x`. For `WHCN`-style data the `N-1`th dimension is
+# the channel dimension. On the GPU, `batchnorm` on 2D/4D/5D `CuArray`s is handled
+# by the cuDNN methods in `NNlibCUDACUDNNExt`; every other case uses the generic
+# code below.
 
-function ∇batchnorm end
+# `eps` converted to the (real) float eltype of `x`, avoiding Float64 promotion of
+# Float16/Float32 data.
+_epsof(x::AbstractArray, eps) = convert(float(real(eltype(x))), eps)
 
+# Half-precision (Float16/BFloat16) feature maps are normalised in Float32: the
+# reductions and running-statistic updates accumulate in `_stats_type`, and the
+# result is cast back to the input eltype. This mirrors the cuDNN contract, which
+# requires Float32 affine parameters and running statistics for half-precision data.
+_stats_type(::Type{T}) where {T} = T
+_stats_type(::Type{Float16}) = Float32
+_stats_type(::Type{BFloat16}) = Float32
 
-function ChainRulesCore.rrule(::typeof(batchnorm), g, b, x, running_mean, running_var, momentum; kw...)
-  y = batchnorm(g, b, x, running_mean, running_var, momentum; kw...) 
-  function batchnorm_pullback(Δ)
-    grad = ∇batchnorm(g, b, x, unthunk(Δ), running_mean, running_var, momentum; kw...)
-    (NoTangent(), grad..., NoTangent(), NoTangent(), NoTangent())
-  end
-  y, batchnorm_pullback
+# Enforce the Float32-parameter contract for half-precision inputs so a mismatch
+# surfaces as a clear error rather than a silent precision loss.
+function _check_norm_types(::Type{T}, g, b, running_mean, running_var) where {T}
+    _stats_type(T) === T && return nothing  # full-precision: parameters may promote freely
+    for (name, a) in (("scale g", g), ("bias b", b),
+                      ("running_mean", running_mean), ("running_var", running_var))
+        a === nothing && continue
+        eltype(a) === Float32 || throw(ArgumentError(
+            "$T normalization requires Float32 $name, got $(eltype(a)); " *
+            "half-precision statistics are numerically unstable."))
+    end
+    return nothing
 end
+
+# Strip `ForwardDiff.Dual`s when writing back into running statistics (see #2122 in
+# Flux). Extended in `NNlibForwardDiffExt`; identity everywhere else.
+_value(x) = x
+
+"""
+    normalise(x; dims=ndims(x), eps=1f-5)
+
+Normalise `x` to zero mean and unit standard deviation across the dimension(s)
+given by `dims`. Per default, `dims` is the last dimension. `eps` is a small term
+added to the variance for numerical stability.
+
+This is the stateless building block behind [`layernorm`](@ref); it applies no
+learnable shift or scale.
+
+# Examples
+```jldoctest
+julia> using Statistics
+
+julia> x = [90, 100, 110, 130, 70];
+
+julia> y = NNlib.normalise(x);
+
+julia> isapprox(std(y; corrected=false), 1, atol=1e-5)
+true
+```
+"""
+function normalise(x::AbstractArray; dims=ndims(x), eps=1f-5)
+    μ = mean(x; dims)
+    σ² = var(x; dims, mean=μ, corrected=false)
+    return (x .- μ) ./ sqrt.(σ² .+ _epsof(x, eps))
+end
+
+# Core affine-normalize transform: `y = g * (x - μ)/√(σ² + ϵ) + b`.
+# `μ`, `σ²`, `g`, `b` are already reshaped to broadcast against `x`; `g`/`b` may be
+# `nothing` (no affine transform).
+function _affine_normalize(x, μ, σ², g, b, ϵ)
+    denom = sqrt.(σ² .+ ϵ)
+    if g === nothing && b === nothing
+        return (x .- μ) ./ denom
+    else
+        g = g === nothing ? one(eltype(x)) : g
+        b = b === nothing ? zero(eltype(x)) : b
+        return @. g / denom * (x - μ) + b
+    end
+end
+
+# In-place moving-average update of the running statistics, mirroring
+# `Flux._track_stats!`. `reduce_dims` are the dimensions the batch statistics were
+# computed over; the batch dimension `N` is averaged out when it is not among them
+# (InstanceNorm). Non-differentiable: never traced by reverse-mode AD.
+function _update_running_stats!(running_mean, running_var, μ, σ², momentum, reduce_dims, sz)
+    V = eltype(running_var)
+    mtm = V(momentum)
+    res_mtm = one(V) - mtm
+    N = length(sz)
+    m = prod(i -> sz[i], reduce_dims)
+    μnew = vec(N in reduce_dims ? μ : mean(μ; dims=N))
+    σ²new = vec(N in reduce_dims ? σ² : mean(σ²; dims=N))
+    running_mean .= res_mtm .* running_mean .+ mtm .* _value.(μnew)
+    running_var  .= res_mtm .* running_var  .+ mtm .* (m / (m - one(V))) .* _value.(σ²new)
+    return nothing
+end
+
+ChainRulesCore.@non_differentiable _update_running_stats!(::Any...)
+
+# Shared engine for `batchnorm` and `instancenorm`: per-channel statistics/affine
+# over `reduce_dims`, with optional running-statistics tracking. The channel
+# dimension is `N-1`.
+function _norm_layer(g, b, x::AbstractArray{T,N}, running_mean, running_var,
+                     reduce_dims; training, momentum, eps, track_stats) where {T,N}
+    _check_norm_types(T, g, b, running_mean, running_var)
+    Tc = _stats_type(T)
+    xc = Tc === T ? x : Tc.(x)  # half-precision: accumulate statistics in Float32
+    ϵ = _epsof(xc, eps)
+    affine_shape = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
+    if !training && running_mean !== nothing
+        μ = reshape(running_mean, affine_shape)
+        σ² = reshape(running_var, affine_shape)
+    else
+        μ = mean(xc; dims=reduce_dims)
+        σ² = var(xc; mean=μ, dims=reduce_dims, corrected=false)
+        if track_stats && running_mean !== nothing
+            _update_running_stats!(running_mean, running_var, μ, σ², momentum, reduce_dims, size(x))
+        end
+    end
+    g = g === nothing ? nothing : reshape(g, affine_shape)
+    b = b === nothing ? nothing : reshape(b, affine_shape)
+    y = _affine_normalize(xc, μ, σ², g, b, ϵ)
+    return Tc === T ? y : T.(y)
+end
+
+"""
+    batchnorm(g, b, x, running_mean=nothing, running_var=nothing, momentum=0.1f0;
+              eps=1f-5, training=true, track_stats=true)
+
+Functional [batch normalization](https://arxiv.org/abs/1502.03167). `g` and `b`
+are the per-channel scale and bias (either may be `nothing` for no affine
+transform); `x` are the feature maps. For an input with `N` dimensions the `N-1`th
+is the channel dimension (the usual convention for `WHCN` images); statistics are
+computed over every `D_1×…×D_{N-2}×1×D_N` slice, so per channel.
+
+If `running_mean`/`running_var` are supplied:
+- with `training=true` (default) they are updated **in place** (when
+  `track_stats=true`) with an exponential moving average controlled by `momentum`,
+  while statistics of the current batch are used to normalise;
+- with `training=false` they are used to normalise (inference / test mode).
+
+`eps` is added to the variance for numerical stability. On the GPU, 2D/4D/5D
+`CuArray`s are dispatched to the cuDNN implementation.
+
+For half-precision (`Float16`/`BFloat16`) feature maps the statistics are computed
+in `Float32` and the result is cast back; `g`, `b`, `running_mean` and
+`running_var` must then be `Float32`.
+
+See also [`instancenorm`](@ref), [`groupnorm`](@ref), [`layernorm`](@ref).
+"""
+function batchnorm(g, b, x::AbstractArray{T,N},
+                   running_mean=nothing, running_var=nothing, momentum=0.1f0;
+                   eps=1f-5, training::Bool=true, track_stats::Bool=true) where {T,N}
+    N > 1 || throw(ArgumentError("batchnorm expects an array with at least 2 dimensions, got $N"))
+    reduce_dims = (ntuple(identity, N-2)..., N)
+    return _norm_layer(g, b, x, running_mean, running_var, reduce_dims;
+                       training, momentum, eps, track_stats)
+end
+
+"""
+    instancenorm(g, b, x, running_mean=nothing, running_var=nothing, momentum=0.1f0;
+                 eps=1f-5, training=true, track_stats=false)
+
+Functional [instance normalization](https://arxiv.org/abs/1607.08022). Arguments
+match [`batchnorm`](@ref), but for an input with `N > 2` dimensions statistics are
+computed over every `D_1×…×D_{N-2}×1×1` slice, so per channel **and** per sample in
+the batch. When tracked, the running statistics (length `size(x, N-1)`) accumulate
+the per-channel average across the batch.
+
+See also [`batchnorm`](@ref), [`groupnorm`](@ref), [`layernorm`](@ref).
+"""
+function instancenorm(g, b, x::AbstractArray{T,N},
+                      running_mean=nothing, running_var=nothing, momentum=0.1f0;
+                      eps=1f-5, training::Bool=true, track_stats::Bool=false) where {T,N}
+    N > 2 || throw(ArgumentError("instancenorm expects an array with at least 3 dimensions, got $N"))
+    reduce_dims = ntuple(identity, N-2)
+    return _norm_layer(g, b, x, running_mean, running_var, reduce_dims;
+                       training, momentum, eps, track_stats)
+end
+
+"""
+    groupnorm(g, b, x, G::Integer; eps=1f-5)
+
+Functional [group normalization](https://arxiv.org/abs/1803.08494). `g` and `b`
+are the per-channel scale and bias (either may be `nothing`); `x` are the feature
+maps. For an input with `N > 2` dimensions the `N-1`th is the channel dimension;
+its `C = size(x, N-1)` channels are split into `G` groups (`G` must divide `C`) and
+statistics are computed over each group together with the spatial dimensions, per
+sample. `eps` is added to the variance.
+
+See also [`batchnorm`](@ref), [`instancenorm`](@ref), [`layernorm`](@ref).
+"""
+function groupnorm(g, b, x::AbstractArray{T,N}, G::Integer; eps=1f-5) where {T,N}
+    N > 2 || throw(ArgumentError("groupnorm expects an array with at least 3 dimensions, got $N"))
+    C = size(x, N-1)
+    C % G == 0 || throw(ArgumentError("the number of groups G=$G must divide the number of channels C=$C"))
+    _check_norm_types(T, g, b, nothing, nothing)
+    Tc = _stats_type(T)
+    sz = size(x)
+    # Split the channel dimension into (C÷G) × G, giving an (N+1)-dim array.
+    x2 = reshape(Tc === T ? x : Tc.(x), sz[1:N-2]..., C ÷ G, G, sz[N])
+    reduce_dims = ntuple(identity, N-1)  # spatial dims + the intra-group channel dim
+    μ = mean(x2; dims=reduce_dims)
+    σ² = var(x2; mean=μ, dims=reduce_dims, corrected=false)
+    ϵ = _epsof(x2, eps)
+    affine_shape = (ntuple(_ -> 1, N-2)..., C ÷ G, G, 1)
+    g2 = g === nothing ? nothing : reshape(g, affine_shape)
+    b2 = b === nothing ? nothing : reshape(b, affine_shape)
+    y = _affine_normalize(x2, μ, σ², g2, b2, ϵ)
+    y = reshape(y, sz)
+    return Tc === T ? y : T.(y)
+end
+
+"""
+    layernorm(g, b, x; dims=1, eps=1f-5)
+
+Functional [layer normalization](https://arxiv.org/abs/1607.06450). `g` and `b`
+are the scale and bias (either may be `nothing`); `x` is normalised over the
+dimensions `dims` (the leading dimension by default).
+
+`g` and `b`, when given, must broadcast against the normalised region, e.g. have
+size `size(x)[dims]` with singleton trailing dimensions.
+
+See also [`normalise`](@ref), [`batchnorm`](@ref), [`instancenorm`](@ref),
+[`groupnorm`](@ref).
+"""
+function layernorm(g, b, x::AbstractArray{T}; dims=1, eps=1f-5) where {T}
+    _check_norm_types(T, g, b, nothing, nothing)
+    Tc = _stats_type(T)
+    xc = Tc === T ? x : Tc.(x)
+    μ = mean(xc; dims)
+    σ² = var(xc; dims, mean=μ, corrected=false)
+    y = _affine_normalize(xc, μ, σ², g, b, _epsof(xc, eps))
+    return Tc === T ? y : T.(y)
+end
+
+# --- Low-level cuDNN batchnorm bridge ----------------------------------------
+# The GPU fast path for `batchnorm` (2D/4D/5D `CuArray`s) and its reverse pass are
+# implemented in `NNlibCUDACUDNNExt`, together with the ChainRules `rrule` that
+# routes GPU differentiation through `∇batchnorm`. On every other array type the
+# generic `batchnorm` above is used and differentiated through the standard AD path.
+function ∇batchnorm end

--- a/test/common_testsuite/normalization.jl
+++ b/test/common_testsuite/normalization.jl
@@ -1,0 +1,101 @@
+using NNlib: batchnorm, instancenorm, groupnorm, layernorm, normalise
+
+function normalization_testsuite(Backend)
+    device(x) = adapt(Backend(), x)
+    gpu = Backend != CPU
+    T = Float32
+    atol = 1e-3
+    var(a; kws...) = Statistics.var(a; kws...)
+    # Enzyme's reverse pass over GPU reductions (mean/var) currently segfaults
+    # upstream, so on a GPU backend we compare only against Zygote.
+    cmp = gpu ? AutoZygote() : [AutoZygote(), AutoEnzyme()]
+
+    # Reference forward pass (matches Flux's `_norm_layer_forward`) for the
+    # channel-wise layers, computed on the CPU.
+    function ref_norm(g, b, x, reduce_dims; eps=1f-5)
+        μ = mean(x; dims=reduce_dims)
+        σ² = var(x; mean=μ, dims=reduce_dims, corrected=false)
+        N = ndims(x)
+        as = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
+        g === nothing && return (x .- μ) ./ sqrt.(σ² .+ eps)
+        gr = reshape(g, as); br = reshape(b, as)
+        s = gr ./ sqrt.(σ² .+ eps)
+        return s .* x .- s .* μ .+ br
+    end
+
+    @testset "batchnorm" begin
+        x = randn(T, 4, 5, 3, 8); g = randn(T, 3); b = randn(T, 3)
+        rd = (1, 2, 4)
+        @test cpu(batchnorm(device(g), device(b), device(x))) ≈ ref_norm(g, b, x, rd) atol=atol
+        @test cpu(batchnorm(nothing, nothing, device(x))) ≈ ref_norm(nothing, nothing, x, rd) atol=atol
+        # 2D (feature-vector) input
+        x2 = randn(T, 3, 8)
+        @test cpu(batchnorm(device(g), device(b), device(x2))) ≈ ref_norm(g, b, x2, (2,)) atol=atol
+
+        @test test_gradients(batchnorm, g, b, x; test_gpu=gpu, atol, compare=cmp)
+
+        @test_throws ArgumentError batchnorm(nothing, nothing, device(randn(T, 5)))
+    end
+
+    @testset "batchnorm running stats" begin
+        x = randn(T, 4, 5, 3, 8); g = randn(T, 3); b = randn(T, 3); mom = 0.1f0
+        rm = device(zeros(T, 3)); rv = device(ones(T, 3))
+        batchnorm(device(g), device(b), device(x), rm, rv, mom; training=true)
+        μ = vec(mean(x; dims=(1,2,4))); σ² = vec(var(x; dims=(1,2,4), corrected=false)); m = 4*5*8
+        @test cpu(rm) ≈ mom .* μ atol=atol
+        @test cpu(rv) ≈ (1-mom) .* ones(T, 3) .+ mom .* (m/(m-1)) .* σ² atol=atol
+        # inference: normalise with the stored running stats
+        yinf = cpu(batchnorm(device(g), device(b), device(x), rm, rv, mom; training=false))
+        rm4 = reshape(cpu(rm),1,1,3,1); rv4 = reshape(cpu(rv),1,1,3,1)
+        @test yinf ≈ reshape(g,1,1,3,1)./sqrt.(rv4.+1f-5).*(x.-rm4).+reshape(b,1,1,3,1) atol=atol
+        # track_stats=false leaves the running stats untouched
+        rm2 = device(zeros(T, 3)); rv2 = device(ones(T, 3))
+        batchnorm(device(g), device(b), device(x), rm2, rv2, mom; training=true, track_stats=false)
+        @test cpu(rm2) == zeros(T, 3) && cpu(rv2) == ones(T, 3)
+    end
+
+    @testset "instancenorm" begin
+        x = randn(T, 4, 5, 3, 8); g = randn(T, 3); b = randn(T, 3)
+        @test cpu(instancenorm(device(g), device(b), device(x))) ≈ ref_norm(g, b, x, (1,2)) atol=atol
+        @test cpu(instancenorm(nothing, nothing, device(x))) ≈ ref_norm(nothing, nothing, x, (1,2)) atol=atol
+        @test test_gradients(instancenorm, g, b, x; test_gpu=gpu, atol, compare=cmp)
+        @test_throws ArgumentError instancenorm(nothing, nothing, device(randn(T, 3, 8)))
+
+        # running stats accumulate the per-channel average across the batch
+        rm = device(zeros(T, 3)); rv = device(ones(T, 3)); mom = 0.1f0
+        instancenorm(device(g), device(b), device(x), rm, rv, mom; training=true, track_stats=true)
+        μi = vec(mean(mean(x; dims=(1,2)); dims=4)); σ²i = vec(mean(var(x; dims=(1,2), corrected=false); dims=4)); mi = 4*5
+        @test cpu(rm) ≈ mom .* μi atol=atol
+        @test cpu(rv) ≈ (1-mom) .* ones(T, 3) .+ mom .* (mi/(mi-1)) .* σ²i atol=atol
+    end
+
+    @testset "groupnorm" begin
+        x = randn(T, 4, 5, 6, 2); g = randn(T, 6); b = randn(T, 6)
+        function ref_gn(g, b, x, G; eps=1f-5)
+            sz = size(x); N = ndims(x); C = sz[N-1]
+            x2 = reshape(x, sz[1:N-2]..., C÷G, G, sz[N])
+            rd = ntuple(identity, N-1)
+            μ = mean(x2; dims=rd); σ² = var(x2; mean=μ, dims=rd, corrected=false)
+            as = (ntuple(_->1, N-2)..., C÷G, G, 1)
+            reshape(reshape(g,as)./sqrt.(σ².+eps).*(x2.-μ).+reshape(b,as), sz)
+        end
+        @test cpu(groupnorm(device(g), device(b), device(x), 3)) ≈ ref_gn(g, b, x, 3) atol=atol
+        @test cpu(groupnorm(nothing, nothing, device(x), 2)) ≈ ref_gn(ones(T,6), zeros(T,6), x, 2) atol=atol
+        @test test_gradients((g,b,x) -> groupnorm(g, b, x, 3), g, b, x; test_gpu=gpu, atol, compare=cmp)
+        @test_throws ArgumentError groupnorm(device(g), device(b), device(x), 4)  # 4 ∤ 6
+    end
+
+    @testset "layernorm / normalise" begin
+        x = randn(T, 6, 4)
+        μ = mean(x; dims=1); σ² = var(x; mean=μ, dims=1, corrected=false)
+        @test cpu(layernorm(nothing, nothing, device(x); dims=1)) ≈ (x .- μ) ./ sqrt.(σ² .+ 1f-5) atol=atol
+        g = randn(T, 6); b = randn(T, 6)
+        @test cpu(layernorm(device(g), device(b), device(x); dims=1)) ≈
+            g ./ sqrt.(σ².+1f-5) .* (x .- μ) .+ b atol=atol
+        @test test_gradients((g,b,x) -> layernorm(g, b, x; dims=1), g, b, x; test_gpu=gpu, atol, compare=cmp)
+
+        # normalise: zero mean, unit std over `dims`
+        z = cpu(normalise(device(x); dims=1))
+        @test all(isapprox.(vec(Statistics.std(z; dims=1, corrected=false)), 1; atol=1e-3))
+    end
+end

--- a/test/gpu/cuda/bfloat16.jl
+++ b/test/gpu/cuda/bfloat16.jl
@@ -154,3 +154,52 @@ BF16_CUDNN && @testset "batchnorm" begin
         @test eltype(y) == BFloat16
     end
 end
+
+# instancenorm/groupnorm/layernorm (and batchnorm on non-2D/4D/5D inputs) have no
+# cuDNN path, so they use the generic NNlib implementation. On half precision it
+# accumulates the statistics in Float32 and casts the result back to BFloat16, and
+# requires Float32 scale/bias/running statistics — matching the cuDNN contract.
+BF16_CUDNN && @testset "generic normalization" begin
+    rng = StableRNG(41)
+    gf = CuArray(rand(rng, Float32, 3)); bf = CuArray(rand(rng, Float32, 3))
+
+    @testset "instancenorm" begin
+        xf = CuArray(rand(rng, Float32, 4, 4, 3, 8)); xb = tobf(collect(xf))
+        yf = instancenorm(gf, bf, xf); yb = instancenorm(gf, bf, xb)
+        @test eltype(yb) == BFloat16
+        @test Float32.(collect(yb)) ≈ collect(yf) rtol=5e-2 atol=5e-2
+    end
+
+    @testset "groupnorm" begin
+        xf = CuArray(rand(rng, Float32, 4, 4, 3, 8)); xb = tobf(collect(xf))
+        yf = groupnorm(gf, bf, xf, 3); yb = groupnorm(gf, bf, xb, 3)
+        @test eltype(yb) == BFloat16
+        @test Float32.(collect(yb)) ≈ collect(yf) rtol=5e-2 atol=5e-2
+    end
+
+    @testset "layernorm" begin
+        gl = CuArray(rand(rng, Float32, 4)); bl = CuArray(rand(rng, Float32, 4))
+        xf = CuArray(rand(rng, Float32, 4, 8)); xb = tobf(collect(xf))
+        yf = layernorm(gl, bl, xf; dims=1); yb = layernorm(gl, bl, xb; dims=1)
+        @test eltype(yb) == BFloat16
+        @test Float32.(collect(yb)) ≈ collect(yf) rtol=5e-2 atol=5e-2
+    end
+
+    @testset "batchnorm (generic 3D path)" begin
+        xf = CuArray(rand(rng, Float32, 6, 3, 8)); xb = tobf(collect(xf))  # (W, C, N)
+        yf = batchnorm(gf, bf, xf); yb = batchnorm(gf, bf, xb)
+        @test eltype(yb) == BFloat16
+        @test Float32.(collect(yb)) ≈ collect(yf) rtol=5e-2 atol=5e-2
+    end
+
+    @testset "type contract" begin
+        xb = CUDA.randn(BFloat16, 4, 4, 3, 8)
+        gb = CUDA.rand(BFloat16, 3); bb = CUDA.rand(BFloat16, 3)
+        rmb = CUDA.zeros(BFloat16, 3); rvb = CUDA.ones(BFloat16, 3)
+        @test_throws ArgumentError instancenorm(gb, bb, xb)
+        @test_throws ArgumentError groupnorm(gb, bb, xb, 3)
+        @test_throws ArgumentError layernorm(gb, bb, xb; dims=1)
+        # Float32 params but half-precision running stats are rejected too.
+        @test_throws ArgumentError instancenorm(gf, bf, xb, rmb, rvb, 0.1f0; training=true, track_stats=true)
+    end
+end

--- a/test/gpu/cuda/test_setup.jl
+++ b/test/gpu/cuda/test_setup.jl
@@ -10,7 +10,7 @@ using BFloat16s: BFloat16             # bare `BFloat16` in cuda/bfloat16.jl
 import CUDA.CUSPARSE: CuSparseMatrixCSC, CuSparseMatrixCSR, CuSparseMatrixCOO
 using ForwardDiff: Dual              # bare `Dual` in cuda/{activations,softmax}.jl
 using Mooncake.TestUtils: test_rule  # bare `test_rule` in cuda/batchnorm.jl
-using NNlib: batchnorm, ∇batchnorm   # NNlib internals exercised by cuda/batchnorm.jl
+using NNlib: batchnorm, ∇batchnorm, instancenorm, groupnorm, layernorm  # exercised by cuda/{batchnorm,bfloat16}.jl
 CUDA.allowscalar(false)
 
 function gputest(f, xs...; checkgrad=true, rtol=1e-7, atol=1e-10, broken=false, broken_grad=false, kws...)


### PR DESCRIPTION
Supersedes https://github.com/FluxML/NNlib.jl/pull/452

Adds device-agnostic **functional normalization primitives**.

## API

All public and documented; the channel-wise ops share the cuDNN `batchnorm` argument layout:

```julia
batchnorm(g, b, x, running_mean=nothing, running_var=nothing, momentum=0.1f0; eps=1f-5, training=true, track_stats=true)
instancenorm(g, b, x, running_mean=nothing, running_var=nothing, momentum=0.1f0; eps=1f-5, training=true, track_stats=false)
groupnorm(g, b, x, G::Integer; eps=1f-5)
layernorm(g, b, x; dims=1, eps=1f-5)
normalise(x; dims=ndims(x), eps=1f-5)
```

`g`/`b` (scale/bias) may be `nothing` for no affine transform. The maths mirrors Flux's `_norm_layer_forward`, so `BatchNorm`/`InstanceNorm`/`GroupNorm`/`LayerNorm` can delegate their forward pass here.

## Design notes

- **cuDNN fast path untouched.** `batchnorm` keeps its existing signature, so 2D/4D/5D `CuArray`s still dispatch to cuDNN; the generic Julia implementation only takes over on the CPU and off the cuDNN path. No custom rrules — the ops build on `mean`/`var`/broadcast and differentiate through the standard AD path.
- The cuDNN `batchnorm` ChainRules `rrule` moved from core into `NNlibCUDACUDNNExt` (typed on `DenseCuArray`), and the Enzyme `batchnorm` rule is restricted to GPU arrays, so CPU `batchnorm` differentiates generically instead of calling the GPU-only `∇batchnorm`.
- **Half precision:** Float16/BFloat16 inputs accumulate statistics in Float32 and cast the result back, and require Float32 scale/bias/running statistics — the same contract cuDNN already enforces (a mismatch throws a clear `ArgumentError`).

## Tests

- New device-agnostic `test/common_testsuite/normalization.jl` — runs on CPU and every GPU backend (forward vs reference, running-stats tracking, inference mode, `track_stats=false`, gradients via Zygote + Enzyme on CPU / Zygote on GPU).
- Extended `test/gpu/cuda/bfloat16.jl` with generic-path coverage (`instancenorm`/`groupnorm`/`layernorm` and 3D `batchnorm`) plus the half-precision type contract.

All CPU and CUDA suites pass locally (incl. 163 BFloat16 CUDA checks on an sm_120 device).

Note: no version bump included — leaving that to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)