### PR TITLE
Fix conv on a zero-sized batch dimension (#760)

### DIFF
--- a/src/impl/conv_direct.jl
+++ b/src/impl/conv_direct.jl
@@ -192,6 +192,12 @@ Calculate the gradient imposed upon `w` in the convolution `y = x * w`.
 function ∇conv_filter_direct!(dw::AbstractArray{wT,5}, x::AbstractArray{xT,5},
                               dy::AbstractArray{yT,5}, cdims::DenseConvDims;
                               alpha::wT=wT(1), beta=false) where {xT, yT, wT}
+    # Zero-sized batch: nothing to accumulate, so the result is `beta*dw`. Bail
+    # out before `transpose_swapbatch` moves the empty batch into the channel
+    # slot, where `DenseConvDims` would divide by it (0 % 0). See issue #760.
+    if size(x, 5) == 0
+        return iszero(beta) ? fill!(dw, zero(wT)) : (dw .*= beta)
+    end
     x = conj(transpose_swapbatch(x[end:-1:1, end:-1:1, end:-1:1, :, :]))
     dy = transpose_swapbatch(predilate(dy, stride(cdims)))
     ctdims = DenseConvDims(dy, x; padding=transpose_pad(cdims),

--- a/src/impl/conv_im2col.jl
+++ b/src/impl/conv_im2col.jl
@@ -46,6 +46,10 @@ function conv_im2col!(
     K = prod(kernel_size(cdims))*channels_in(cdims)
 
     nbatch = size(x, 5)
+    # Zero-sized batch: `y` already has the correct (…, 0) shape and no elements
+    # to write, so return before the partitioning below (which chokes on nbatch==0,
+    # via `divrem(ntasks, 0)` or `partition(1:0, 0)`). See issue #760.
+    nbatch == 0 && return y
     ntasks = min(ntasks, size(col, 3))
 
     # Multiply a contiguous block of `m_len` output-spatial rows, starting at
@@ -173,6 +177,14 @@ function ∇conv_filter_im2col!(
     N = channels_out(cdims)
     K = prod(output_size(cdims))
 
+    # Zero-sized batch: nothing to accumulate, so the result is just `beta*dw`.
+    # Unlike the forward/data paths, `dw` is not empty here, and the loop below
+    # would otherwise leave it untouched (uninitialized when beta==0). Mirror
+    # GEMM's write-only semantics for beta==0 by zeroing it outright. See #760.
+    if size(x, 5) == 0
+        return iszero(beta) ? fill!(dw, zero(T)) : (dw .*= beta)
+    end
+
     for batch_idx in 1:size(x,5)
         col_slice = view(col, :, :, 1)
 
@@ -223,6 +235,10 @@ function ∇conv_data_im2col!(
     M = prod(output_size(cdims))
     N = prod(kernel_size(cdims))*channels_in(cdims)
     K = channels_out(cdims)
+
+    # Zero-sized batch: `dx` already has the correct (…, 0) shape and no elements
+    # to write, so return before partitioning (`partition(1:0, 0)` errors). See #760.
+    size(dx, 5) == 0 && return dx
 
     parts = Iterators.partition(axes(dx, 5), ceil(Int, size(dx, 5) / ntasks))
 

--- a/test/cpu/conv.jl
+++ b/test/cpu/conv.jl
@@ -854,6 +854,36 @@ end
     @test size(depthwiseconv(x, w1; stride = (1, 2), pad = (2, 3), dilation = (2, 2), flipped = true)) == (10, 5, 9, 10)
 end
 
+# https://github.com/FluxML/NNlib.jl/issues/760
+@testset "conv with zero-sized batch dimension" begin
+    for rank in (1, 2, 3)
+        @testset "rank=$rank" begin
+            x = randn(Float32, ntuple(_ -> 6, rank)..., 2, 0)  # zero batch
+            w = randn(Float32, ntuple(_ -> 2, rank)..., 2, 3)
+            cdims = DenseConvDims(x, w)
+            y = randn(Float32, ntuple(_ -> 5, rank)..., 3, 0)  # matching empty output
+
+            y_shape = (ntuple(_ -> 5, rank)..., 3, 0)
+            for (fwd, ∇data, ∇filter) in (
+                    (NNlib.conv, NNlib.∇conv_data, NNlib.∇conv_filter),
+                    (NNlib.conv_im2col, NNlib.∇conv_data_im2col, NNlib.∇conv_filter_im2col),
+                    (NNlib.conv_direct, NNlib.∇conv_data_direct, NNlib.∇conv_filter_direct))
+                @test size(fwd(x, w, cdims)) == y_shape
+                @test size(∇data(y, w, cdims)) == size(x)
+                dw = ∇filter(x, y, cdims)
+                @test size(dw) == size(w)
+                # no batches to sum over ⇒ the filter gradient is exactly zero
+                @test all(iszero, dw)
+            end
+        end
+    end
+
+    # empty minibatch obtained by slicing an empty range (the motivating case)
+    x = randn(Float32, 10, 10, 3, 5)
+    w = randn(Float32, 3, 3, 3, 4)
+    @test size(conv(x[:, :, :, 3:2], w)) == (8, 8, 4, 0)
+end
+
 # https://github.com/FluxML/NNlib.jl/pull/171
 @testset "conv_direct! - Check Sizes" begin
     x_size = (6, 7, 8, 5, 3)


### PR DESCRIPTION
Fixes #760.

`conv`/`conv!` and their gradients crashed (or silently returned garbage) when the input has a zero-length batch dimension — a legitimate edge case such as an empty minibatch or an empty-range slice `x[:, :, :, a:b]`. Every other shape flows through fine.

Investigating turned up that the bug was broader than the issue reported — **four** functions were affected, not two:

| Function | Symptom on zero batch |
|---|---|
| `conv_im2col!` (forward) | `divrem(ntasks, 0)` (`DivideError`) on the multithreaded small-batch path, or `partition(1:0, 0)` (`ArgumentError`) on the serial path — which one fires depended on the thread count |
| `∇conv_data_im2col!` | same `partition(1:0, 0)` crash |
| `∇conv_filter_im2col!` | no crash, but the accumulation loop never ran, so `dw` was returned **uninitialized** instead of the correct all-zeros gradient |
| `∇conv_filter_direct!` | `transpose_swapbatch` moves the empty batch into the channel slot, then `DenseConvDims` divides by it (`0 % 0`, `DivideError`) |

### Fix

Each function returns early on a zero-sized batch:

- **Forward** and **data-gradient**: the output already has the correct `(…, 0)` shape and no elements to write, so it is returned as-is.
- **Filter-gradient** (both backends): the output `dw` is *not* empty (kernel-shaped). With no batches to sum over the result is `beta * dw` — `fill!(dw, 0)` for the default `beta == 0` (mirroring GEMM's write-only semantics, since `dw` may be uninitialized), else `dw .*= beta`.

The `conv_direct!` forward and `∇conv_data_direct!` already handled this correctly via their batch loops (as `meanpool`/`maxpool` do).

### Tests

Added a regression testset covering forward, `∇conv_data`, and `∇conv_filter` across all three backends (`conv`/`conv_im2col`/`conv_direct`) and spatial ranks 1/2/3, plus the motivating empty-slice case. Also verified the three backends still agree bit-for-bit on non-empty inputs (no regression), and that `depthwiseconv`/grouped `conv` now handle zero batch too.

This is the NNlib half of FluxML/Flux.jl#2407.

Note: I left the version at the already-pending `0.9.44` (unreleased) rather than bumping — happy to bump if you'd prefer a dedicated patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)