### PR TITLE
Support 3D CuArray batchnorm via cuDNN reshape (fixes #753)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NNlib"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.9.41"
+version = "0.9.42"
 
 [workspace]
 projects = ["test", "docs"]

--- a/ext/NNlibCUDACUDNNExt/batchnorm.jl
+++ b/ext/NNlibCUDACUDNNExt/batchnorm.jl
@@ -57,6 +57,16 @@ function batchnorm(g::DenseCuArray{P}, b::DenseCuArray{P}, x::DenseCuArray{T,2},
   return dropdims(y, dims = (1, 2))
 end
 
+# Likewise, reshape a 3D (W, C, N) Tensor into 4D (1, W, C, N) so the feature
+# (channel) dimension stays second-to-last, as cuDNN batchnorm requires.
+function batchnorm(g::DenseCuArray{P}, b::DenseCuArray{P}, x::DenseCuArray{T,3},
+                   running_mean, running_var, momentum; kws...) where {T<:CUDNNFloat, P}
+  _check_bn_param_types(T, P, running_mean, running_var)
+  x = reshape(x, 1, size(x, 1), size(x, 2), size(x, 3))
+  y = batchnorm(g, b, x, running_mean, running_var, momentum; kws...)
+  return dropdims(y, dims = 1)
+end
+
 function batchnorm(g::DenseCuArray{P}, b::DenseCuArray{P}, x::Union{DenseCuArray{T,4},DenseCuArray{T,5}},
                    running_mean, running_var, momentum; kws...) where {T<:CUDNNFloat, P}
   _check_bn_param_types(T, P, running_mean, running_var)
@@ -139,6 +149,16 @@ function ∇batchnorm(g::DenseCuArray{P}, b::DenseCuArray{P}, x::DenseCuArray{T,
   dg, db, dx = ∇batchnorm(g, b, reshape(x, 1, 1, size(x, 1), size(x, 2)), reshape(dy, 1, 1, size(dy, 1),
                           size(dy, 2)), running_mean, running_var, momentum; kws...)
   (dg, db, dropdims(dx, dims = (1, 2)))
+end
+
+function ∇batchnorm(g::DenseCuArray{P}, b::DenseCuArray{P}, x::DenseCuArray{T, 3}, dy::DenseCuArray{T, 3},
+            running_mean, running_var, momentum;
+            kws...) where {T<:CUDNNFloat, P}
+  _check_bn_param_types(T, P, running_mean, running_var)
+  dg, db, dx = ∇batchnorm(g, b, reshape(x, 1, size(x, 1), size(x, 2), size(x, 3)),
+                          reshape(dy, 1, size(dy, 1), size(dy, 2), size(dy, 3)),
+                          running_mean, running_var, momentum; kws...)
+  (dg, db, dropdims(dx, dims = 1))
 end
 
 

--- a/test/gpu/cuda/batchnorm.jl
+++ b/test/gpu/cuda/batchnorm.jl
@@ -34,6 +34,16 @@
             @test_throws ArgumentError batchnorm(v, v, m, α, β, 1.0; kws...)
         end
     end 
+    @testset "3D input (issue #753)" begin
+        # cuDNN batchnorm supports only 4D/5D descriptors; a 3D (W, C, N) input is
+        # reshaped to 4D (1, W, C, N) on both the forward and backward paths. Guards
+        # against the regression where the backward path errored with BAD_PARAM.
+        g3 = rand(Float32, 4)
+        b3 = rand(Float32, 4)
+        x3 = rand(Float32, 5, 4, 8)
+        _bn3(g, b, x) = batchnorm(g, b, x, nothing, nothing, 0.1f0; training=true)
+        gputest(_bn3, g3, b3, x3; rtol=1e-3, atol=1e-4)
+    end
     @testset "test mode" begin
         y_no_track_stats = batchnorm(v, v, m, nothing, nothing, 1.0; training=false, track_stats=false)
         running_mean = mean(m, dims=[2])


### PR DESCRIPTION
Fixes #753.

cuDNN batchnorm only supports 4D/5D descriptors. The forward path handled 2D (reshaped to 4D), 4D, and 5D, letting a 3D input fall through to the generic implementation. The backward `∇batchnorm`/`rrule` matched a `CuArray` of *any* rank, so a 3D gradient was routed into `cudnnBatchNormalizationBackward` → `CUDNN_STATUS_BAD_PARAM`.

Rather than restricting the backward path to fall back to the generic implementation for 3D, this keeps the cuDNN fast path by reshaping `(W, C, N)` → `(1, W, C, N)` on both forward and backward, mirroring the existing 2D `(C, N)` → `(1, 1, C, N)` handling. The channel dimension stays second-to-last as cuDNN requires.

## Verification
- The issue's repro now works for both forward and backward.
- Forward matches the CPU generic implementation; the 3D cuDNN gradient matches the equivalent 4D cuDNN gradient exactly.
- Added a regression test in `test/gpu/cuda/batchnorm.jl` (via `gputest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)