### PR TITLE
Enable Enzyme gradient tests on Windows

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,7 @@ const NNLIB_TEST_ENZYME =   if haskey(ENV, "NNLIB_TEST_ENZYME")
                                 ENV["NNLIB_TEST_ENZYME"] == "true"
                             else
                                 VERSION <= v"1.13-" && # fails on nightly
-                                !NNLIB_TEST_AMDGPU && !NNLIB_TEST_METAL && !NNLIB_TEST_CUDA && # TODO fails on GPU backends
-                                !Sys.iswindows() # TODO fails on Windows
+                                !NNLIB_TEST_AMDGPU && !NNLIB_TEST_METAL && !NNLIB_TEST_CUDA # TODO fails on GPU backends
                             end
 
 # Tests that exercise NNlib's multithreaded code paths (`@spawn` / `@threads`).


### PR DESCRIPTION
Enzyme upstream has landed Windows support and fixes for the segfaults tracked in #734, so this drops the `!Sys.iswindows()` gate in the test suite and lets CI actually exercise the Enzyme gradient comparisons on Windows.

If CI is green, the Windows half of #734 is resolved. The CUDA segfaults remain gated (`!NNLIB_TEST_CUDA`) and #734 should stay open scoped to GPU until those are addressed.

Refs #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)