### PR TITLE
Fix documentation of the flipped kwarg for conv

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -89,13 +89,13 @@ pad_zeros
 
 `NNlib.conv` supports complex datatypes on CPU and CUDA devices.
 
-!!! note "AMDGPU MIOpen supports only cross-correlation (`flipkernel=true`)."
+!!! note "AMDGPU MIOpen supports only cross-correlation (flipped=true)."
 
-    Therefore for every regular convolution (`flipkernel=false`)
-    kernel is flipped before calculation.
-    For better performance, use cross-correlation (`flipkernel=true`)
-    and manually flip the kernel before `NNlib.conv` call.
-    `Flux` handles this automatically, this is only required for direct calls.
+    Therefore, for every regular convolution (`flipped=false`), the kernel is flipped before
+    calculation.
+    For better performance, use cross-correlation (`flipped=true`) and manually flip the
+    kernel before the `NNlib.conv` call.
+    `Flux` handles this automatically; this is only required for direct calls.
 
 ```@docs
 conv

--- a/src/conv.jl
+++ b/src/conv.jl
@@ -60,8 +60,8 @@ The output spatial size for each dimension is
 - `pad`: zero padding. An `Int` or tuple applies symmetric padding; a tuple of
   `2*ndims` entries gives `(left, right)` padding per spatial dimension.
 - `dilation`: spacing between filter elements (atrous convolution).
-- `flipped`: if `false` (default), perform cross-correlation (the usual deep-learning
-  convention); if `true`, perform a true mathematical convolution by flipping `w`.
+- `flipped`: if `false` (default), perform true mathematical convolution; if `true`, perform
+  cross-correlation (the usual deep-learning convention).
 - `groups`: number of groups for grouped convolution.
 
 # Examples


### PR DESCRIPTION
Fix the docstring for NNlib.conv, indicating that `flipped=false` corresponds to convolution and `flipped=true` corresponds to cross-correlation.
Update the AMDGPU MIOpen note in the documentation with the correct argument name.

This closes #755.